### PR TITLE
Add unwrapping signals

### DIFF
--- a/.changeset/hungry-dancers-eat.md
+++ b/.changeset/hungry-dancers-eat.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-core": minor
+"@preact/signals": minor
+"@preact/signals-react": minor
+---
+
+Add unwrapping signal

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -252,6 +252,11 @@ export function signal<T>(value: T): Signal<T> {
 export type ReadonlySignal<T = any> = Omit<Signal<T>, "value"> & {
 	readonly value: T;
 };
+
+export function unwrap<T>(val: T | Signal<T>): T {
+	return val instanceof Signal ? val.value : val;
+}
+
 export function computed<T>(compute: () => T): ReadonlySignal<T> {
 	const signal = new Signal<T>(undefined as any);
 	signal._readonly = true;

--- a/packages/core/test/signal.test.ts
+++ b/packages/core/test/signal.test.ts
@@ -1,4 +1,4 @@
-import { signal, computed, effect, batch } from "@preact/signals-core";
+import { signal, computed, effect, batch, unwrap } from "@preact/signals-core";
 
 describe("signal", () => {
 	it("should return value", () => {
@@ -651,5 +651,21 @@ describe("batch/transaction", () => {
 		});
 		c.value = "cc";
 		expect(result).to.equal("aa bb cc");
+	});
+});
+
+describe("unwrap()", () => {
+	it("should unwrap signals", () => {
+		const count = signal(123);
+
+		const result = unwrap(count);
+		expect(result).to.equal(123);
+	});
+
+	it("should pass non-signals", () => {
+		const count = 234;
+
+		const result = unwrap(count);
+		expect(result).to.equal(234);
 	});
 });

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -2,6 +2,7 @@ import { options, Component, createElement } from "preact";
 import { useRef, useMemo } from "preact/hooks";
 import {
 	signal,
+	unwrap,
 	computed,
 	batch,
 	effect,
@@ -17,7 +18,7 @@ import {
 	ElementUpdater,
 } from "./internal";
 
-export { signal, computed, batch, effect, Signal, type ReadonlySignal };
+export { signal, unwrap, computed, batch, effect, Signal, type ReadonlySignal };
 
 // Components that have a pending Signal update: (used to bypass default sCU:false)
 const hasPendingUpdate = new WeakSet<Component>();

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,7 @@ import {
 import React from "react";
 import {
 	signal,
+	unwrap,
 	computed,
 	batch,
 	effect,
@@ -16,7 +17,7 @@ import {
 } from "@preact/signals-core";
 import { Updater, ReactOwner, ReactDispatcher } from "./internal";
 
-export { signal, computed, batch, effect, Signal, type ReadonlySignal };
+export { signal, unwrap, computed, batch, effect, Signal, type ReadonlySignal };
 
 /**
  * Install a middleware into React.createElement to replace any Signals in props with their value.


### PR DESCRIPTION
Adds an utility function to unwrap signals, useful if you want to accept both signals and non-signals, and only want the actual value.

Peeking isn't used here because the intention is that you'd still want to have your signal tracked in the case that it is one.