### PR TITLE
Make activation and signal updates one and the same

### DIFF
--- a/.changeset/moody-vans-exercise.md
+++ b/.changeset/moody-vans-exercise.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals-core": patch
+"@preact/signals": patch
+---
+
+Fix conditional computed not updated by switching to a simpler and more reliable invalidation algorithm.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,10 +3,11 @@ let currentSignal: Signal | undefined;
 let commitError: Error | null = null;
 
 const pending = new Set<Signal>();
+const effects = new Set<Signal>();
 /** Batch calls can be nested. 0 means that there is no batching */
 let batchPending = 0;
 
-let oldDeps = new Set<Signal>();
+let oldDeps = new Map<Signal, number>();
 
 export class Signal<T = any> {
 	// These property names get minified - see /mangle.json
@@ -14,15 +15,15 @@ export class Signal<T = any> {
 	/** @internal Internal, do not use. */
 	_subs = new Set<Signal>();
 	/** @internal Internal, do not use. */
-	_deps = new Set<Signal>();
+	_deps = new Map<Signal, number>();
 	/** @internal Internal, do not use. */
-	_pending = 0;
+	_version = 0;
+	/** @internal Internal, do not use. */
+	_dirty = false;
 	/** @internal Internal, do not use. */
 	_value: T;
 	/** @internal Determine if a computed is allowed to write or not */
 	_readonly = false;
-	/** @internal Marks the signal as requiring an update */
-	_requiresUpdate = false;
 	/** @internal Determine if reads should eagerly activate value */
 	_active = false;
 	/** @internal Used to detect if there is a cycle in the graph */
@@ -45,6 +46,9 @@ export class Signal<T = any> {
 
 	get value() {
 		if (!this._active) {
+			if (!currentSignal) {
+				effects.add(this);
+			}
 			activate(this);
 		}
 
@@ -58,7 +62,7 @@ export class Signal<T = any> {
 		// subscribe the current computed to this signal:
 		this._subs.add(currentSignal);
 		// update the current computed's dependencies:
-		currentSignal._deps.add(this);
+		currentSignal._deps.set(this, this._version);
 		oldDeps.delete(this);
 
 		return this._value;
@@ -70,18 +74,21 @@ export class Signal<T = any> {
 		}
 
 		if (this._value !== value) {
+			this._version++;
 			this._value = value;
 			let isFirst = pending.size === 0;
+
 			pending.add(this);
 			// in batch mode this signal may be marked already
-			if (this._pending === 0) {
+			if (!this._dirty) {
 				mark(this);
 			}
 
 			// this is the first change, not a computed and we are not
 			// in batch mode:
 			if (isFirst && batchPending === 0) {
-				sweep(pending);
+				effects.forEach(signal => activate(signal));
+				pending.forEach(signal => (signal._dirty = false));
 				pending.clear();
 				if (commitError) {
 					const err = commitError;
@@ -103,18 +110,16 @@ export class Signal<T = any> {
 		let prevOldDeps = oldDeps;
 		currentSignal = this;
 		oldDeps = this._deps;
-		this._deps = new Set();
+		this._deps = new Map();
 
 		return (shouldUnmark: boolean, shouldCleanup: boolean) => {
-			if (shouldUnmark) this._subs.forEach(unmark);
-
 			// Any leftover dependencies here are not needed anymore
 			if (shouldCleanup) {
 				// Unsubscribe from dependencies that were not accessed:
-				oldDeps.forEach(dep => unsubscribe(this, dep));
+				oldDeps.forEach((_, dep) => unsubscribe(this, dep));
 			} else {
 				// Re-subscribe to dependencies that were not accessed:
-				oldDeps.forEach(dep => subscribe(this, dep));
+				oldDeps.forEach((_, dep) => subscribe(this, dep));
 			}
 
 			oldDeps.clear();
@@ -133,22 +138,13 @@ export class Signal<T = any> {
 }
 
 function mark(signal: Signal) {
-	if (signal._pending++ === 0) {
-		signal._subs.forEach(mark);
-	}
-}
-
-function unmark(signal: Signal<any>) {
-	// We can only unmark this node as not needing an update if it
-	// wasn't flagged as needing an update by someone else. This is
-	// done to make the sweeping logic independent of the order
-	// in which a dependency tries to unmark a subtree.
-	if (
-		!signal._requiresUpdate &&
-		signal._pending > 0 &&
-		--signal._pending === 0
-	) {
-		signal._subs.forEach(unmark);
+	if (!signal._dirty) {
+		signal._dirty = true;
+		if (signal._subs.size === 0) {
+			effects.add(signal);
+		} else {
+			signal._subs.forEach(mark);
+		}
 	}
 }
 
@@ -156,27 +152,24 @@ function sweep(subs: Set<Signal<any>>) {
 	subs.forEach(signal => {
 		// If a computed errored during sweep, we'll discard that subtree
 		// for this sweep cycle by setting PENDING to 0;
-		if (signal._pending > 0) {
-			signal._requiresUpdate = true;
+		if (signal._dirty) {
+			signal._dirty = false;
 
-			if (--signal._pending === 0) {
-				if (signal._isComputing) {
-					throw Error("Cycle detected");
-				}
+			// if (signal._isComputing) {
+			// throw Error("Cycle detected");
+			// }
 
-				signal._requiresUpdate = false;
-				signal._isComputing = true;
-				signal._updater();
-				signal._isComputing = false;
-				sweep(signal._subs);
-			}
+			// signal._isComputing = true;
+			signal._updater();
+			// signal._isComputing = false;
+			sweep(signal._subs);
 		}
 	});
 }
 
 function subscribe(signal: Signal<any>, to: Signal<any>) {
 	signal._active = true;
-	signal._deps.add(to);
+	signal._deps.set(to, to._version);
 	to._subs.add(signal);
 }
 
@@ -189,11 +182,10 @@ function unsubscribe(signal: Signal<any>, from: Signal<any>) {
 	// signal or a signal that others listen to as well.
 	if (from._subs.size === 0) {
 		from._active = false;
-		from._deps.forEach(dep => unsubscribe(from, dep));
+		from._deps.forEach((_, dep) => unsubscribe(from, dep));
 	}
 }
 
-const tmpPending: Signal[] = [];
 /**
  * Refresh _just_ this signal and its dependencies recursively.
  * All other signals will be left untouched and added to the
@@ -201,25 +193,39 @@ const tmpPending: Signal[] = [];
  * we don't have to care about topological sorting.
  */
 function refreshStale(signal: Signal) {
-	pending.delete(signal);
-	signal._pending = 0;
-	signal._updater();
-	if (commitError) {
-		const err = commitError;
-		commitError = null;
-		throw err;
+	const first = signal._deps.size === 0;
+
+	let shouldUpdate = false;
+	if (signal._dirty) {
+		signal._deps.forEach((version, dep) => {
+			if (dep._dirty) {
+				refreshStale(dep);
+			}
+
+			if (dep._version !== version) {
+				shouldUpdate = true;
+				signal._deps.set(dep, dep._version);
+			}
+		});
 	}
 
-	signal._subs.forEach(sub => {
-		if (sub._pending > 0) {
-			// If PENDING > 1 then we can safely reduce the counter because
-			// the final sweep will take care of the rest. But if it's
-			// exactly 1 we can't do that otherwise the sweeping logic
-			// assumes that this signal was already updated.
-			if (sub._pending > 1) sub._pending--;
-			tmpPending.push(sub);
+	effects.delete(signal);
+	signal._dirty = false;
+
+	if (first || shouldUpdate) {
+		try {
+			signal._updater();
+		} catch (err) {
+			console.log("caught", err);
+			signal._version--;
+			throw err;
 		}
-	});
+		if (commitError) {
+			const err = commitError;
+			commitError = null;
+			throw err;
+		}
+	}
 }
 
 function activate(signal: Signal) {
@@ -242,13 +248,22 @@ export function computed<T>(compute: () => T): ReadonlySignal<T> {
 		let finish = signal._setCurrent();
 
 		try {
+			if (signal._isComputing) {
+				throw new Error("Cycle detected");
+			}
+
+			signal._isComputing = true;
 			let ret = compute();
 
-			finish(signal._value === ret, true);
+			const stale = signal._value === ret;
+			if (!stale) signal._version++;
+			finish(stale, true);
 			signal._value = ret;
 		} catch (err: any) {
 			// Ensure that we log the first error not the last
 			if (!commitError) commitError = err;
+		} finally {
+			signal._isComputing = false;
 			finish(true, false);
 		}
 	}
@@ -270,16 +285,13 @@ export function batch<T>(cb: () => T): T {
 	try {
 		return cb();
 	} finally {
-		// Since stale signals are refreshed upwards, we need to
-		// add pending signals in reverse
-		let item: Signal | undefined;
-		while ((item = tmpPending.pop()) !== undefined) {
-			pending.add(item);
-		}
-
 		if (--batchPending === 0) {
-			sweep(pending);
-			pending.clear();
+			try {
+				effects.forEach(signal => activate(signal));
+			} finally {
+				pending.forEach(signal => (signal._dirty = false));
+				pending.clear();
+			}
 		}
 	}
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,9 +45,6 @@ export class Signal<T = any> {
 
 	get value() {
 		if (!this._active) {
-			if (!currentSignal) {
-				effects.add(this);
-			}
 			activate(this);
 		}
 

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -585,6 +585,32 @@ describe("computed()", () => {
 			a.value = 0;
 			expect(c.value).to.equal(0);
 		});
+
+		it("should not update a sub if all deps unmark it", () => {
+			// In this scenario "B" and "C" always return the same value. When "A"
+			// changes, "D" should not update.
+			//     A
+			//   /   \
+			// *B     *C
+			//   \   /
+			//     D
+			const a = signal("a");
+			const b = computed(() => {
+				a.value;
+				return "b";
+			});
+			const c = computed(() => {
+				a.value;
+				return "c";
+			});
+			const spy = sinon.spy(() => b.value + " " + c.value);
+			const d = computed(spy);
+			expect(d.value).to.equal("b c");
+			spy.resetHistory();
+
+			a.value = "aa";
+			expect(spy).not.to.be.called;
+		});
 	});
 });
 

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -223,7 +223,7 @@ hook(OptionsTypes.UNMOUNT, (old, vnode: VNode) => {
 		updaterForComponent.delete(thing);
 		const signals = updater._deps;
 		if (signals) {
-			signals.forEach(signal => signal._subs.delete(updater));
+			signals.forEach((_, signal) => signal._subs.delete(updater));
 			signals.clear();
 		}
 	}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -128,7 +128,7 @@ function Text(this: ComponentType, { data }: { data: Signal }) {
 
 		// Replace this component's vdom updater with a direct text one:
 		currentUpdater!._updater = () => {
-			(this.base as Text).data = s._value;
+			(this.base as Text).data = currentSignal.value.value;
 		};
 
 		return computed(() => {


### PR DESCRIPTION
This replaces the existing invalidation algorithm with a much simpler one that always recurses upwards from bottom to top. It avoids a bunch of ordering issues that we were running into with the previous algorithm and it's shorter too.

Also kudos to @jviide for sending me various gists that made it click for me!

Fixes #124 .