### PR TITLE
Add release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
 		"docs:build": "cd docs && pnpm build",
 		"docs:preview": "cd docs && pnpm preview",
 		"ci:build": "pnpm build && pnpm docs:build",
-		"ci:test": "pnpm lint && pnpm test"
+		"ci:test": "pnpm lint && pnpm test",
+		"release": "pnpm changeset version && pnpm install && git add -A && git commit -m 'Version Packages' && changeset tag && pnpm publish -r",
+		"release2": "pnpm changeset version && pnpm install && git add -A && git commit -m 'Version Packages' && changeset tag "
 	},
 	"keywords": [],
 	"author": "",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
 		"docs:preview": "cd docs && pnpm preview",
 		"ci:build": "pnpm build && pnpm docs:build",
 		"ci:test": "pnpm lint && pnpm test",
-		"release": "pnpm changeset version && pnpm install && git add -A && git commit -m 'Version Packages' && changeset tag && pnpm publish -r",
-		"release2": "pnpm changeset version && pnpm install && git add -A && git commit -m 'Version Packages' && changeset tag "
+		"release": "pnpm changeset version && pnpm install && git add -A && git commit -m 'Version Packages' && changeset tag && pnpm publish -r"
 	},
 	"keywords": [],
 	"author": "",


### PR DESCRIPTION
This PR adds a release script to `package.json`. Reason being that with `pnpm` we cannot do just `pnpm changeset publish` because it stores the versions in the lockfile. That lockfile needs to be updated with every release and has led to a few annoyances in the past.