### PR TITLE
DRAFT: Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Any signal that is accessed inside the `computed`'s callback function will be au
 
 ### `effect(fn)`
 
-The `effect` function is the last piece that makes everything reactive. When you access a signal inside its callback function, that signal and every dependency of said signal will be activated and subscribed to. By default all updates are lazy, so nothing will update until you access a signal inside `effect`.
+The `effect` function is the last piece that makes everything reactive. When you access a signal inside its callback function, that signal and every dependency of said signal will be activated and subscribed to. In that regard it is very similar to [`computed(fn)](#computedfn). By default all updates are lazy, so nothing will update until you access a signal inside `effect`.
 
 ```js
 import { signal, computed, effect } from "@preact/signals-core";


### PR DESCRIPTION
This PR adds some docs in our README.

While I like the content, I'm personally a bit torn between having the docs here vs having them over on `preact-www`. I'm worried that we're fracturing the "Preact experience" by expecting users to jump around sites. And by not having a dedicated page on `preact-www`, we're not positioning them on the same level as hooks.