### PR TITLE
fix import typo in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ batch(() => {
 When you access a signal that you wrote to earlier inside the callback, or access a computed signal that was invalidated by another signal, we'll only update the necessary dependencies to get the current value for the signal you read from. All other invalidated signals will update at the end of the callback function.
 
 ```js
-import { signal, computed, effect batch } from "@preact/signals-core";
+import { signal, computed, effect, batch } from "@preact/signals-core";
 
 const counter = signal(0);
 const double = computed(() => counter.value * 2);
@@ -180,7 +180,7 @@ batch(() => {
 Batches can be nested and updates will be flushed when the outermost batch call completes.
 
 ```js
-import { signal, computed, effect batch } from "@preact/signals-core";
+import { signal, computed, effect, batch } from "@preact/signals-core";
 
 const counter = signal(0);
 effect(() => console.log(counter.value));


### PR DESCRIPTION
Signals look really exciting! Just fixing a small typo I noticed as I read through the readme.