### PR TITLE
Small fixes to core

### DIFF
--- a/.changeset/mighty-pianos-end.md
+++ b/.changeset/mighty-pianos-end.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Fix incorrectly named variables and address typos in code comments.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,10 +111,10 @@ export class Signal<T = any> {
 			// Any leftover dependencies here are not needed anymore
 			if (shouldCleanup) {
 				// Unsubscribe from dependencies that were not accessed:
-				oldDeps.forEach(sub => unsubscribe(this, sub));
+				oldDeps.forEach(dep => unsubscribe(this, dep));
 			} else {
-				// Re-subscribe to dependencies that not accessed:
-				oldDeps.forEach(sub => subscribe(this, sub));
+				// Re-subscribe to dependencies that were not accessed:
+				oldDeps.forEach(dep => subscribe(this, dep));
 			}
 
 			oldDeps.clear();
@@ -198,7 +198,7 @@ const tmpPending: Signal[] = [];
  * Refresh _just_ this signal and its dependencies recursively.
  * All other signals will be left untouched and added to the
  * global queue to flush later. Since we're traversing "upwards",
- * we don't have to car about topological sorting.
+ * we don't have to care about topological sorting.
  */
 function refreshStale(signal: Signal) {
 	pending.delete(signal);

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -361,7 +361,7 @@ describe("computed()", () => {
 
 			// top to bottom
 			expect(eSpy).to.have.been.calledBefore(fSpy);
-			// right to left
+			// left to right
 			expect(fSpy).to.have.been.calledBefore(gSpy);
 		});
 
@@ -650,7 +650,7 @@ describe("batch/transaction", () => {
 		const spyD = sinon.spy(() => c.value);
 		const d = computed(spyD);
 
-		const spyE = sinon.spy(() => b.value);
+		const spyE = sinon.spy(() => d.value);
 		const e = computed(spyE);
 
 		spyC.resetHistory();


### PR DESCRIPTION
Just some suggestions I noticed while reading over the code. Mostly typo fixes in comments, but I also thought using the parameter name dep instead of sub in those arrow functions made more sense, and then I noticed that in one of the tests, the code didn't seem to align with the comment at the top of the test, it looks like that eSpy function should be reading d.value.

Thanks for building this library. I'm looking forward to trying it out some more.

Note: This PR is a redo of https://github.com/preactjs/signals/pull/123