### PR TITLE
Correctly peek and replace value

### DIFF
--- a/.changeset/nice-timers-sort.md
+++ b/.changeset/nice-timers-sort.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Correctly replace props-value with peeked value

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,7 +88,6 @@ export class Signal<T = any> {
 		if (this._value !== value) {
 			this._value = value;
 			let isFirst = pending.size === 0;
-
 			pending.add(this);
 			// in batch mode this signal may be marked already
 			if (this._pending === 0) {

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -65,6 +65,7 @@ function getElementUpdater(vnode: VNode) {
 			for (let i = 0; i < signalProps.length; i++) {
 				let { _key: prop, _signal: signal } = signalProps[i];
 				let value = signal._value;
+				if (!dom) return;
 				if (prop in dom) {
 					// @ts-ignore-next-line silly
 					dom[prop] = value;

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -58,12 +58,12 @@ function createUpdater(updater: () => void) {
 function getElementUpdater(vnode: VNode) {
 	let updater = updaterForComponent.get(vnode) as ElementUpdater;
 	if (!updater) {
-		let signalProps: Array<{ key: string, signal: Signal }> = [];
+		let signalProps: Array<{ _key: string, _signal: Signal }> = [];
 		updater = createUpdater(() => {
 			let dom = vnode.__e as Element;
 
 			for (let i = 0; i < signalProps.length; i++) {
-				let { key: prop, signal } = signalProps[i];
+				let { _key: prop, _signal: signal } = signalProps[i];
 				let value = signal.peek();
 				if (prop in dom) {
 					// @ts-ignore-next-line silly
@@ -151,7 +151,7 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 				// first Signal prop triggers creation/cleanup of the updater:
 				if (!updater) updater = getElementUpdater(vnode);
 				// track which props are Signals for precise updates:
-				updater._props.push({ key: i, signal: value });
+				updater._props.push({ _key: i, _signal: value });
 				props[i] = value.peek()
 			}
 		}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -153,6 +153,7 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 				if (!updater) updater = getElementUpdater(vnode);
 				// track which props are Signals for precise updates:
 				updater._props.push(i);
+				props[i] = value.peek()
 			}
 		}
 

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -60,12 +60,12 @@ function getElementUpdater(vnode: VNode) {
 	if (!updater) {
 		let signalProps: Array<{ _key: string, _signal: Signal }> = [];
 		updater = createUpdater(() => {
-			console.log('updater', signalProps)
 			let dom = vnode.__e as Element;
 
 			for (let i = 0; i < signalProps.length; i++) {
 				let { _key: prop, _signal: signal } = signalProps[i];
 				let value = signal.peek();
+				console.log('hi', prop, value)
 				if (prop in dom) {
 					// @ts-ignore-next-line silly
 					dom[prop] = value;
@@ -153,6 +153,7 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 				if (!updater) updater = getElementUpdater(vnode);
 				// track which props are Signals for precise updates:
 				updater._props.push({ _key: i, _signal: value });
+				console.log('updater', i, value.peek())
 				props[i] = value.peek()
 			}
 		}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -58,14 +58,13 @@ function createUpdater(updater: () => void) {
 function getElementUpdater(vnode: VNode) {
 	let updater = updaterForComponent.get(vnode) as ElementUpdater;
 	if (!updater) {
-		let signalProps: string[] = [];
+		let signalProps: Array<{ key: string, signal: Signal }> = [];
 		updater = createUpdater(() => {
 			let dom = vnode.__e as Element;
-			let props = vnode.props;
 
 			for (let i = 0; i < signalProps.length; i++) {
-				let prop = signalProps[i];
-				let value = props[prop]._value;
+				let { key: prop, signal } = signalProps[i];
+				let value = signal.peek();
 				if (prop in dom) {
 					// @ts-ignore-next-line silly
 					dom[prop] = value;
@@ -152,7 +151,7 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 				// first Signal prop triggers creation/cleanup of the updater:
 				if (!updater) updater = getElementUpdater(vnode);
 				// track which props are Signals for precise updates:
-				updater._props.push(i);
+				updater._props.push({ key: i, signal: value });
 				props[i] = value.peek()
 			}
 		}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -163,7 +163,7 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 				} else {
 					value._updater = newUpdater
 				}
-				props[i] = value._value
+				props[i] = value.peek()
 			}
 		}
 

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -65,7 +65,6 @@ function getElementUpdater(vnode: VNode) {
 			for (let i = 0; i < signalProps.length; i++) {
 				let { _key: prop, _signal: signal } = signalProps[i];
 				let value = signal.peek();
-				console.log('hi', prop, value)
 				if (prop in dom) {
 					// @ts-ignore-next-line silly
 					dom[prop] = value;
@@ -153,7 +152,7 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 				if (!updater) updater = getElementUpdater(vnode);
 				// track which props are Signals for precise updates:
 				updater._props.push({ _key: i, _signal: value });
-				console.log('updater', i, value.peek())
+				value._updater = updater._updater
 				props[i] = value.peek()
 			}
 		}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -60,6 +60,7 @@ function getElementUpdater(vnode: VNode) {
 	if (!updater) {
 		let signalProps: Array<{ _key: string, _signal: Signal }> = [];
 		updater = createUpdater(() => {
+			console.log('updater', signalProps)
 			let dom = vnode.__e as Element;
 
 			for (let i = 0; i < signalProps.length; i++) {

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -18,7 +18,7 @@ export interface ComponentType extends Component {
 export type Updater = Signal<unknown>;
 
 export interface ElementUpdater extends Updater {
-	_props: Array<{ key: string, signal: Signal }>;
+	_props: Array<{ _key: string, _signal: Signal }>;
 }
 
 export const enum OptionsTypes {

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -18,7 +18,7 @@ export interface ComponentType extends Component {
 export type Updater = Signal<unknown>;
 
 export interface ElementUpdater extends Updater {
-	_props: string[];
+	_props: Array<{ key: string, signal: Signal }>;
 }
 
 export const enum OptionsTypes {

--- a/packages/preact/test/index.test.ts
+++ b/packages/preact/test/index.test.ts
@@ -200,5 +200,24 @@ describe("@preact/signals", () => {
 			expect((scratch.firstChild?.childNodes[0] as HTMLInputElement).value).to.equal('bar')
 			expect((scratch.firstChild?.childNodes[1] as HTMLInputElement).value).to.equal('bar')
 		})
+
+		it('supports reusing an attribute value-signal', () => {
+			const s = signal('foo');
+			function App() {
+				// @ts-ignore
+				return h('div', {}, [h('input', { value: s.value }), h('input', { value: s.value })])
+			}
+			render(h(App, {}), scratch);
+
+			expect((scratch.firstChild?.childNodes[0] as HTMLInputElement).value).to.equal('foo')
+			expect((scratch.firstChild?.childNodes[1] as HTMLInputElement).value).to.equal('foo')
+			expect(s.peek()).to.equal('foo')
+
+			s.value = 'bar'
+			rerender();
+			expect(s.peek()).to.equal('bar')
+			expect((scratch.firstChild?.childNodes[0] as HTMLInputElement).value).to.equal('bar')
+			expect((scratch.firstChild?.childNodes[1] as HTMLInputElement).value).to.equal('bar')
+		})
 	})
 });

--- a/packages/preact/test/index.test.ts
+++ b/packages/preact/test/index.test.ts
@@ -201,20 +201,32 @@ describe("@preact/signals", () => {
 			expect(spy).not.to.have.been.called;
 		});
 
-		it("should set and update string style property", () => {
-			// const style = signal({ left: "10px" });
+		it("should set and update string style property", async () => {
 			const style = signal("left: 10px");
-			// @ts-ignore
-			render(h("div", { style }), scratch);
+			const spy = sinon.spy();
+			function Wrap() {
+				spy();
+				// @ts-ignore
+				return h("div", { style });
+			}
+			render(h(Wrap, {}), scratch);
+			spy.resetHistory();
 
 			const div = scratch.firstChild as HTMLDivElement;
 
 			expect(div.style).to.have.property("left", "10px");
 
-			// style.value = { left: "20px" };
+			// ensure the component was never re-rendered: (even after a tick)
+			await sleep();
+			expect(spy).not.to.have.been.called;
+
 			style.value = "left: 20px;";
 
 			expect(div.style).to.have.property("left", "20px");
+
+			// ensure the component was never re-rendered: (even after a tick)
+			await sleep();
+			expect(spy).not.to.have.been.called;
 		});
 	});
 });

--- a/packages/preact/test/index.test.ts
+++ b/packages/preact/test/index.test.ts
@@ -181,5 +181,24 @@ describe("@preact/signals", () => {
 			expect(s.peek()).to.equal('bar')
 			expect((scratch.firstChild as HTMLInputElement).value).to.equal('bar')
 		})
+
+		it('supports reusing an attribute signal', () => {
+			const s = signal('foo');
+			function App() {
+				// @ts-ignore
+				return h('div', {}, [h('input', { value: s }), h('input', { value: s })])
+			}
+			render(h(App, {}), scratch);
+
+			expect((scratch.firstChild?.childNodes[0] as HTMLInputElement).value).to.equal('foo')
+			expect((scratch.firstChild?.childNodes[1] as HTMLInputElement).value).to.equal('foo')
+			expect(s.peek()).to.equal('foo')
+
+			s.value = 'bar'
+			rerender();
+			expect(s.peek()).to.equal('bar')
+			expect((scratch.firstChild?.childNodes[0] as HTMLInputElement).value).to.equal('bar')
+			expect((scratch.firstChild?.childNodes[1] as HTMLInputElement).value).to.equal('bar')
+		})
 	})
 });

--- a/packages/preact/test/index.test.ts
+++ b/packages/preact/test/index.test.ts
@@ -146,4 +146,15 @@ describe("@preact/signals", () => {
 			expect(scratch.textContent).to.equal("bar");
 		});
 	});
+
+	describe('attribute bindings', () => {
+		it('checked', () => {
+			const s = signal(false);
+			// @ts-ignore
+			render(h('input', { checked: s }), scratch);
+
+			expect((scratch.firstChild as HTMLInputElement).checked).to.equal(false)
+			expect(s.value).to.equal(false)
+		})
+	})
 });

--- a/packages/preact/test/index.test.ts
+++ b/packages/preact/test/index.test.ts
@@ -148,18 +148,38 @@ describe("@preact/signals", () => {
 	});
 
 	describe('attribute bindings', () => {
-		it('checked', () => {
+		it('supports creating and upating an input checked', () => {
 			const s = signal(false);
-			// @ts-ignore
-			render(h('input', { checked: s }), scratch);
+			function App() {
+				// @ts-ignore
+				return h('input', { checked: s })
+			}
+			render(h(App, {}), scratch);
 
 			expect((scratch.firstChild as HTMLInputElement).checked).to.equal(false)
-			expect(s.value).to.equal(false)
+			expect(s.peek()).to.equal(false)
 
 			s.value = true
 			rerender();
+			expect(s.peek()).to.equal(true)
 			expect((scratch.firstChild as HTMLInputElement).checked).to.equal(true)
-			expect(s.value).to.equal(true)
+		})
+
+		it('supports creating and upating an input value', () => {
+			const s = signal('foo');
+			function App() {
+				// @ts-ignore
+				return h('input', { value: s })
+			}
+			render(h(App, {}), scratch);
+
+			expect((scratch.firstChild as HTMLInputElement).value).to.equal('foo')
+			expect(s.peek()).to.equal('foo')
+
+			s.value = 'bar'
+			rerender();
+			expect(s.peek()).to.equal('bar')
+			expect((scratch.firstChild as HTMLInputElement).value).to.equal('bar')
 		})
 	})
 });

--- a/packages/preact/test/index.test.ts
+++ b/packages/preact/test/index.test.ts
@@ -155,6 +155,11 @@ describe("@preact/signals", () => {
 
 			expect((scratch.firstChild as HTMLInputElement).checked).to.equal(false)
 			expect(s.value).to.equal(false)
+
+			s.value = true
+			rerender();
+			expect((scratch.firstChild as HTMLInputElement).checked).to.equal(true)
+			expect(s.value).to.equal(true)
 		})
 	})
 });


### PR DESCRIPTION
Before we never unwrapped the signal passed into the element-attributes, this lead to the issue described in #74. We resolve this by assigning the prop to `signal.peek()`, this however leads to us losing the reference to the signal on `vnode.props[attribute-key]` which is used for the updater. To resolve the updater losing signal reference we switch the underlying data-structure to use an object of `{ key signal }` to save the reference.

While writing tests I noticed that the updater was never properly called as it would call the updater of the passed-in signal rather than the one we created with `createUpdater`, this is fixed by inheriting the `_updater` function to the props-signal.

Fixes https://github.com/preactjs/signals/issues/74
CSB Repro: https://codesandbox.io/s/jovial-nova-8xgk76?file=/src/signals.js:0-3518