### PR TITLE
[demo] Fix entry bundle names

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           pattern: '{packages/*/dist/!(*.module|*.min).{js,mjs},docs/dist/**/*.{js,css}}'
           build-script: 'ci:build'
-          strip-hash: "\\.(\\w{8})\\.(?:js|css)$"
+          strip-hash: "[.-](\\w{8,9})\\.(?:js|css)$"
 

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -29,6 +29,20 @@ export default defineConfig(env => ({
 	],
 	build: {
 		polyfillModulePreload: false,
+		cssCodeSplit: false,
+		rollupOptions: {
+			output: {
+				entryFileNames(chunk) {
+					let name = chunk.name;
+					if (chunk.facadeModuleId) {
+						const p = posix.normalize(chunk.facadeModuleId);
+						const m = p.match(/([^/]+)(?:\/index)?\.[^/]+$/);
+						if (m) name = m[1];
+					}
+					return `${name}-[hash].js`;
+				},
+			},
+		},
 	},
 	resolve: {
 		extensions: [".ts", ".tsx", ".js", ".jsx", ".d.ts"],

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, Plugin, Connect } from "vite";
 import preact from "@preact/preset-vite";
-import { resolve } from "path";
+import { resolve, posix } from "path";
 import fs from "fs";
 
 // Automatically set up aliases for monorepo packages.


### PR DESCRIPTION
This changes the names of the `import()` bundles from `index.[hash].js` to `{basic,react,nesting}.[hash].js`, where the first part of the name is the directory (in the case of an import for an `index.*` file.

This should fix the randomization issue with our CI size action.