### PR TITLE
Remove hash when size-checking docs stuff

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
 	"scripts": {
 		"start": "vite",
 		"build": "vite build",
+		"build:size": "SIZE_CHECK=true vite build",
 		"preview": "vite preview"
 	},
 	"postcss": {

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -29,6 +29,13 @@ export default defineConfig(env => ({
 	],
 	build: {
 		polyfillModulePreload: false,
+		rollupOptions: process.env.SIZE_CHECK ? {
+			output: {
+				entryFileNames: `[name].js`,
+				chunkFileNames: `[name].js`,
+				assetFileNames: `[name].[ext]`
+			}
+		} : {}
 	},
 	resolve: {
 		extensions: [".ts", ".tsx", ".js", ".jsx", ".d.ts"],

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
 		"test:watch": "karma start karma.conf.js --no-single-run",
 		"docs:start": "cd docs && pnpm start",
 		"docs:build": "cd docs && pnpm build",
+		"docs:build:size": "cd docs && pnpm build:size",
 		"docs:preview": "cd docs && pnpm preview",
-		"ci:build": "pnpm build && pnpm docs:build",
+		"ci:build": "pnpm build && pnpm docs:build:size",
 		"ci:test": "pnpm lint && pnpm test"
 	},
 	"keywords": [],


### PR DESCRIPTION
This enables the compressed-size plugin to accurately track differences in built files