### PR TITLE
Add link to announcement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Signals
 
 Signals is a performant state management library with two primary goals:
@@ -5,7 +6,9 @@ Signals is a performant state management library with two primary goals:
 1. Make it as easy as possible to write business logic for small up to complex apps. No matter how complex your logic is, your app updates should stay fast without you needing to think about it. Signals automatically optimize state updates behind the scenes to trigger the fewest updates necessary. They are lazy by default and automatically skip signals that no one listens to.
 2. Integrate into frameworks as if they were native built-in primitives. You don't need any selectors, wrapper functions, or anything else. Signals can be accessed directly and your component will automatically re-render when the signal's value changes.
 
-Installation:
+Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solve and how it came to be.
+
+## Installation:
 
 ```sh
 # Just the core library


### PR DESCRIPTION
Unfortunately this was shared on hackernews instead of the announcement post. Hopefully just adding the link helps folks on HN understand more about the motivation to create signals etc.