### PR TITLE
Add a basic devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-alpine
+RUN npm --global install pnpm
+RUN apk add --no-cache \
+  chromium \
+  git \
+  openssh \
+  ripgrep
+USER node
+ENV CHROME_BIN=chromium-browser

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "preact/signals",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "eslint.format.enable": true,
+        "explorer.excludeGitIgnore": true,
+        "[javascript][javascriptreact][typescript][typescriptreact]": {
+          "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+        }
+      },
+      "extensions":[
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  },
+  "postCreateCommand": "pnpm i",
+  "remoteUser": "node"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.pnpm-store/


### PR DESCRIPTION
This pull request adds a basic devcontainer setup:
 * pnpm installed
 * Chromium installed for running tests
 * ESLint and Prettier extensions for VSCode

I went with Alpine, as I have the most experience with it and it had Chromium etc. nicely packaged for both x86_64 and aarch64. Tested with a M1 based Mac.