### PR TITLE
Remove root signal

### DIFF
--- a/.changeset/two-mails-sip.md
+++ b/.changeset/two-mails-sip.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+- Fix a memory leak when computed signals and effects are removed

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,21 +43,24 @@ export class Signal<T = any> {
 	}
 
 	peek() {
-		if (currentSignal && currentSignal._canActivate && this._deps.size === 0) {
+		const shouldActivate = !currentSignal || currentSignal._canActivate;
+		if (shouldActivate && this._deps.size === 0) {
 			activate(this);
 		}
 		return this._value;
 	}
 
 	get value() {
-		if (!currentSignal) {
-			return this._value;
+		const shouldActivate = !currentSignal || currentSignal._canActivate;
+		if (shouldActivate && this._deps.size === 0) {
+			activate(this);
 		}
+
 		// If we read a signal outside of a computed we have no way
 		// to unsubscribe from that. So we assume that the user wants
 		// to get the value immediately like for testing.
-		if (currentSignal._canActivate && this._deps.size === 0) {
-			activate(this);
+		if (!currentSignal) {
+			return this._value;
 		}
 
 		// subscribe the current computed to this signal:


### PR DESCRIPTION
This fixes a memory leak caused by all signals being addressable from our internal `ROOT` signal. We never ended up using the root signal, and removing it means computed graphs within components get nicely GC'd when unmounted.