### PR TITLE
fix `peak()` example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ effect(() => {
 
 	// Whenever this effect is triggered, increase `effectCount`.
 	// But we don't want this signal to react to `effectCount`
-	effectCount = effectCount.peek() + 1;
+	effectCount.value = effectCount.peek() + 1;
 });
 ```
 


### PR DESCRIPTION
I think you meant to set the `value`?