### PR TITLE
Add marker for devtools to detect Signal Text nodes

### DIFF
--- a/.changeset/blue-jobs-join.md
+++ b/.changeset/blue-jobs-join.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Add marker for devtools to `Text` that is created when a signal is passed into JSX

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -135,6 +135,7 @@ function Text(this: ComponentType, { data }: { data: Signal }) {
 
 	return s.value;
 }
+Text.displayName = "_st";
 
 /** Inject low-level property/attribute bindings for Signals into Preact's diff */
 hook(OptionsTypes.DIFF, (old, vnode) => {


### PR DESCRIPTION
This way devtools can detect that we're dealing with Signals passed directly into JSX.