### PR TITLE
Fix stack trace not logged for inifinite loops

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -172,18 +172,32 @@ module.exports = function (config) {
 		reporters: ["mocha"].concat(coverage ? "coverage" : []),
 
 		formatError(msg) {
-			const frames = errorstacks.parseStackTrace(msg);
+			let stack = msg;
+			// Karma prints error twice if it's an infinite loop
+			if (/^\s*Uncaught/.test(msg)) {
+				const lines = msg.split(/\n/g);
+				const emptyIdx = lines.findIndex(line => /^\s*$/.test(line));
+				stack = lines.slice(emptyIdx).join("\n");
+			}
+
+			const frames = errorstacks.parseStackTrace(stack);
 			if (!frames.length || frames[0].column === -1) return "\n" + msg + "\n";
 
-			const frame = frames[0];
-			const filePath = kl.lightCyan(
-				frame.fileName.replace(__dirname + "/", "")
-			);
+			let out = "";
+			for (let i = 0; i < frames.length; i++) {
+				const frame = frames[i];
+				const filePath = kl.lightCyan(
+					frame.fileName.replace(__dirname + "/", "")
+				);
 
-			const indentMatch = msg.match(/^(\s*)/);
-			const indent = indentMatch ? indentMatch[1] : "  ";
-			const location = kl.yellow(`:${frame.line}:${frame.column}`);
-			return `${indent}at ${frame.name} (${filePath}${location})\n`;
+				const indentMatch = msg.match(/^(\s*)/);
+				const indent = indentMatch ? indentMatch[1] : "  ";
+				const location = kl.yellow(`:${frame.line}:${frame.column}`);
+
+				out += `${indent}at ${frame.name} (${filePath}${location})\n`;
+			}
+
+			return out;
 		},
 
 		coverageReporter: {


### PR DESCRIPTION
For some reason karma logs a shortened stack trace first, which is then followed by the actual one. Noticed this in #53 .

Before:

![Screenshot 2022-09-01 at 10 14 06](https://user-images.githubusercontent.com/1062408/187866083-221aa20d-d9be-466b-b456-d9b0abfcd885.png)

After:
![Screenshot 2022-09-01 at 10 13 44](https://user-images.githubusercontent.com/1062408/187866112-229fe1e1-86b0-4b59-89ae-c1c62540613f.png)
