### PR TITLE
Proposal: deepSignal listenable container

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -305,7 +305,7 @@ export function batch<T>(cb: () => T): T {
 
 type Signalable = Array<any> | ((...args: any[]) => any) | string | boolean | number | bigint | symbol | undefined | null;
 
-type Storeable = {
+export type Storeable = {
 	[key: string]: (() => any) | Signalable | Storeable
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -302,3 +302,76 @@ export function batch<T>(cb: () => T): T {
 		}
 	}
 }
+
+type Signalable = Array<any> | ((...args: any[]) => any) | string | boolean | number | bigint | symbol | undefined | null;
+
+type Storeable = {
+	[key: string]: (() => any) | Signalable | Storeable
+};
+
+type ReadOnlyDeep<T> = {
+	readonly [P in keyof T]: ReadOnlyDeep<T[P]>;
+}
+
+interface IDeepSignal<T extends Storeable> { value: ReadOnlyDeep<T>, peek: () => ReadOnlyDeep<T> }
+
+type DeepSignal<T extends Storeable> = IDeepSignal<T> & {
+	[K in keyof T]:
+	T[K] extends Signalable ? Signal<T[K]> :
+	T[K] extends Storeable ? DeepSignal<T[K]> :
+	Signal<T[K]>;
+};
+
+export class DeepSignalImpl<T extends Storeable> implements IDeepSignal<T> {
+	get value(): ReadOnlyDeep<T> {
+		return getValue(this as any as DeepSignal<T>);
+	}
+
+	set value(payload: ReadOnlyDeep<T>) {
+		batch(() => setValue(this as any as DeepSignal<T>, payload));
+	}
+
+	peek(): ReadOnlyDeep<T> {
+		return getValue(this as any as DeepSignal<T>, { peek: true });
+	}
+}
+
+export const deepSignal = <T extends Storeable>(initialValue: T): DeepSignal<T> =>
+	Object.assign(
+		new DeepSignalImpl(),
+		Object.entries(initialValue).reduce(
+			(acc, [key, value]) => {
+				if (["value", "peek"].some(iKey => iKey === key)) {
+					throw new Error(`${key} is a reserved property name`);
+				} else if (typeof value !== "object" || value === null || Array.isArray(value)) {
+					acc[key] = signal(value);
+				} else {
+					acc[key] = deepSignal(value);
+				}
+				return acc;
+			}, {} as { [key: string]: unknown })
+	) as DeepSignal<T>;
+
+const setValue = <U extends Storeable, T extends DeepSignal<U>>(
+	deepSignal: T,
+	payload: U
+): void =>
+	Object.keys(payload).forEach((key: keyof U) =>
+		deepSignal[key].value = payload[key]
+	);
+
+const getValue = <U extends Storeable, T extends DeepSignal<U>>(
+	deepSignal: T,
+	{ peek = false }: { peek?: boolean } = {}
+): ReadOnlyDeep<U> =>
+	Object.entries(deepSignal).reduce((
+		acc,
+		[key, value]
+	) => {
+		if (value instanceof Signal) {
+			acc[key] = peek ? value.peek() : value.value;
+		} else if (value instanceof DeepSignalImpl) {
+			acc[key] = getValue(value as DeepSignal<Storeable>, { peek });
+		}
+		return acc;
+	}, {} as { [key: string]: unknown }) as ReadOnlyDeep<U>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -313,9 +313,9 @@ type ReadOnlyDeep<T> = {
 	readonly [P in keyof T]: ReadOnlyDeep<T[P]>;
 }
 
-interface IDeepSignal<T extends Storeable> { value: ReadOnlyDeep<T>, peek: () => ReadOnlyDeep<T> }
+export interface IDeepSignal<T extends Storeable> { value: ReadOnlyDeep<T>, peek: () => ReadOnlyDeep<T> }
 
-type DeepSignal<T extends Storeable> = IDeepSignal<T> & {
+export type DeepSignal<T extends Storeable> = IDeepSignal<T> & {
 	[K in keyof T]:
 	T[K] extends Signalable ? Signal<T[K]> :
 	T[K] extends Storeable ? DeepSignal<T[K]> :

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -8,6 +8,7 @@ import {
 	Signal,
 	deepSignal,
 	DeepSignalImpl,
+	type Storeable,
 	type ReadonlySignal,
 } from "@preact/signals-core";
 import {
@@ -19,7 +20,7 @@ import {
 	ElementUpdater,
 } from "./internal";
 
-export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal };
+export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal, type Storeable };
 
 // Components that have a pending Signal update: (used to bypass default sCU:false)
 const hasPendingUpdate = new WeakSet<Component>();
@@ -300,6 +301,10 @@ export function useComputed<T>(compute: () => T) {
 	$compute.current = compute;
 	hasComputeds.add(currentComponent!);
 	return useMemo(() => computed<T>(() => $compute.current()), []);
+}
+
+export function useDeepSignal<T extends Storeable> (initial: T | (() => T)) {
+	return useMemo(() => deepSignal(typeof initial === "function" ? initial() : initial), []);
 }
 
 /**

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -8,6 +8,8 @@ import {
 	Signal,
 	deepSignal,
 	DeepSignalImpl,
+	type IDeepSignal,
+	type DeepSignal,
 	type Storeable,
 	type ReadonlySignal,
 } from "@preact/signals-core";
@@ -20,7 +22,7 @@ import {
 	ElementUpdater,
 } from "./internal";
 
-export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal, type Storeable };
+export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal, type Storeable, type IDeepSignal, type DeepSignal };
 
 // Components that have a pending Signal update: (used to bypass default sCU:false)
 const hasPendingUpdate = new WeakSet<Component>();

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -6,6 +6,8 @@ import {
 	batch,
 	effect,
 	Signal,
+	deepSignal,
+	DeepSignalImpl,
 	type ReadonlySignal,
 } from "@preact/signals-core";
 import {
@@ -17,7 +19,7 @@ import {
 	ElementUpdater,
 } from "./internal";
 
-export { signal, computed, batch, effect, Signal, type ReadonlySignal };
+export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal };
 
 // Components that have a pending Signal update: (used to bypass default sCU:false)
 const hasPendingUpdate = new WeakSet<Component>();

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,11 +14,12 @@ import {
 	Signal,
 	deepSignal,
 	DeepSignalImpl,
+	type Storeable,
 	type ReadonlySignal,
 } from "@preact/signals-core";
 import { Updater, ReactOwner, ReactDispatcher } from "./internal";
 
-export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal };
+export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal, type Storeable };
 
 /**
  * Install a middleware into React.createElement to replace any Signals in props with their value.
@@ -152,4 +153,8 @@ export function useComputed<T>(compute: () => T) {
 	const $compute = useRef(compute);
 	$compute.current = compute;
 	return useMemo(() => computed<T>(() => $compute.current()), []);
+}
+
+export function useDeepSignal<T extends Storeable> (initial: T | (() => T)) {
+	return useMemo(() => deepSignal(typeof initial === "function" ? initial() : initial), []);
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -15,11 +15,13 @@ import {
 	deepSignal,
 	DeepSignalImpl,
 	type Storeable,
+	type IDeepSignal,
+	type DeepSignal,
 	type ReadonlySignal,
 } from "@preact/signals-core";
 import { Updater, ReactOwner, ReactDispatcher } from "./internal";
 
-export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal, type Storeable };
+export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal, type Storeable, type IDeepSignal, type DeepSignal };
 
 /**
  * Install a middleware into React.createElement to replace any Signals in props with their value.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,11 +12,13 @@ import {
 	batch,
 	effect,
 	Signal,
+	deepSignal,
+	DeepSignalImpl,
 	type ReadonlySignal,
 } from "@preact/signals-core";
 import { Updater, ReactOwner, ReactDispatcher } from "./internal";
 
-export { signal, computed, batch, effect, Signal, type ReadonlySignal };
+export { signal, computed, batch, effect, Signal, DeepSignalImpl, deepSignal, type ReadonlySignal };
 
 /**
  * Install a middleware into React.createElement to replace any Signals in props with their value.


### PR DESCRIPTION
This is intended to be a solution to #4 . This proposal is generally just the meat of a library I made [`preact-signal-store`](https://www.npmjs.com/package/preact-signal-store), but I'd love to entirely deprecate this library and have this new primitive added to this package. I'd be certainly willing to add more tests or add to the demos website if the maintainers think that this primitive is worth having.

I also would be totally receptive of reccomendations for better sorting of the types as I realize the existence of `DeepSignal`, `IDeepSignal` and `DeepSignalImpl` appears obtuse/excessive.

I also considerred making the `value` getter on `DeepSignal` return a stored private `computed` `_value` property but honestly, I just didn't see what would be gained by this.

Here's the current README.md to the package for a better description of what this offers.

## How it works

Very simply, the library just takes an arbitrary object of any scale or shape, and recursively turns all properties into signals. The objects themselves each turn into a `DeepSignal` which contains a `value` getter & setter as well as a `peek` method just like regular `Signal` instances. However, if you assign a new value to a `DeepSignal`, the setter method will recursively find every true `Signal` inside the object and assign them to a new value. So if you subscribe to a `Signal` in a component, you can guarantee that it will be updated no matter what level of the store gets reassigned.

So a simple example like this

```ts
import { deepSignal } from "preact-signal-store";

const userStore = deepSignal({
  name: {
    first: "Thor",
    last: "Odinson"
  },
  email: "thor@avengers.org"
});
```

...is equivalent to this code...

```ts
const userStore = {
  name: {
    first: signal("Thor"),
    last: signal("Odinson"),
    get value(): { first: string, last: string } {
      return {
        first: this.first.value,
        last: this.last.value
      }
    },
    set value(payload: { first: string, last: string }) {
      batch(() => {
        this.first.value = payload.first;
        this.last.value = payload.last;
      });
    },
    peek(): { first: string, last: string } {
      return {
        first: this.first.peek(),
        last: this.last.peek()
      }
    },
  },
  email: signal("thor@avengers.org"),
  get value(): { name: { first: string, last: string }, email: string } {
    return {
      name: {
        first: this.name.first.value,
        last: this.name.last.value
      },
      email: this.email.value
    }
  },
  set value(payload: { name: { first: string, last: string }, email: string }) {
    batch(() => {
      this.name.first.value = payload.name.first;
      this.name.last.value = payload.name.last;
      this.email.value = payload.email;
    });
  },
  peek(): { name: { first: string, last: string }, email: string } {
    return {
      name: {
        first: this.name.first.peek(),
        last: this.name.last.peek()
      },
      email: this.email.peek()
    }
  },
};
```

### Using `DeepSignal` in a local context

By utilizing `useDeepSignal` you can get a local state DX that's very similar to class components while continuing to have the
performance advantages of signals.

```tsx
import { useDeepSignal } from "preact-signal-store";

const UserRegistrationForm = () => {
  const user = useDeepSignal(() => ({
    name: {
      first: "",
      last: ""
    },
    email: ""
  }));

  const submitRegistration = (event) => {
    event.preventDefault();
    fetch(
      "/register",
      { method: "POST", body: JSON.stringify(user.peek()) }
    );
  }

  return (
    <form onSubmit={submitRegistration}>
      <label>
        First name
        <input value={user.name.first}
          onInput={e => user.name.first.value = e.currentTarget.value} />
      </label>
      <label>
        Last name
        <input value={user.name.last}
          onInput={e => user.name.last.value = e.currentTarget.value} />
      </label>
      <label>
        Email
        <input value={user.email}
          onInput={e => user.email.value = e.currentTarget.value} />
      </label>
      <button>Submit</button>
    </form>
  );
}
```

## Recipes

### Zustand style method actions

When I look to Zustand for the API it provides, it seems like a lot of their API (as much as I admire it) is based around supporting the
functional context. But the output of `preact-signal-store` is very openly dynamic and writing to it inside or outside of a component 
ends up being the same. So you can take Zustand's basic example...

```ts
import create from "zustand";

export const useBearStore = create((set) => ({
  bears: 0,
  increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
  removeAllBears: () => set({ bears: 0 }),
}))
```

...and create an effectively equivalent version with `preact-signal-store` like this...

```ts
import { deepSignal } from "preact-signal-store";

export const bearStore = {
  data: deepSignal({
    bears: 0
  }),
  increasePopulation() {
    this.data.bears.value++;
  },
  removeAllBears() {
    this.data.bears.value = 0
  }
};
```

### Storing and fetching from localStorage

Because the `value` getter on a `DeepSignal` effectively calls the `value` getter on each underlying `Signal`, calling the `DeepSignal`'s
getter will properly subscribe to each underlying signal. So if you wanted to manage the side effects of any level of a `DeepSignal` you
just need to call `effect` from `@preact/signals` and call `DeepSignal.value`

```ts
import { deepSignal } from "preact-signal-store";
import { effect } from "@preact/signals";

type UserStore = {
  name: {
    first: string;
    last: string;
  };
  email: string;
}

const getInitialUserStore = (): UserStore => {
  const storedUserStore = localStorage.getItem("USER_STORE_KEY");
  if (storedUserStore) {
    // you should probably validate this 🤷‍♂️
    return JSON.parse(storedUserStore);
  } else {
    return {
      name: {
        first: "",
        last: ""
      },
      email: ""
    };
  }
}

const userStore = deepSignal(getInitialUserStore());

effect(() => localStorage.setItem("USER_STORE_KEY", JSON.stringify(userStore.value)));
```

This would also work for any level of the `DeepSignal`.

```ts
import { deepSignal } from "preact-signal-store";
import { effect } from "@preact/signals";

type UserNameStore = {
  first: string;
  last: string;
};

const getInitialUserNameStore = (): UserNameStore => {
  const storedUserStore = localStorage.getItem("USER_NAME_STORE_KEY");

  // you should probably validate this too 🤷‍♂️
  return storedUserStore ? JSON.parse(storedUserStore) : { first: "", last: "" },
}

const userStore = deepSignal({
  name: getInitialUserNameStore(),
  email: ""
});

effect(() => localStorage.setItem("USER_NAME_STORE_KEY", JSON.stringify(userStore.name.value)));
```

This should fulfill most needs for middleware or plugins. If this fails to meet your needs, please file an
issue and I will address the particular ask.

## TypeScript support

The API for `deepStore` and `useDeepStore` will handle dynamic typing for arbitrary input! It will also help you avoid a case like this

```ts
import { deepSignal } from "preact-signal-store";

const userStore = deepSignal({
  name: {
    first: "Thor",
    last: "Odinson"
  },
  email: "thor@avengers.org"
});

// TS error: Cannot assign to 'email' because it is a read-only property.
userStore.value.email = "another@email.com"
```