### PR TITLE
[preact] Optimize performance of prop bindings

### DIFF
--- a/.changeset/unlucky-rocks-return.md
+++ b/.changeset/unlucky-rocks-return.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Optimize the performance of prop bindings in Preact

--- a/docs/demos/animation/index.tsx
+++ b/docs/demos/animation/index.tsx
@@ -1,0 +1,140 @@
+import { useEffect } from "preact/hooks";
+import { useSignal, useComputed, Signal } from "@preact/signals";
+import "./style.css";
+import { setFlashingEnabled } from "../render-flasher";
+
+const COUNT = 200;
+const LOOPS = 6;
+
+export default function Animation() {
+	const x = useSignal(0);
+	const y = useSignal(0);
+	const big = useSignal(false);
+	const counter = useSignal(0);
+
+	useEffect(() => {
+		let touch = navigator.maxTouchPoints > 1;
+
+		// set mouse position state on move:
+		function move(e: MouseEvent | TouchEvent) {
+			const pointer = "touches" in e ? e.touches[0] : e;
+			x.value = pointer.clientX;
+			y.value = pointer.clientY - 52;
+		}
+		// holding the mouse down enables big mode:
+		function setBig(e: Event) {
+			big.value = true;
+			e.preventDefault();
+		}
+		function notBig() {
+			big.value = false;
+		}
+		addEventListener(touch ? "touchmove" : "mousemove", move);
+		addEventListener(touch ? "touchstart" : "mousedown", setBig);
+		addEventListener(touch ? "touchend" : "mouseup", notBig);
+
+		let running = true;
+		function tick() {
+			if (running === false) return;
+			counter.value++;
+			requestAnimationFrame(tick);
+		}
+		requestAnimationFrame(tick);
+
+		setFlashingEnabled(false);
+		setTimeout(() => setFlashingEnabled(false), 150);
+
+		return () => {
+			running = false;
+			setFlashingEnabled(true);
+			removeEventListener(touch ? "touchmove" : "mousemove", move);
+			removeEventListener(touch ? "touchstart" : "mousedown", setBig);
+			removeEventListener(touch ? "touchend" : "mouseup", notBig);
+		};
+	}, []);
+
+	const max = useComputed(() => {
+		return (
+			COUNT +
+			Math.round(Math.sin((counter.value / 90) * 2 * Math.PI) * COUNT * 0.5)
+		);
+	});
+
+	let circles = [];
+
+	// the advantage of JSX is that you can use the entirety of JS to "template":
+	for (let i = max.value; i--; ) {
+		circles[i] = (
+			<Circle i={i} x={x} y={y} big={big} max={max} counter={counter} />
+		);
+	}
+
+	return (
+		<div class="animation">
+			<Circle i={0} x={x} y={y} big={big} max={max} counter={counter} label />
+			{circles}
+		</div>
+	);
+}
+
+interface CircleProps {
+	i: number;
+	x: Signal<number>;
+	y: Signal<number>;
+	big: Signal<boolean>;
+	max: Signal<number>;
+	counter: Signal<number>;
+	label?: boolean;
+}
+
+/** Represents a single coloured dot. */
+function Circle({ label, i, x, y, big, max, counter }: CircleProps) {
+	const hue = useComputed(() => {
+		let f = (i / max.value) * LOOPS;
+		return (f * 255 + counter.value * 10) % 255;
+	});
+
+	const offsetX = useComputed(() => {
+		let f = (i / max.value) * LOOPS;
+		let θ = f * 2 * Math.PI;
+		return Math.sin(θ) * (20 + i * 2);
+	});
+
+	const offsetY = useComputed(() => {
+		let f = (i / max.value) * LOOPS;
+		let θ = f * 2 * Math.PI;
+		return Math.cos(θ) * (20 + i * 2);
+	});
+
+	// For testing nested "computeds-only" components (for GC):
+	// 	return <CircleInner {...{ label, x, y, offsetX, offsetY, hue, big }} />;
+	// }
+	// function CircleInner({ label, x, y, offsetX, offsetY, hue, big }) {
+
+	const style = useComputed(() => {
+		let left = (x.value + offsetX.value) | 0;
+		let top = (y.value + offsetY.value) | 0;
+		return `left:${left}px; top:${top}px; border-color:hsl(${hue},100%,50%);`;
+	});
+
+	const cl = useComputed(() => {
+		let cl = "circle";
+		if (label) cl += " label";
+		if (big.value) cl += " big";
+		return cl;
+	});
+
+	return (
+		<div class={cl} style={style}>
+			{label && <Label x={x} y={y} />}
+		</div>
+	);
+}
+
+function Label({ x, y }: { x: Signal<number>; y: Signal<number> }) {
+	return (
+		<span class="label">
+			{x},{y}
+		</span>
+	);
+}

