### PR TITLE
Improve Signal->Text rendering in Preact

### DIFF
--- a/.changeset/popular-avocados-sip.md
+++ b/.changeset/popular-avocados-sip.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals": patch
+"@preact/signals-react": patch
+---
+
+Improve performance when rendering Signals as Text in Preact.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -80,14 +80,15 @@ function Text({ data }: { data: Signal }) {
 //@ts-ignore-next-line
 const $$typeof = createElement("a").$$typeof;
 Object.defineProperties(Signal.prototype, {
-	$$typeof: { value: $$typeof },
-	type: { value: Text },
+	$$typeof: { configurable: true, value: $$typeof },
+	type: { configurable: true, value: Text },
 	props: {
+		configurable: true,
 		get() {
 			return { data: this };
 		},
 	},
-	ref: { value: null },
+	ref: { configurable: true, value: null },
 });
 
 // Track the current owner (roughly equiv to current vnode)


### PR DESCRIPTION
This switches the Preact integration to automatically render Signals as Text, rather than walking the Virtual DOM tree to to convert Signals to JSX. The technique is the same as what we use in the React integration. I had avoided using this technique for Preact because Preact 10 adds internal properties to VNodes, which would cause shape changes for Signals used in JSXText positions, however it turns out there's an easy fix: add `__b:1` to the Signal prototype to trigger Preact's [existing VNode re-use cloning behavior](https://github.com/preactjs/preact/blob/d7a433ee8463a7dc23a05111bb47de9ec729ad4d/src/diff/children.js#L77).

I also updated the React integration to include `configurable:true` in the property descriptors we install into `Signal.prototype`. Folks should never have two copies of a single framework integration installing themselves into a single `Signal.prototype`, but it _is_ possible both the Preact and React integrations would do so.