### PR TITLE
Support signal writes without triggering reads

### DIFF
--- a/.changeset/quiet-gorillas-burn.md
+++ b/.changeset/quiet-gorillas-burn.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": minor
+---
+
+Add `.peek()` method to read from signals without subscribing to them.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,10 @@ export class Signal<T = any> {
 		return "" + this.value;
 	}
 
+	peek() {
+		return this._value;
+	}
+
 	get value() {
 		// If we read a signal outside of a computed we have no way
 		// to unsubscribe from that. So we assume that the user wants

--- a/packages/core/test/signal.test.ts
+++ b/packages/core/test/signal.test.ts
@@ -11,6 +11,28 @@ describe("signal", () => {
 		const s = signal(123);
 		expect(s.toString()).equal("123");
 	});
+
+	describe(".peek()", () => {
+		it("should get value", () => {
+			const s = signal(1);
+			expect(s.peek()).equal(1);
+		});
+
+		it("should not trigger a read", () => {
+			const s = signal(1);
+
+			const spy = sinon.spy(() => {
+				// When we trigger a read this would cause an infinite loop
+				s.peek();
+			});
+
+			effect(spy);
+
+			s.value = 2;
+
+			expect(spy).to.be.calledOnce;
+		});
+	});
 });
 
 describe("effect()", () => {


### PR DESCRIPTION
This PR adds a new `.peek()` method onto signals to allow writing to signals without triggering a "read". ~~It works similar to `setState` from hooks, but I skipped on the `null` bailout case for now as that might be more confusing.~~

A practical use case for this is logging how often an `effect` has run to another signal.

```js
const effectCount = signal(0);

effect(() => {
  // ...other code

  // Will update signal without triggering a read
  effectCount.value = effectCount.peek() + 1;
});
```

~~Downside is that this increases the API surface and there are now two ways to update a signal: `.value = 2` _and_ `.set(2)`.~~

Fixes #32 .