### PR TITLE
Implement core without Sets, Maps, Arrays etc.

### DIFF
--- a/packages/core/src/bench.ts
+++ b/packages/core/src/bench.ts
@@ -1,0 +1,19 @@
+import * as core from "./index";
+
+{
+  const count = core.signal(0);
+  const double = core.computed(() => count.value * 2);
+
+  core.effect(() => double.value + count.value);
+  core.effect(() => double.value + count.value);
+  core.effect(() => double.value + count.value);
+
+  console.time("core");
+
+  for (let i = 0; i < 20000000; i++) {
+    count.value++;
+    double.value;
+  }
+
+  console.timeEnd("core");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,6 +146,10 @@ export class Signal<T = any> {
 		}
 	}
 
+	subscribe(fn: (value: T) => void): () => void {
+		return effect(() => fn(this.value));
+	}
+
 	toString(): string {
 		return "" + this.value;
 	}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,7 +232,7 @@ function returnComputed<T>(computed: Computed<T>): T {
 }
 
 export class Computed<T = any> extends Signal<T> {
-	_compute?: () => T;
+	_compute: () => T;
 	_sources?: Node = undefined;
 	_computing = false;
 	_valid = false;
@@ -310,7 +310,7 @@ export class Computed<T = any> extends Signal<T> {
 			this._computing = true;
 			this._sources = undefined;
 
-			value = this._compute!();
+			value = this._compute();
 		} catch (err: unknown) {
 			valueIsError = true;
 			value = err;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -359,6 +359,9 @@ export class Computed<T = any> extends Signal<T> {
 	}
 
 	get value(): T {
+		if (this._computing) {
+			throw new Error("Cycle detected");
+		}
 		return getValue(this);
 	}
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,7 +47,7 @@ function endBatch() {
 			effect._nextEffect = undefined;
 			effect._batched = false;
 			try {
-				effect._notify();
+				effect._callback();
 			} catch (err) {
 				if (!hasError) {
 					error = err;
@@ -398,13 +398,13 @@ function endEffect(this: Effect, prevContext?: Computed | Effect) {
 }
 
 class Effect {
-	_notify: () => void;
+	_callback: () => void;
 	_sources?: Node = undefined;
 	_batched = false;
 	_nextEffect?: Effect = undefined;
 
-	constructor(notify: () => void) {
-		this._notify = notify;
+	constructor(callback: () => void) {
+		this._callback = callback;
 	}
 
 	_start() {
@@ -443,7 +443,7 @@ export function effect(callback: () => void): () => void {
 			finish();
 		}
 	});
-	effect._notify();
+	effect._callback();
 	// Return a bound function instead of a wrapper like `() => effect._dispose()`,
 	// because bound functions seem to be just as fast and take up a lot less memory.
 	return effect._dispose.bind(effect);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -245,7 +245,7 @@ export class Computed<T = any> extends Signal<T> {
 
 	peek(): T {
 		if (this._computing) {
-			throw new Error("cycle detected");
+			throw new Error("Cycle detected");
 		}
 		if (this._globalVersion === globalVersion) {
 			return returnComputed(this);
@@ -306,6 +306,10 @@ export class Computed<T = any> extends Signal<T> {
 
 	get value(): T {
 		return getValue(this);
+	}
+
+	set value(value: T) {
+		throw Error("Computed signals are readonly");
 	}
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -229,11 +229,9 @@ export class Computed<T = any> extends Signal<T> {
 	}
 
 	_invalidate() {
-		if (this._valid) {
-			this._valid = false;
-			for (let node = this._targets; node; node = node.nextTarget) {
-				node.target._invalidate();
-			}
+		this._valid = false;
+		for (let node = this._targets; node; node = node.nextTarget) {
+			node.target._invalidate();
 		}
 	}
 
@@ -369,6 +367,6 @@ export function _doNotUseOrYouWillBeFired_notify<S extends Signal>(
 	const node = { signal: signal as Signal, target: notify, version: 0 };
 	notify._run = cb;
 	notify._sources = node;
-	(signal as Signal)._subscribe(node);
+	signal._subscribe(node);
 	return notify._dispose.bind(notify);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-function cycleDetected() {
+function cycleDetected(): never {
 	throw new Error("Cycle detected");
 }
 
@@ -433,19 +433,12 @@ export class Computed<T = any> extends Signal<T> {
 		}
 		return getValue(this);
 	}
-
-	set value(value: T) {
-		throw Error("Computed signals are readonly");
-	}
 }
 
-export interface ReadonlySignal<T = any> extends Signal<T> {
-	readonly value: T;
-}
-
-export function computed<T>(compute: () => T): ReadonlySignal<T> {
+export function computed<T>(compute: () => T): Computed<T> {
 	return new Computed(compute);
 }
+export type { Computed as ReadonlySignal };
 
 function endEffect(this: Effect, prevContext?: Computed | Effect) {
 	cleanupSources(this);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -319,6 +319,7 @@ class Effect {
 	}
 
 	_start() {
+		/*@__INLINE__**/ startBatch();
 		const oldSources = this._sources;
 		const prevContext = evalContext;
 		const prevRollback = currentRollback;
@@ -336,6 +337,7 @@ class Effect {
 
 		evalContext = prevContext;
 		currentRollback = prevRollback;
+		endBatch();
 	}
 
 	_invalidate() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -309,7 +309,7 @@ function returnComputed<T>(computed: Computed<T>): T {
 	return computed._value as T;
 }
 
-export class Computed<T = any> extends Signal<T> {
+class Computed<T = any> extends Signal<T> {
 	_compute: () => T;
 	_sources?: Node = undefined;
 	_globalVersion = globalVersion - 1;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,9 +310,16 @@ function returnComputed<T>(computed: Computed<T>): T {
 }
 
 class Computed<T = any> extends Signal<T> {
+	/** @internal */
 	_compute: () => T;
+
+	/** @internal */
 	_sources?: Node = undefined;
+
+	/** @internal */
 	_globalVersion = globalVersion - 1;
+
+	/** @internal */
 	_flags = STALE;
 
 	constructor(compute: () => T) {
@@ -320,6 +327,7 @@ class Computed<T = any> extends Signal<T> {
 		this._compute = compute;
 	}
 
+	/** @internal */
 	_subscribe(node: Node) {
 		if (this._targets === undefined) {
 			this._flags |= STALE | SHOULD_SUBSCRIBE;
@@ -333,6 +341,7 @@ class Computed<T = any> extends Signal<T> {
 		super._subscribe(node);
 	}
 
+	/** @internal */
 	_unsubscribe(node: Node) {
 		super._unsubscribe(node)
 
@@ -346,6 +355,7 @@ class Computed<T = any> extends Signal<T> {
 		}
 	}
 
+	/** @internal */
 	_notify() {
 		if (!(this._flags & NOTIFIED)) {
 			this._flags |= STALE | NOTIFIED;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,7 +57,7 @@ function endBatch() {
 		for (let item = batch; item; item = item.next) {
 			const runnable = item.effect;
 			runnable._batched = false;
-			runnable._run()
+			runnable._run();
 		}
 	}
 }
@@ -89,7 +89,11 @@ function getValue<T>(signal: Signal<T>): T {
 	let node: Node | undefined = undefined;
 	if (evalContext !== undefined && signal._evalContext !== evalContext) {
 		node = { signal: signal, target: evalContext, version: 0 };
-		currentRollback = { signal: signal, evalContext: signal._evalContext, next: currentRollback };
+		currentRollback = {
+			signal: signal,
+			evalContext: signal._evalContext,
+			next: currentRollback,
+		};
 		signal._evalContext = evalContext;
 	}
 	const value = signal.peek();
@@ -190,9 +194,9 @@ function returnComputed<T>(computed: Computed<T>): T {
 	return computed._value as T;
 }
 
-export class Computed<T = any> extends Signal<T>{
+export class Computed<T = any> extends Signal<T> {
 	_compute?: () => T;
-	_sources?: Node = undefined;;
+	_sources?: Node = undefined;
 	_computing = false;
 	_valid = false;
 	_valueIsError = false;
@@ -352,12 +356,15 @@ export function effect(callback: () => void): () => void {
 	return effect._dispose.bind(effect);
 }
 
-export function _doNotUseOrYouWillBeFired_notify<S extends Signal | ReadonlySignal>(signal: S, callback: (signal: S) => void): () => void {
+export function _doNotUseOrYouWillBeFired_notify<S extends Signal>(
+	signal: S,
+	callback: (signal: S) => void
+): () => void {
 	const cb = () => callback(signal);
 	const notify = new Effect(cb);
-	const node = { signal: signal as Signal, target: notify, version: 0 };
+	const node = { signal: signal, target: notify, version: 0 };
 	notify._run = cb;
 	notify._sources = node;
-	(signal as Signal)._subscribe(node);
+	signal._subscribe(node);
 	return notify._dispose.bind(notify);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -304,7 +304,12 @@ export class Computed<T = any> extends Signal<T> {
 		if (this._version > 0) {
 			let node = this._sources;
 			while (node !== undefined) {
-				node.signal.peek();
+				try {
+					node.signal.peek();
+				} catch {
+					// Failures of previous dependencies shouldn't be rethrown here
+					// in case they're not dependencies anymore.
+				}
 				if (node.signal._version !== node.version) {
 					break;
 				}
@@ -345,7 +350,7 @@ export class Computed<T = any> extends Signal<T> {
 			evalContext = prevContext;
 		}
 
-		if (valueIsError || this._valueIsError || this._value !== value) {
+		if (valueIsError || this._valueIsError || this._value !== value || this._version === 0) {
 			this._value = value;
 			this._valueIsError = valueIsError;
 			this._version++;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -135,10 +135,10 @@ function getValue<T>(signal: Signal<T>): T {
 			if (node !== head) {
 				const prev = node._prevSource;
 				const next = node._nextSource;
-				if (prev) {
+				if (prev !== undefined) {
 					prev._nextSource = next;
 				}
-				if (next) {
+				if (next !== undefined) {
 					next._prevSource = prev;
 				}
 				if (head !== undefined) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -500,6 +500,9 @@ class Effect {
 	}
 
 	_dispose() {
+		if (this._flags & RUNNING) {
+			throw new Error("Effect still running");
+		}
 		for (let node = this._sources; node !== undefined; node = node._nextSource) {
 			node._source._unsubscribe(node);
 		}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -449,6 +449,10 @@ export function computed<T>(compute: () => T): Computed<T> {
 export type { Computed as ReadonlySignal };
 
 function endEffect(this: Effect, prevContext?: Computed | Effect) {
+	if (evalContext !== this) {
+		throw new Error("Out-of-order effect");
+	}
+
 	cleanupSources(this);
 
 	evalContext = prevContext;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -292,7 +292,7 @@ export class Computed<T = any> extends Signal<T> {
 
 	peek(): T {
 		if (this._computing) {
-			throw new Error("cycle detected");
+			throw new Error("Cycle detected");
 		}
 		if (this._globalVersion === globalVersion) {
 			return returnComputed(this);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -342,6 +342,9 @@ class Effect {
 export function effect(callback: () => void): () => void {
 	const effect = new Effect(callback);
 	effect._run();
+
+	// Return a bound function instead of a wrapper like `() => effect._dispose()`,
+	// because bound functions seem to be just as fast and take up a lot less memory.
 	return effect._dispose.bind(effect);
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,9 +59,10 @@ function endBatch() {
 
 		while (effect !== undefined) {
 			const next: Effect | undefined = effect._nextEffect;
+			effect._nextEffect = undefined;
+			effect._flags &= ~NOTIFIED;
+
 			if (!(effect._flags & DISPOSED)) {
-				effect._nextEffect = undefined;
-				effect._flags &= ~NOTIFIED;
 				try {
 					effect._callback();
 				} catch (err) {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -161,6 +161,24 @@ describe("effect()", () => {
 		expect(fn).to.throw(/Cycle detected/);
 	});
 
+	it("should allow disposing the effect multiple times", () => {
+		const dispose = effect(() => undefined);
+		dispose();
+		expect(() => dispose()).to.throw;
+	});
+
+	it("should throw when disposing a running effect", () => {
+		const a = signal(0);
+		const dispose = effect(() => {
+			if (a.value === 1) {
+				dispose();
+			}
+		});
+		expect(() => {
+			a.value = 1;
+		}).to.throw("Effect still running");
+	});
+
 	it("should not run if it's first been triggered and then disposed in a batch", () => {
 		const a = signal(0);
 		const spy = sinon.spy(() => a.value);

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -210,6 +210,19 @@ describe("computed()", () => {
 		expect(spy).to.be.calledOnce;
 	});
 
+	it("should detect simple dependency cycles", () => {
+		const a: Signal = computed(() => a.value);
+		expect(() => a.value).to.throw(/Cycle detected/);
+	});
+
+	it("should detect deep dependency cycles", () => {
+		const a: Signal = computed(() => b.value);
+		const b: Signal = computed(() => c.value);
+		const c: Signal = computed(() => d.value);
+		const d: Signal = computed(() => a.value);
+		expect(() => a.value).to.throw(/Cycle detected/);
+	});
+
 	it("should conditionally unsubscribe from signals", () => {
 		const a = signal("a");
 		const b = signal("b");

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -226,6 +226,8 @@ describe("computed()", () => {
 			compute.resetHistory();
 
 			a.value = "aa";
+			b.value = "bb";
+			c.value;
 			expect(compute).to.have.been.calledOnce;
 		});
 
@@ -251,7 +253,7 @@ describe("computed()", () => {
 			compute.resetHistory();
 
 			a.value = 4;
-
+			e.value;
 			expect(compute).to.have.been.calledOnce;
 		});
 
@@ -467,6 +469,7 @@ describe("computed()", () => {
 			spy.resetHistory();
 
 			a.value = "aa";
+			d.value;
 			expect(spy).to.returned("aa c");
 		});
 
@@ -495,6 +498,7 @@ describe("computed()", () => {
 			spy.resetHistory();
 
 			a.value = "aa";
+			e.value;
 			expect(spy).to.returned("aa c d");
 		});
 

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -501,21 +501,6 @@ describe("computed()", () => {
 			e.value;
 			expect(spy).to.returned("aa c d");
 		});
-
-		it("should prevent invalid unmark state when called on a source signal", () => {
-			// Don't allow our internal logic to get in an invalid state, even through
-			// our own internal API. The bug this tests for is that a source signal
-			// will be unmarked, leading to all its subscribers `_pending` value to become
-			// negative. This is invalid and breaks further updates.
-			const a = signal("a");
-			const b = computed(() => a.value);
-			effect(() => b.value);
-
-			a._setCurrent()(true, true);
-
-			a.value = "aa";
-			expect(b.value).to.equal("aa");
-		});
 	});
 
 	describe("error handling", () => {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -160,6 +160,34 @@ describe("effect()", () => {
 
 		expect(fn).to.throw(/Cycle detected/);
 	});
+
+	it("should not run if it's first been triggered and then disposed in a batch", () => {
+		const a = signal(0);
+		const spy = sinon.spy(() => a.value);
+		const dispose = effect(spy);
+		spy.resetHistory();
+
+		batch(() => {
+			a.value = 1;
+			dispose();
+		});
+
+		expect(spy).not.to.be.called;
+	});
+
+	it("should not run if it's been triggered, disposed and then triggered again in a batch", () => {
+		const a = signal(0);
+		const spy = sinon.spy(() => a.value);
+		const dispose = effect(spy);
+		spy.resetHistory();
+
+		batch(() => {
+			a.value = 2;
+			dispose();
+		});
+
+		expect(spy).not.to.be.called;
+	});
 });
 
 describe("computed()", () => {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -151,7 +151,7 @@ describe("effect()", () => {
 		const fn = () =>
 			effect(() => {
 				// Prevent test suite from spinning if limit is not hit
-				if (i++ > 10) {
+				if (i++ > 200) {
 					throw new Error("test failed");
 				}
 				a.value;

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -182,6 +182,34 @@ describe("computed()", () => {
 		expect(c.value).to.equal("aab");
 	});
 
+	it("should be lazily computed on demand", () => {
+		const a = signal("a");
+		const b = signal("b");
+		const spy = sinon.spy(() => a.value + b.value);
+		const c = computed(spy);
+		expect(spy).to.not.be.called;
+		c.value;
+		expect(spy).to.be.calledOnce;
+		a.value = "x";
+		b.value = "y";
+		expect(spy).to.be.calledOnce;
+		c.value;
+		expect(spy).to.be.calledTwice;
+	});
+
+	it("should computed only when dependency has changed at some point", () => {
+		const a = signal("a");
+		const spy = sinon.spy(() => {
+			return a.value;
+		});
+		const c = computed(spy);
+		c.value;
+		expect(spy).to.be.calledOnce;
+		a.value = "a";
+		c.value;
+		expect(spy).to.be.calledOnce;
+	});
+
 	it("should conditionally unsubscribe from signals", () => {
 		const a = signal("a");
 		const b = signal("b");

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -659,7 +659,7 @@ describe("computed()", () => {
 			const a = signal("a");
 			const b = computed(() => a.value);
 			const fn = () => ((b as Signal).value = "aa");
-			expect(fn).to.throw(/readonly/);
+			expect(fn).to.throw(/Cannot set property value/);
 		});
 
 		it("should keep graph consistent on errors during activation", () => {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -355,7 +355,6 @@ describe("effect()", () => {
 			done2();
 			expect(e._sources).to.be.undefined;
 
-
 			const done3 = e._start();
 			try {
 				s.value;
@@ -612,7 +611,7 @@ describe("computed()", () => {
 			compute.resetHistory();
 
 			a.value = 4;
-			e.value;
+			d.value;
 			expect(compute).to.have.been.calledOnce;
 		});
 

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -308,6 +308,24 @@ describe("computed()", () => {
 		expect(c.value).to.equal("ok");
 	});
 
+	it("should propagate invalidation even right after first subscription", () => {
+		const a = signal(0);
+		const b = computed(() => a.value);
+		const c = computed(() => b.value);
+		c.value;
+
+		const spy = sinon.spy(() => {
+			c.value;
+		});
+
+		effect(spy);
+		expect(spy).to.be.calledOnce;
+		spy.resetHistory();
+
+		a.value = 1;
+		expect(spy).to.be.calledOnce;
+	});
+
 	describe("graph updates", () => {
 		it("should run computeds once for multiple dep changes", async () => {
 			const a = signal("a");

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -210,6 +210,35 @@ describe("computed()", () => {
 		expect(spy).not.to.be.called;
 	});
 
+	it("should consider undefined value separate from uninitialized value", () => {
+		const a = signal(0);
+		const spy = sinon.spy(() => undefined);
+		const c = computed(spy);
+
+		expect(c.value).to.be.undefined;
+		a.value = 1;
+		expect(c.value).to.be.undefined;
+		expect(spy).to.be.calledOnce;
+	});
+
+	it("should not leak errors raised by dependencies", () => {
+		const a = signal(0);
+		const b = computed(() => {
+			a.value;
+			throw new Error("error");
+		});
+		const c = computed(() => {
+			try {
+				b.value;
+			} catch {
+				return "ok";
+			}
+		});
+		expect(c.value).to.equal("ok");
+		a.value = 1;
+		expect(c.value).to.equal("ok");
+	});
+
 	describe("graph updates", () => {
 		it("should run computeds once for multiple dep changes", async () => {
 			const a = signal("a");

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -236,7 +236,7 @@ describe("effect()", () => {
 			expect(newSpy).to.be.called;
 		});
 
-		it("_start returns a function for closing the effect scope", () => {
+		it("should returns a function for closing the effect scope from _start", () => {
 			const s = signal(0);
 
 			let e: any;
@@ -261,7 +261,7 @@ describe("effect()", () => {
 			expect(spy).not.to.be.called;
 		});
 
-		it("___", () => {
+		it("should throw on out-of-order start1-start2-end1 sequences", () => {
 			let e1: any;
 			effect(function (this: any) { e1 = this; });
 
@@ -334,6 +334,38 @@ describe("effect()", () => {
 			}
 			s.value = 2;
 			expect(spy).to.be.called;
+		});
+
+		it("should have property _sources that is undefined when and only when the effect has no sources", () => {
+			const s = signal(0);
+
+			let e: any;
+			effect(function (this: any) { e = this; });
+			expect(e._sources).to.be.undefined;
+
+			const done1 = e._start();
+			try {
+				s.value;
+			} finally {
+				done1();
+			}
+			expect(e._sources).not.to.be.undefined;
+
+			const done2 = e._start();
+			done2();
+			expect(e._sources).to.be.undefined;
+
+
+			const done3 = e._start();
+			try {
+				s.value;
+			} finally {
+				done3();
+			}
+			expect(e._sources).not.to.be.undefined;
+
+			e._dispose();
+			expect(e._sources).to.be.undefined;
 		});
 	});
 });

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -326,6 +326,41 @@ describe("computed()", () => {
 		expect(spy).to.be.calledOnce;
 	});
 
+	it("should not recompute dependencies out of order", () => {
+		const a = signal(1);
+		const b = signal(1);
+		const c = signal(1);
+
+		const spy = sinon.spy(() => c.value);
+		const d = computed(spy);
+
+		const e = computed(() => {
+			if (a.value > 0) {
+				b.value;
+				d.value;
+			} else {
+				b.value;
+			}
+		});
+
+		e.value;
+		spy.resetHistory()
+
+		a.value = 2;
+		b.value = 2;
+		c.value = 2;
+		e.value;
+		expect(spy).to.be.calledOnce;
+		spy.resetHistory()
+
+		a.value = -1;
+		b.value = -1;
+		c.value = -1;
+		e.value;
+		expect(spy).not.to.be.called;
+		spy.resetHistory()
+	});
+
 	describe("graph updates", () => {
 		it("should run computeds once for multiple dep changes", async () => {
 			const a = signal("a");


### PR DESCRIPTION
This pull request rewrites the core to avoid allocating Sets, Maps and Arrays on the fly. The implementation uses linked lists of nodes that contain both the source (signal) and target (computed/effect) of dependency-subscription pairs. The aim was to facilitate constant-time subscribe/unsubscribe operations without sets.

Currently this breaks the Preact/React integrations, as the core internals have changed quite a bit.

## Very lazily computed signals

Computed signals evaluate their values lazily whenever their `.value` is accessed or `.peek()` is called.

Computed signals also lazily subscribe to be notified when their dependencies change _only_ when the computed itself already has subscribers. This is done so that computed signals that aren't currently (direct or indirect) dependencies of some effects or other computed signals can be garbage collected when they go out of scope.

When value of a subscribeless computed signal is accessed the computed signal always checks whether its dependencies have changed. To speed this process up, signals also keep track of their own "version numbers" that change whenever their value changes.  Computed signals then store (in the linked list nodes) last version numbers they've seen from their dependencies, and use that info to estimate whether their computation function has to be re-evaluated.

> Note that the computed signals _could_ store the actual dependency values instead of version numbers. However I went with the version numbers, because a single dependency value can take an arbitrary amount of memory. As computed signals are lazily evaluated they could theoretically hang on to those already out-of-date dependency values indefinitely before the computed is evaluated again. 

When a computed has subscribers it gets notifications about changed dependencies as per usual, and the recomputation process can be short-circuited when the computed signal's `._valid` flag is `true`.

Every signal value change increments a global version number. Computed signals remember what the global version number was when their computed value was last validated. This info is then used to fast-track `.value`/`.peek()` calls when nothing has changed globally.

## Error handling

If a computed signal value function throws, the error is stored and subsequent `.value`/`.peek()` calls throw the same error without re-evaluating the compute function until one of the computed signal's dependency values changes.

If a computed value depends on itself (directly or indirectly) a "cycle detected" error is raised inside the compute function. To prevent runaway recursive effects, the top level batch handler tracks how many operation batches it has had to process consecutively. After 100 iterations all 'signal.value = ...` calls throw a "cycle detected" error.

When an effect in a batch handler throws an error it's percolated to the calling context that started the topmost batch handler. If multiple effects fail inside one batch handling loop then only the first error is percolated to the top.

## Notes about avoiding sets

The main use case for using Sets instead the original implementation was to avoid subscribing to the same dependency twice inside an effect or a computed signal's value function. Arrays can be used instead of Sets, but for then avoiding duplicate subscriptions requires checking the array for duplicates, which is an O(n) operation.

This PR tried to solve this with the linked lists, by making signals keep track of the last evaluation context in the stack that has accessed their value. Signals can then can quickly check whether they've already been inserted to the evaluation context's dependencies. This way the check is constant-time.

Signal's `._node` property keeps track of the last linked list node in the evaluation stack where the signal is the dependency. This way `_node.target` value can be used for the evaluation context check described above, but also for recycling nodes.

Those same linked list nodes are also used to remember `node.signal`'s `._node` values after entering a new evaluation context, and then for restoring the `._node` values when exiting from the evaluation context.

Batching is done with a linked list of effects that should be run in the next batch iteration. To avoid memory churn Effect instances themselves act as nodes in that linked list.

## Benchmark

This (extremely simplistic, should be run with d8 etc.) benchmark:

```ts
import * as core from "@preact/signals";
import * as setless from "./the-new-core";

{
  const count = core.signal(0);
  const double = core.computed(() => count.value * 2);

  console.time("core");

  for (let i = 0; i < 20000000; i++) {
    count.value++;
    double.value;
  }

  console.timeEnd("core");
}

{
  const count = setless.signal(0);
  const double = setless.computed(() => count.value * 2);

  console.time("setless");

  for (let i = 0; i < 20000000; i++) {
    count.value++;
    double.value;
  }

  console.timeEnd("setless");
}
```

I get on my machine:

```sh
$ npx ts-node benchmark.ts
core: 6.385s
setless: 458.465ms
```