### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ batch(() => {
 	counter.value = 1;
 	// Logs: 2, despite being inside batch, but `tripple`
 	// will only update once the callback is complete
-	console.log(counter.double);
+	console.log(double.value);
 });
 // Now we reached the end of the batch and call the effect
 ```


### PR DESCRIPTION
Relating to https://github.com/preactjs/signals/issues/89.

Changed `counter.double` to read `double.value`.