### PR TITLE
Proposal: introduce option to always peek

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -128,12 +128,14 @@ function Text(this: ComponentType, { data }: { data: Signal }) {
 		};
 
 		return computed(() => {
-			let s = data.value;
+			// @ts-ignore-next-line private options hooks usage
+			let s = options.alwaysPeek ? data.peek() : data.value;
 			return s === 0 ? 0 : s === true ? "" : s || "";
 		});
 	}, []);
 
-	return s.value;
+	// @ts-ignore-next-line private options hooks usage
+	return options.alwaysPeek ? s.peek() : s.value;
 }
 Text.displayName = "_st";
 


### PR DESCRIPTION
This introduces an option to always peek so we don't subscribe, the use case for this would be distributive repetitive renderers like render-to-string and prepass.

This currently only affects `text` optimization but this should probably apply to all of these 😅 another alternative would be to register an option to `unsubscribeAll`