### PR TITLE
Throw on build for unused variables

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,12 +5,6 @@ let commitError: Error | null = null;
 const pending = new Set<Signal>();
 /** Batch calls can be nested. 0 means that there is no batching */
 let batchPending = 0;
-/**
- * Subscriptions are set up lazily when a "reactor" is set up.
- * During this activation phase we traverse the graph upwards
- * and refresh all signals that are stale on signal read.
- */
-let activating = false;
 
 let oldDeps = new Set<Signal>();
 
@@ -229,13 +223,8 @@ function refreshStale(signal: Signal) {
 }
 
 function activate(signal: Signal) {
-	activating = true;
 	signal._active = true;
-	try {
-		refreshStale(signal);
-	} finally {
-		activating = false;
-	}
+	refreshStale(signal);
 }
 
 export function signal<T>(value: T): Signal<T> {

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -276,6 +276,7 @@ Component.prototype.shouldComponentUpdate = function (props, state) {
 
 	// if there is hook or class state, update:
 	if (hasHookState.has(this)) return true;
+	// @ts-ignore
 	for (let i in state) return true;
 
 	// if any non-Signal props changed, update:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "jsxFactory": "createElement",
     "jsxFragmentFactory": "Fragment",
     "stripInternal": true,
+    "noUnusedLocals": true,
     "paths": {
       "@preact/signals-core": [
         "./packages/core/src/index.ts"


### PR DESCRIPTION
Missed this variable in #127 . Our tooling should fail on build if it detects unused variables. This PR addresses that.