--- a/docs/demos/animation/style.css
+++ b/docs/demos/animation/style.css
@@ -1,0 +1,49 @@
+.animation {
+	position: absolute;
+	left: 0;
+	top: 52px;
+	bottom: 0;
+	width: 100%;
+	background: #222;
+	color: #888;
+	text-rendering: optimizeSpeed;
+	touch-action: none;
+	overflow: hidden;
+}
+
+.circle {
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 8px;
+	height: 8px;
+	margin: -5px 0 0 -5px;
+	border: 2px solid #f00;
+	border-radius: 50%;
+	transform-origin: 50% 50%;
+	transition: all 250ms ease;
+	transition-property: width, height, margin;
+	pointer-events: none;
+	overflow: hidden;
+	font-size: 9px;
+	line-height: 25px;
+	text-indent: 15px;
+	white-space: nowrap;
+
+	&.label {
+		overflow: visible;
+	}
+
+	&.big {
+		width: 24px;
+		height: 24px;
+		margin: -13px 0 0 -13px;
+	}
+
+	& > .label {
+		position: absolute;
+		left: 0;
+		top: 0;
+		z-index: 10;
+	}
+}

--- a/docs/demos/index.tsx
+++ b/docs/demos/index.tsx
@@ -12,6 +12,7 @@ const demos = {
 	GlobalCounter,
 	DuelingCounters,
 	Nesting: lazy(() => import("./nesting")),
+	Animation: lazy(() => import("./animation")),
 };
 
 function Demos() {

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -21,12 +21,18 @@ function packages(prod: boolean) {
 
 export default defineConfig(env => ({
 	plugins: [
-		preact({
-			exclude: /\breact/,
-		}),
+		process.env.DEBUG
+			? preact({
+					exclude: /\breact/,
+			  })
+			: null,
 		multiSpa(["index.html", "demos/**/*.html"]),
 		unsetPreactAliases(),
 	],
+	esbuild: {
+		jsx: "automatic",
+		jsxImportSource: "preact",
+	},
 	build: {
 		polyfillModulePreload: false,
 		cssCodeSplit: false,

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -33,6 +33,9 @@ export default defineConfig(env => ({
 		jsx: "automatic",
 		jsxImportSource: "preact",
 	},
+	optimizeDeps: {
+		include: ["preact/jsx-runtime", "preact/jsx-dev-runtime"],
+	},
 	build: {
 		polyfillModulePreload: false,
 		cssCodeSplit: false,

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -8,6 +8,8 @@ export interface VNode<P = any> extends preact.VNode<P> {
 	__?: VNode;
 	/** The DOM node for this VNode */
 	__e?: Element | Text;
+	/** Props that had Signal values before diffing (used after diffing to subscribe) */
+	__np?: Record<string, any> | null;
 }
 
 export interface ComponentType extends Component {
@@ -18,7 +20,7 @@ export interface ComponentType extends Component {
 export type Updater = Signal<unknown>;
 
 export interface ElementUpdater extends Updater {
-	_props: Array<{ _key: string, _signal: Signal }>;
+	_props: Record<string, any>;
 }
 
 export const enum OptionsTypes {


### PR DESCRIPTION
In Preact 10, new `VNode` instances are passed to the `DIFF` hook on every render. In the previous prop bindings implementation, this was causing signal prop values to be bound on every VDOM render, leaking memory and doing unnecessary work.

This new approach replaces Signal prop values with their peek()'d current values in order to allow Preact to render those props using its standard setProperty mechanics, and the Signal instances are stored in a new property attached to the element VNode. After a VNode is diffed (`options.diffed`), if it has Signals stored in this new property, their DOM bindings are set up using an Updater that is stored on the DOM element itself - this works because DOM elements are stable references in Preact 10, whereas VNodes are not.

The implementation in this PR uses a single Updater instance for each Element VNode with one or more Signal prop values. Any time one of the Signals is changed, the Updater loops over the current set of Signals bound to its associated element and compares their new value to a cached copy - if the value is different, a DOM mutation is performed.  In the future when #136 has landed, it may be more efficient (and smaller) to instead do per-signal-prop bindings using Effect. I have a version locally that does this.