### PR TITLE
Update lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ importers:
 
   packages/preact:
     specifiers:
-      '@preact/signals-core': workspace:^0.0.5
+      '@preact/signals-core': workspace:^1.0.0
       preact: 10.9.0
     dependencies:
       '@preact/signals-core': link:../core
@@ -134,7 +134,7 @@ importers:
 
   packages/react:
     specifiers:
-      '@preact/signals-core': workspace:^0.0.5
+      '@preact/signals-core': workspace:^1.0.0
       '@types/react': ^18.0.18
       '@types/react-dom': ^18.0.6
       react: ^18.2.0


### PR DESCRIPTION
Maybe with the 1.0.0 release pnpm will be hopefully more quiet in the future with lockfile updates.

This PR will fix the CI error on `main`.