### PR TITLE
Fix no writes flushed after batch()

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -230,6 +230,7 @@ export function batch<T>(cb: () => T): T {
 
 		if (--batchPending === 0) {
 			sweep(pending);
+			pending.clear();
 		}
 	}
 }

--- a/packages/core/test/signal.test.ts
+++ b/packages/core/test/signal.test.ts
@@ -448,4 +448,24 @@ describe("batch/transaction", () => {
 		expect(spyD).to.be.calledOnce;
 		expect(spyE).to.be.calledOnce;
 	});
+
+	it("should not block writes after batching completed", () => {
+		// If no further writes after batch() are possible, than we
+		// didn't restore state properly. Most likely "pending" still
+		// holds elements that are already processed.
+		const a = signal("a");
+		const b = signal("b");
+		const c = signal("c");
+		const d = computed(() => a.value + " " + b.value + " " + c.value);
+
+		let result;
+		effect(() => (result = d.value));
+
+		batch(() => {
+			a.value = "aa";
+			b.value = "bb";
+		});
+		c.value = "cc";
+		expect(result).to.equal("aa bb cc");
+	});
 });


### PR DESCRIPTION
If we don't clear `pending` after `batch()` the [`isFirst`](https://github.com/preactjs/signals/blob/batch-writes/packages/core/src/index.ts#L67) boolean is always `false` when writing to the next signal.