### PR TITLE
Fix internal API able to unmark non-marked signals

### DIFF
--- a/.changeset/neat-dingos-shake.md
+++ b/.changeset/neat-dingos-shake.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Fix internal API functions being able to unmark non-invalidated signals

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,7 +162,11 @@ function unmark(signal: Signal<any>) {
 	// wasn't flagged as needing an update by someone else. This is
 	// done to make the sweeping logic independent of the order
 	// in which a dependency tries to unmark a subtree.
-	if (!signal._requiresUpdate && --signal._pending === 0) {
+	if (
+		!signal._requiresUpdate &&
+		signal._pending > 0 &&
+		--signal._pending === 0
+	) {
 		signal._subs.forEach(unmark);
 	}
 }

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -470,6 +470,21 @@ describe("computed()", () => {
 			a.value = "aa";
 			expect(spy).to.returned("aa c d");
 		});
+
+		it("should prevent invalid unmark state when called on a source signal", () => {
+			// Don't allow our internal logic to get in an invalid state, even through
+			// our own internal API. The bug this tests for is that a source signal
+			// will be unmarked, leading to all its subscribers `_pending` value to become
+			// negative. This is invalid and breaks further updates.
+			const a = signal("a");
+			const b = computed(() => a.value);
+			effect(() => b.value);
+
+			a._setCurrent()(true, true);
+
+			a.value = "aa";
+			expect(b.value).to.equal("aa");
+		});
 	});
 
 	describe("error handling", () => {


### PR DESCRIPTION
This is something that cannot occur through the public API. Ran into this whilst writing a custom adapter for another project.

We were missing a guard check before trying to unmark a signal, that checks if it was marked in the first place. We should bail out if it wasn't marked as needing an update.