### PR TITLE
Throw error when a cycle is detected

### DIFF
--- a/.changeset/swift-ducks-greet.md
+++ b/.changeset/swift-ducks-greet.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Throw an error when a cycle was detected during state updates

--- a/packages/core/test/signal.test.ts
+++ b/packages/core/test/signal.test.ts
@@ -107,6 +107,23 @@ describe("effect()", () => {
 
 		expect(spy).to.be.calledOnce;
 	});
+
+	it("should throw on cycles", () => {
+		const a = signal(0);
+		let i = 0;
+
+		const fn = () =>
+			effect(() => {
+				// Prevent test suite from spinning if limit is not hit
+				if (i++ > 10) {
+					throw new Error("test failed");
+				}
+				a.value;
+				a.value = NaN;
+			});
+
+		expect(fn).to.throw(/Cycle detected/);
+	});
 });
 
 describe("computed()", () => {


### PR DESCRIPTION
This aborts updates when a cycle has been detected. Ran into this on the repl on our site where I accidentally triggered a cyclic update and couldn't continue without killing the page.

Looked around what other reactive libs do and MobX has a similar detection logic. In general we don't want to allow cycles in the graph at all.