### PR TITLE
Throw when writing to a computed signal

### DIFF
--- a/packages/core/test/signal.test.ts
+++ b/packages/core/test/signal.test.ts
@@ -250,6 +250,13 @@ describe("computed()", () => {
 	});
 
 	describe("error handling", () => {
+		it("should throw when writing to computeds", () => {
+			const a = signal("a");
+			const b = computed(() => a.value);
+			const fn = () => (b.value = "aa");
+			expect(fn).to.throw(/readonly/);
+		});
+
 		it("should keep graph consistent on errors in computeds", () => {
 			const a = signal(0);
 			let shouldThrow = false;


### PR DESCRIPTION
Computed signals are expected to be readonly, but we didn't have anything in place that prevents a computed signal being written to. This PR addresses that.

```js
const a = signal("a");
const b = computed(() => a.value);
// This is not allowed
b.value = "foo"
```