### PR TITLE
fix(react): track owners separately, mutate updaters with dispatcher

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -126,6 +126,7 @@ Object.defineProperty(internals.ReactCurrentDispatcher, "current", {
 			if (!updater || !lastDispatcher !== api) {
 				updater = createUpdater(rerender);
 				updaterForComponent.set(lastOwner, updater);
+				lastDispatcher = api;
 			}
 			setCurrentUpdater(updater);
 		} else {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -91,8 +91,8 @@ Object.defineProperties(Signal.prototype, {
 });
 
 // Track the current owner (roughly equiv to current vnode)
-let lastOwner: ReactOwner;
-let currentOwner: ReactOwner;
+let lastOwner: ReactOwner | undefined;
+let currentOwner: ReactOwner | null = null;
 Object.defineProperty(internals.ReactCurrentOwner, "current", {
 	get() {
 		return currentOwner;
@@ -106,7 +106,7 @@ Object.defineProperty(internals.ReactCurrentOwner, "current", {
 // Track the current dispatcher (roughly equiv to current component impl)
 let lock = false;
 const UPDATE = () => ({});
-let lastDispatcher: ReactDispatcher;
+let lastDispatcher: ReactDispatcher | undefined;
 let currentDispatcher: ReactDispatcher;
 Object.defineProperty(internals.ReactCurrentDispatcher, "current", {
 	get() {
@@ -123,7 +123,7 @@ Object.defineProperty(internals.ReactCurrentDispatcher, "current", {
 			lock = false;
 
 			let updater = updaterForComponent.get(lastOwner);
-			if (!updater || !lastDispatcher !== api) {
+			if (!updater || lastDispatcher !== api) {
 				updater = createUpdater(rerender);
 				updaterForComponent.set(lastOwner, updater);
 				lastDispatcher = api;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -120,15 +120,15 @@ Object.defineProperty(internals.ReactCurrentDispatcher, "current", {
 		return currentDispatcher;
 	},
 	set(api) {
-		let updaterForComponent = dispatcherQueue.get(api);
-		if (!updaterForComponent) {
-			updaterForComponent = new WeakMap<ReactOwner, Updater>();
-			dispatcherQueue.set(api, updaterForComponent);
-		}
-
 		currentDispatcher = api;
 		if (lock) return;
 		if (api && !isInvalidHookAccessor(api)) {
+			let updaterForComponent = dispatcherQueue.get(api);
+			if (!updaterForComponent) {
+				updaterForComponent = new WeakMap<ReactOwner, Updater>();
+				dispatcherQueue.set(api, updaterForComponent);
+			}
+
 			// prevent re-injecting useReducer when the Dispatcher
 			// context changes to run the reducer callback:
 			lock = true;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -54,6 +54,7 @@ function createPropUpdater(props: any, prop: string, signal: Signal) {
 */
 
 let finishUpdate: ReturnType<Updater["_setCurrent"]> | undefined;
+const updaterForComponent = new WeakMap<ReactOwner, Updater>();
 
 function setCurrentUpdater(updater?: Updater) {
 	// end tracking for the current update:
@@ -101,9 +102,6 @@ Object.defineProperty(internals.ReactCurrentOwner, "current", {
 		if (currentOwner) lastComponent = currentOwner;
 	},
 });
-
-// Tracks component updaters per dispatcher
-const updaterForComponent = new WeakMap<ReactOwner, Updater>();
 
 // Track the current dispatcher (roughly equiv to current component impl)
 let lock = false;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -106,7 +106,6 @@ Object.defineProperty(internals.ReactCurrentOwner, "current", {
 // Track the current dispatcher (roughly equiv to current component impl)
 let lock = false;
 const UPDATE = () => ({});
-let lastDispatcher: ReactDispatcher | undefined;
 let currentDispatcher: ReactDispatcher;
 Object.defineProperty(internals.ReactCurrentDispatcher, "current", {
 	get() {
@@ -123,10 +122,11 @@ Object.defineProperty(internals.ReactCurrentDispatcher, "current", {
 			lock = false;
 
 			let updater = updaterForComponent.get(lastOwner);
-			if (!updater || lastDispatcher !== api) {
+			if (!updater) {
 				updater = createUpdater(rerender);
 				updaterForComponent.set(lastOwner, updater);
-				lastDispatcher = api;
+			} else {
+				updater._updater = rerender;
 			}
 			setCurrentUpdater(updater);
 		} else {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -91,7 +91,7 @@ Object.defineProperties(Signal.prototype, {
 });
 
 // Track the current owner (roughly equiv to current vnode)
-let lastComponent: ReactOwner;
+let lastOwner: ReactOwner;
 let currentOwner: ReactOwner;
 Object.defineProperty(internals.ReactCurrentOwner, "current", {
 	get() {
@@ -99,7 +99,7 @@ Object.defineProperty(internals.ReactCurrentOwner, "current", {
 	},
 	set(owner) {
 		currentOwner = owner;
-		if (currentOwner) lastComponent = currentOwner;
+		if (currentOwner) lastOwner = currentOwner;
 	},
 });
 
@@ -115,17 +115,17 @@ Object.defineProperty(internals.ReactCurrentDispatcher, "current", {
 	set(api) {
 		currentDispatcher = api;
 		if (lock) return;
-		if (lastComponent && api && !isInvalidHookAccessor(api)) {
+		if (lastOwner && api && !isInvalidHookAccessor(api)) {
 			// prevent re-injecting useReducer when the Dispatcher
 			// context changes to run the reducer callback:
 			lock = true;
 			const rerender = api.useReducer(UPDATE, {})[1];
 			lock = false;
 
-			let updater = updaterForComponent.get(lastComponent);
+			let updater = updaterForComponent.get(lastOwner);
 			if (!updater || !lastDispatcher !== api) {
 				updater = createUpdater(rerender);
-				updaterForComponent.set(lastComponent, updater);
+				updaterForComponent.set(lastOwner, updater);
 			}
 			setCurrentUpdater(updater);
 		} else {

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -2,7 +2,7 @@
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 import { signal, useComputed } from "@preact/signals-react";
-import { createElement, useMemo } from "react";
+import { createElement, useMemo, memo, StrictMode } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 
@@ -157,6 +157,27 @@ describe("@preact/signals-react", () => {
 				sig.value = "bar";
 			});
 			expect(scratch.textContent).to.equal("bar");
+		});
+
+		it("should consistently rerender in strict mode", async () => {
+			const sig = signal<string>(null!);
+
+			const Test = memo(() => <p>{sig.value}</p>);
+			const App = () => (
+				<StrictMode>
+					<Test />
+				</StrictMode>
+			);
+
+			for (let i = 0; i < 3; i++) {
+				const value = `${i}`;
+
+				act(() => {
+					sig.value = value;
+					render(<App />);
+				});
+				expect(scratch.textContent).to.equal(value);
+			}
 		});
 	});
 });


### PR DESCRIPTION
Fixes #125
Fixes #135
Fixes #70

This PR tracks `ReactCurrentOwner` separately from `ReactCurrentDispatcher` since the former is not guaranteed to be populated when `ReactCurrentDispatcher` is mutated. This is very evident from #125, and you can verify by running against a production build of React. Annoyingly, this behavior is different than that of a development build of React.

Additionally, signals' updaters are mutated on subsequent runs since there are multiple dispatchers during the lifecycle of a component, and holding on to a stale dispatcher can break the re-rendering mechanism (it wouldn't do anything).

> **Note**: The relevant dispatcher states are [invalid](https://github.com/facebook/react/blob/c156ecd483b4adc8e16254b8cab3ee735e893271/packages/react-reconciler/src/ReactFiberHooks.old.js#L2434), [mount](https://github.com/facebook/react/blob/c156ecd483b4adc8e16254b8cab3ee735e893271/packages/react-reconciler/src/ReactFiberHooks.old.js#L2468), [update](https://github.com/facebook/react/blob/c156ecd483b4adc8e16254b8cab3ee735e893271/packages/react-reconciler/src/ReactFiberHooks.old.js#L2501), [re-render](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberHooks.old.js#L2535) -- invalid and re-render are skipped by `isInvalidHookAccessor` and `lock`, respectively. These are unique per reconciler, so #115 would have two pairs of mount and update dispatchers.

The changes in this PR originally came from tweaking with v1 JS output, which you can find [in this gist](https://gist.github.com/CodyJasonBennett/3fb8c092db76da4761e53908752340b1). This is runnable if you want to copy/paste it into a Codesandbox, although ensure you're using the old JSX transform (`React.createElement`) if possible for the moment.