### PR TITLE
chore: Splits README and ensures each pkg is published with one

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ npm install @preact/signals-react
 	- [`computed(fn)`](#computedfn)
 	- [`effect(fn)`](#effectfn)
 	- [`batch(fn)`](#batchfn)
-- [Preact Integration](./packages/preact/README.md)
+- [Preact Integration](./packages/preact/README.md#preact-integration)
 	- [Hooks](./packages/preact/README.md#hooks)
 	- [Rendering optimizations](./packages/preact/README.md#rendering-optimizations)
 		- [Attribute optimization (experimental)](./packages/preact/README.md#attribute-optimization-experimental)
-- [React Integration](./packages/react/README.md)
+- [React Integration](./packages/react/README.md#react-integration)
 	- [Hooks](./packages/react/README.md#hooks)
 - [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ npm install @preact/signals-react
 	- [`computed(fn)`](#computedfn)
 	- [`effect(fn)`](#effectfn)
 	- [`batch(fn)`](#batchfn)
-- [Preact Integration](#preact-integration)
-	- [Hooks](#hooks)
-	- [Rendering optimizations](#rendering-optimizations)
-		- [Attribute optimization (experimental)](#attribute-optimization-experimental)
-- [React Integration](#react-integration)
-	- [Hooks](#hooks-1)
+- [Preact Integration](./packages/preact/README.md)
+	- [Hooks](./packages/preact/README.md#hooks)
+	- [Rendering optimizations](./packages/preact/README.md#rendering-optimizations)
+		- [Attribute optimization (experimental)](./packages/preact/README.md#attribute-optimization-experimental)
+- [React Integration](./packages/react/README.md)
+	- [Hooks](./packages/react/README.md#hooks)
 - [License](#license)
 
 ## Guide / API
@@ -198,128 +198,6 @@ batch(() => {
 	// Still not updated...
 });
 // Now the callback completed and we'll trigger the effect.
-```
-
-## Preact Integration
-
-The Preact integration can be installed via:
-
-```sh
-npm install @preact/signals
-```
-
-It allows you to access signals as if they were native to Preact. Whenever you read a signal inside a component we'll automatically subscribe the component to that. When you update the signal we'll know that this component needs to be updated and will do that for you.
-
-```js
-// The Preact adapter re-exports the core library
-import { signal } from "@preact/signals";
-
-const count = signal(0);
-
-function CounterValue() {
-	// Whenever the `count` signal is updated, we'll
-	// re-render this component automatically for you
-	return <p>Value: {count.value}</p>;
-}
-```
-
-### Hooks
-
-If you need to instantiate new signals inside your components, you can use the `useSignal` or `useComputed` hook.
-
-```js
-import { useSignal, useComputed } from "@preact/signals";
-
-function Counter() {
-	const count = useSignal(0);
-	const double = useComputed(() => count.value * 2);
-
-	return (
-		<button onClick={() => count.value++}>
-			Value: {count.value}, value x 2 = {double.value}
-		</button>
-	);
-}
-```
-
-### Rendering optimizations
-
-The Preact adapter ships with several optimizations it can apply out of the box to skip virtual-dom rendering entirely. If you pass a signal directly into JSX, it will bind directly to the DOM `Text` node that is created and update that whenever the signal changes.
-
-```js
-import { signal } from "@preact/signals";
-
-const count = signal(0);
-
-// Unoptimized: Will trigger the surrounding
-// component to re-render
-function Counter() {
-	return <p>Value: {count.value}</p>;
-}
-
-// Optimized: Will update the text node directly
-function Counter() {
-	return <p>Value: {count}</p>;
-}
-```
-
-To opt into this optimization, simply pass the signal directly instead of accessing the `.value` property.
-
-#### Attribute optimization (experimental)
-
-We can also pass signals directly as an attribute to an HTML element node.
-
-```js
-import { signal } from "@preact/signals";
-
-const inputValue = signal("foobar");
-
-function Person() {
-	return <input value={inputValue} />;
-}
-```
-
-This way we'll bypass checking the virtual-dom and update the DOM property directly.
-
-## React Integration
-
-The React integration can be installed via:
-
-```sh
-npm install @preact/signals-react
-```
-
-Similar to the Preact integration, the React adapter allows you to access signals directly inside your components and will automatically subscribe to them.
-
-```js
-import { signal } from "@preact/signals-react";
-
-const count = signal(0);
-
-function CounterValue() {
-	// Whenver the `count` signal is updated, we'll
-	// re-render this component automatically for you
-	return <p>Value: {count.value}</p>;
-}
-```
-
-### Hooks
-
-If you need to instantiate new signals inside your components, you can use the `useSignal` or `useComputed` hook.
-
-```js
-import { useSignal, useComputed } from "@preact/signals-react";
-
-function Counter() {
-	const count = useSignal(0);
-	const double = useComputed(() => count.value * 2);
-
-	return (
-		<button onClick={() => count.value++}>
-			Value: {count.value}, value x 2 = {double.value}
-		</button>
-	);
-}
 ```
 
 ## License

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,10 @@
 	"authors": [
 		"The Preact Authors (https://github.com/preactjs/signals/contributors)"
 	],
-	"repository": "preactjs/signals",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/preactjs/signals"
+	},
 	"bugs": "https://github.com/preactjs/signals/issues",
 	"homepage": "https://preactjs.com",
 	"funding": {
@@ -31,6 +34,6 @@
 	},
 	"mangle": "../../mangle.json",
 	"scripts": {
-		"prepublishOnly": "cd ../.. && pnpm build:core"
+		"prepublishOnly": "cp ../../README.md . && cd ../.. && pnpm build:core"
 	}
 }

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -6,7 +6,7 @@ Signals is a performant state management library with two primary goals:
 1. Make it as easy as possible to write business logic for small up to complex apps. No matter how complex your logic is, your app updates should stay fast without you needing to think about it. Signals automatically optimize state updates behind the scenes to trigger the fewest updates necessary. They are lazy by default and automatically skip signals that no one listens to.
 2. Integrate into frameworks as if they were native built-in primitives. You don't need any selectors, wrapper functions, or anything else. Signals can be accessed directly and your component will automatically re-render when the signal's value changes.
 
-Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solve and how it came to be.
+Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solves and how it came to be.
 
 ## Installation:
 

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -1,0 +1,112 @@
+
+# Signals
+
+Signals is a performant state management library with two primary goals:
+
+1. Make it as easy as possible to write business logic for small up to complex apps. No matter how complex your logic is, your app updates should stay fast without you needing to think about it. Signals automatically optimize state updates behind the scenes to trigger the fewest updates necessary. They are lazy by default and automatically skip signals that no one listens to.
+2. Integrate into frameworks as if they were native built-in primitives. You don't need any selectors, wrapper functions, or anything else. Signals can be accessed directly and your component will automatically re-render when the signal's value changes.
+
+Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solve and how it came to be.
+
+## Installation:
+
+```sh
+npm install @preact/signals
+```
+
+- [Guide / API](../../README.md#guide--api)
+	- [`signal(initialValue)`](../../README.md#signalinitialvalue)
+		- [`signal.peek()`](../../README.md#signalpeek)
+	- [`computed(fn)`](../../README.md#computedfn)
+	- [`effect(fn)`](../../README.md#effectfn)
+	- [`batch(fn)`](../../README.md#batchfn)
+- [Preact Integration](#preact-integration)
+	- [Hooks](#hooks)
+	- [Rendering optimizations](#rendering-optimizations)
+		- [Attribute optimization (experimental)](#attribute-optimization-experimental)
+- [License](#license)
+
+## Preact Integration
+
+The Preact integration can be installed via:
+
+```sh
+npm install @preact/signals
+```
+
+It allows you to access signals as if they were native to Preact. Whenever you read a signal inside a component we'll automatically subscribe the component to that. When you update the signal we'll know that this component needs to be updated and will do that for you.
+
+```js
+// The Preact adapter re-exports the core library
+import { signal } from "@preact/signals";
+
+const count = signal(0);
+
+function CounterValue() {
+	// Whenever the `count` signal is updated, we'll
+	// re-render this component automatically for you
+	return <p>Value: {count.value}</p>;
+}
+```
+
+### Hooks
+
+If you need to instantiate new signals inside your components, you can use the `useSignal` or `useComputed` hook.
+
+```js
+import { useSignal, useComputed } from "@preact/signals";
+
+function Counter() {
+	const count = useSignal(0);
+	const double = useComputed(() => count.value * 2);
+
+	return (
+		<button onClick={() => count.value++}>
+			Value: {count.value}, value x 2 = {double.value}
+		</button>
+	);
+}
+```
+
+### Rendering optimizations
+
+The Preact adapter ships with several optimizations it can apply out of the box to skip virtual-dom rendering entirely. If you pass a signal directly into JSX, it will bind directly to the DOM `Text` node that is created and update that whenever the signal changes.
+
+```js
+import { signal } from "@preact/signals";
+
+const count = signal(0);
+
+// Unoptimized: Will trigger the surrounding
+// component to re-render
+function Counter() {
+	return <p>Value: {count.value}</p>;
+}
+
+// Optimized: Will update the text node directly
+function Counter() {
+	return <p>Value: {count}</p>;
+}
+```
+
+To opt into this optimization, simply pass the signal directly instead of accessing the `.value` property.
+
+#### Attribute optimization (experimental)
+
+We can also pass signals directly as an attribute to an HTML element node.
+
+```js
+import { signal } from "@preact/signals";
+
+const inputValue = signal("foobar");
+
+function Person() {
+	return <input value={inputValue} />;
+}
+```
+
+This way we'll bypass checking the virtual-dom and update the DOM property directly.
+
+## License
+
+`MIT`, see the [LICENSE](../../LICENSE) file.

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -7,7 +7,10 @@
 	"authors": [
 		"The Preact Authors (https://github.com/preactjs/signals/contributors)"
 	],
-	"repository": "preactjs/signals",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/preactjs/signals"
+	},
 	"bugs": "https://github.com/preactjs/signals/issues",
 	"homepage": "https://preactjs.com",
 	"funding": {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,71 @@
+
+# Signals
+
+Signals is a performant state management library with two primary goals:
+
+1. Make it as easy as possible to write business logic for small up to complex apps. No matter how complex your logic is, your app updates should stay fast without you needing to think about it. Signals automatically optimize state updates behind the scenes to trigger the fewest updates necessary. They are lazy by default and automatically skip signals that no one listens to.
+2. Integrate into frameworks as if they were native built-in primitives. You don't need any selectors, wrapper functions, or anything else. Signals can be accessed directly and your component will automatically re-render when the signal's value changes.
+
+Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solve and how it came to be.
+
+## Installation:
+
+```sh
+npm install @preact/signals-react
+```
+
+- [Guide / API](../../README.md#guide--api)
+	- [`signal(initialValue)`](../../README.md#signalinitialvalue)
+		- [`signal.peek()`](../../README.md#signalpeek)
+	- [`computed(fn)`](../../README.md#computedfn)
+	- [`effect(fn)`](../../README.md#effectfn)
+	- [`batch(fn)`](../../README.md#batchfn)
+- [React Integration](#react-integration)
+	- [Hooks](#hooks)
+- [License](#license)
+
+## React Integration
+
+The React integration can be installed via:
+
+```sh
+npm install @preact/signals-react
+```
+
+Similar to the Preact integration, the React adapter allows you to access signals directly inside your components and will automatically subscribe to them.
+
+```js
+import { signal } from "@preact/signals-react";
+
+const count = signal(0);
+
+function CounterValue() {
+	// Whenver the `count` signal is updated, we'll
+	// re-render this component automatically for you
+	return <p>Value: {count.value}</p>;
+}
+```
+
+### Hooks
+
+If you need to instantiate new signals inside your components, you can use the `useSignal` or `useComputed` hook.
+
+```js
+import { useSignal, useComputed } from "@preact/signals-react";
+
+function Counter() {
+	const count = useSignal(0);
+	const double = useComputed(() => count.value * 2);
+
+	return (
+		<button onClick={() => count.value++}>
+			Value: {count.value}, value x 2 = {double.value}
+		</button>
+	);
+}
+```
+
+## License
+
+`MIT`, see the [LICENSE](../../LICENSE) file.
+

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,7 +6,7 @@ Signals is a performant state management library with two primary goals:
 1. Make it as easy as possible to write business logic for small up to complex apps. No matter how complex your logic is, your app updates should stay fast without you needing to think about it. Signals automatically optimize state updates behind the scenes to trigger the fewest updates necessary. They are lazy by default and automatically skip signals that no one listens to.
 2. Integrate into frameworks as if they were native built-in primitives. You don't need any selectors, wrapper functions, or anything else. Signals can be accessed directly and your component will automatically re-render when the signal's value changes.
 
-Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solve and how it came to be.
+Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solves and how it came to be.
 
 ## Installation:
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,10 @@
 	"authors": [
 		"The Preact Authors (https://github.com/preactjs/signals/contributors)"
 	],
-	"repository": "preactjs/signals",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/preactjs/signals"
+	},
 	"bugs": "https://github.com/preactjs/signals/issues",
 	"homepage": "https://preactjs.com",
 	"funding": {


### PR DESCRIPTION
None of the packages currently are published with ReadMes, which makes it difficult to browse on NPM.

This does 2 things:
 - Copies root ReadMe to core on `prepublish`
 - Splits the Preact & React content into their own ReadMes

I kept the intro blurb in each, not sure how others feel about that. 