### PR TITLE
Batch writes inside effect()

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,7 +243,7 @@ export function computed<T>(compute: () => T): Signal<T> {
 }
 
 export function effect(callback: () => void) {
-	const s = computed(callback);
+	const s = computed(() => batch(callback));
 	// Set up subscriptions since this is a "reactor" signal
 	activate(s);
 	return () => s._setCurrent()(true, true);

--- a/packages/core/test/signal.test.ts
+++ b/packages/core/test/signal.test.ts
@@ -71,6 +71,20 @@ describe("effect()", () => {
 		s.value = 42;
 		expect(spy).not.to.be.called;
 	});
+
+	it("should batch writes", () => {
+		const a = signal("a");
+		const spy = sinon.spy(() => a.value);
+		effect(spy);
+		spy.resetHistory();
+
+		effect(() => {
+			a.value = "aa";
+			a.value = "aaa";
+		});
+
+		expect(spy).to.be.calledOnce;
+	});
 });
 
 describe("computed()", () => {


### PR DESCRIPTION
This should only trigger one update not two:

```js
const a = signal("a");

effect(() => {
  a.value = "aa";
  a.value = "aaa";
});
```