### PR TITLE
Fix stale invalidated signals inside batch

### DIFF
--- a/.changeset/tiny-numbers-argue.md
+++ b/.changeset/tiny-numbers-argue.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Fix invalidated signals inside `batch()` not being refreshed when read inside a batching operation. This fixes a regression.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,14 +35,14 @@ export class Signal<T = any> {
 	}
 
 	peek() {
-		if (!this._active) {
+		if (!this._active || this._pending > 0) {
 			activate(this);
 		}
 		return this._value;
 	}
 
 	get value() {
-		if (!this._active) {
+		if (!this._active || this._pending > 0) {
 			activate(this);
 		}
 
@@ -266,7 +266,6 @@ export function effect(callback: () => void) {
 export function batch<T>(cb: () => T): T {
 	if (batchPending !== null) {
 		return cb();
-
 	} else {
 		const pending: Set<Signal> = new Set();
 
@@ -274,7 +273,6 @@ export function batch<T>(cb: () => T): T {
 
 		try {
 			return cb();
-
 		} finally {
 			// Since stale signals are refreshed upwards, we need to
 			// add pending signals in reverse

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -747,4 +747,44 @@ describe("batch/transaction", () => {
 		c.value = "cc";
 		expect(result).to.equal("aa bb cc");
 	});
+
+	it("should not lead to stale signals with .value in batch", () => {
+		const invokes: number[][] = [];
+		const counter = signal(0);
+		const double = computed(() => counter.value * 2);
+		const tripple = computed(() => counter.value * 3);
+
+		effect(() => {
+			invokes.push([double.value, tripple.value]);
+		});
+
+		expect(invokes).to.deep.equal([[0, 0]]);
+
+		batch(() => {
+			counter.value = 1;
+			expect(double.value).to.equal(2);
+		});
+
+		expect(invokes[1]).to.deep.equal([2, 3]);
+	});
+
+	it("should not lead to stale signals with peek() in batch", () => {
+		const invokes: number[][] = [];
+		const counter = signal(0);
+		const double = computed(() => counter.value * 2);
+		const tripple = computed(() => counter.value * 3);
+
+		effect(() => {
+			invokes.push([double.value, tripple.value]);
+		});
+
+		expect(invokes).to.deep.equal([[0, 0]]);
+
+		batch(() => {
+			counter.value = 1;
+			expect(double.peek()).to.equal(2);
+		});
+
+		expect(invokes[1]).to.deep.equal([2, 3]);
+	});
 });


### PR DESCRIPTION
Just checking if a signal is "active" or not before refreshing it's value is not enough. During batching an active signal can be invalidated and we _must_ refresh its value when read from.

This fixes an accidental regression introduced in #127 .

Fixes #145