### PR TITLE
Replace `observe` with `effect`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -211,9 +211,9 @@ export function computed<T>(compute: () => T): Signal<T> {
 	return signal;
 }
 
-export function observe<T>(signal: Signal<T>, callback: (value: T) => void) {
-	const s = computed(() => callback(signal.value));
-	s._readonly = true;
+export function effect(callback: () => void) {
+	const s = computed(callback);
+	return () => s._setCurrent()(true, true);
 }
 
 export function batch<T>(cb: () => T): T {

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -1,6 +1,6 @@
 import { options, Component, createElement } from "preact";
 import { useRef, useMemo } from "preact/hooks";
-import { signal, computed, observe, Signal } from "@preact/signals-core";
+import { signal, computed, effect, Signal } from "@preact/signals-core";
 import {
 	VNode,
 	ComponentType,
@@ -11,7 +11,7 @@ import {
 } from "./internal";
 
 // @todo: export Signal only as a type?
-export { signal, computed, observe, Signal };
+export { signal, computed, effect, Signal };
 
 // Components that have a pending Signal update: (used to bypass default sCU:false)
 const hasPendingUpdate = new WeakSet<Component>();


### PR DESCRIPTION
This PR splits up the existing `observe()` function into two distinctive use cases:

1) Fire callback when a single signal is updated -> `observe(signal, value => ...)`
2) Fire whenever any accessed signal is updated -> `watch(() => ...)`

The latter is basically a `computed` with the difference that it allows signals to be written to inside the callback. My hope with this change is that people will gravitate to `watch()` and use that in most cases as `observe` is a bit more exotic for us non-native speakers from the wording alone.

The use cases for `observe` are a bit more limited in comparison to `watch`, but nonetheless a useful primitive to have. In the devtools I use for binding signals to Preact. In the future that will be replaced with the adapter in this repository, but until then I'm using something like the following hook:

```ts
// Simplified
export function useObserver<T>(fn: () => T): T {
	const [value, setValue] = useState<T>(undefined);

	const dispose = useMemo(() => {
		const v = computed(fn);
		return observe(v, next => setValue(next));
	}, []);

	useEffect(() => {
		return () => dispose();
	}, [dispose]);

	return value;
}
```

That said `observe` can also lead to some weird patterns, some if which are present in devtools. There, in the profiler for the "record" button I'm setting a signal and based on changing that signal, fire off some effects. This feels wrong and those effects should be fired directly in the event handler that caused the change. So I'm torn. A part of me sees the usefulness of `observe`, but the other part is afraid that folks might build weird effect chains with weird change reaction semantics.