### PR TITLE
Add `ReadonlySignal` TS type for computeds

### DIFF
--- a/.changeset/fair-mails-check.md
+++ b/.changeset/fair-mails-check.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals-core": patch
+"@preact/signals": patch
+---
+
+Update TypeScript types to mark computed signals as readonly

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -237,7 +237,10 @@ export function signal<T>(value: T): Signal<T> {
 	return new Signal(value);
 }
 
-export function computed<T>(compute: () => T): Signal<T> {
+export type ReadonlySignal<T = any> = Omit<Signal<T>, "value"> & {
+	readonly value: T;
+};
+export function computed<T>(compute: () => T): ReadonlySignal<T> {
 	const signal = new Signal<T>(undefined as any);
 	signal._readonly = true;
 

--- a/packages/core/test/signal.test.ts
+++ b/packages/core/test/signal.test.ts
@@ -423,7 +423,7 @@ describe("computed()", () => {
 		it("should throw when writing to computeds", () => {
 			const a = signal("a");
 			const b = computed(() => a.value);
-			const fn = () => (b.value = "aa");
+			const fn = () => ((b as any).value = "aa");
 			expect(fn).to.throw(/readonly/);
 		});
 

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -1,6 +1,13 @@
 import { options, Component, createElement } from "preact";
 import { useRef, useMemo } from "preact/hooks";
-import { signal, computed, batch, effect, Signal } from "@preact/signals-core";
+import {
+	signal,
+	computed,
+	batch,
+	effect,
+	Signal,
+	ReadonlySignal,
+} from "@preact/signals-core";
 import {
 	VNode,
 	ComponentType,
@@ -10,7 +17,7 @@ import {
 	ElementUpdater,
 } from "./internal";
 
-export { signal, computed, batch, effect, Signal };
+export { signal, computed, batch, effect, Signal, ReadonlySignal };
 
 // Components that have a pending Signal update: (used to bypass default sCU:false)
 const hasPendingUpdate = new WeakSet<Component>();


### PR DESCRIPTION
We already throw a runtime error when you try to write to a computed signal, but we can do even better by making this a compile error with TypeScript. This will allow TS to error when you try to write to a readonly signal.

```js
const signal = computed(() => ...);
// TS should complain here.
signal.value = 10;
```

@JoviDeCroock @developit I'm unsure if we should do it this way or the other way round. What are your thoughts?

- `Signal` <-> `ReadonlySignal` (this PR)
- `WritableSignal` <-> `Signal`

~~Another thing to consider is how that affects when users write a function which can read from both "normal" signals and computeds:~~

```ts
// Readonly approach
function readSignal<T>(signal: ReadonlySignal<T>): T {}

// Writable approach is a lot nicer
function readSignal<T>(signal: Signal<T>) {}
```
**EDIT:** This example is flawed, we can just pass `ReadonlySignal` for the first example because the writable one inherits that.

Marking this as draft for now.

Fixes #50 , Fixes #52 .