### PR TITLE
Fix .subscribe's type

### DIFF
--- a/.changeset/quick-ladybugs-cry.md
+++ b/.changeset/quick-ladybugs-cry.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Fix `.subscribe`'s TypeScript type

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,7 +123,7 @@ export class Signal<T = any> {
 		};
 	}
 
-	subscribe(fn: (value: T) => () => void) {
+	subscribe(fn: (value: T) => void): () => void {
 		return effect(() => fn(this.value));
 	}
 


### PR DESCRIPTION
Currently `.subscribe()`'s type is marked as `subscribe(fn: (value: T) => () => void)` ("`.subscribe`takes a function that returns a function, `.subscribe` itself returns `void`").

This PR changes it to `subscribe(fn: (value: T) => void): () => void` ("`.subscribe` takes a function, and `.subscribe` itself returns a function").