### PR TITLE
Support auto-disposing nested effects

### DIFF
--- a/.changeset/heavy-turkeys-relate.md
+++ b/.changeset/heavy-turkeys-relate.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": minor
+---
+
+Add support for auto-disposing nested effects

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,8 +58,8 @@ function endBatch() {
 		batchIteration++;
 
 		while (effect !== undefined) {
-			const next: Effect | undefined = effect._nextEffect;
-			effect._nextEffect = undefined;
+			const next: Effect | undefined = effect._nextBatchedEffect;
+			effect._nextBatchedEffect = undefined;
 			effect._flags &= ~NOTIFIED;
 
 			if (!(effect._flags & DISPOSED)) {
@@ -313,12 +313,26 @@ function returnComputed<T>(computed: Computed<T>): T {
 	return computed._value as T;
 }
 
+function disposeNestedEffects(context: Computed | Effect) {
+	let effect = context._effects;
+	if (effect !== undefined) {
+		do {
+			effect._dispose();
+			effect = effect._nextNestedEffect;
+		} while (effect !== undefined);
+		context._effects = undefined;
+	}
+}
+
 class Computed<T = any> extends Signal<T> {
 	/** @internal */
 	_compute: () => T;
 
 	/** @internal */
 	_sources?: Node = undefined;
+
+	/** @internal */
+	_effects?: Effect = undefined;
 
 	/** @internal */
 	_globalVersion = globalVersion - 1;
@@ -413,6 +427,8 @@ class Computed<T = any> extends Signal<T> {
 			}
 		}
 
+		disposeNestedEffects(this);
+
 		const prevValue = this._value;
 		const prevFlags = this._flags;
 		const prevContext = evalContext;
@@ -463,8 +479,10 @@ function endEffect(this: Effect, prevContext?: Computed | Effect) {
 
 class Effect {
 	_compute: () => void;
-	_sources?: Node = undefined;
-	_nextEffect?: Effect = undefined;
+	_sources?: Node;
+	_effects?: Effect;
+	_nextNestedEffect?: Effect;
+	_nextBatchedEffect?: Effect;
 	_flags = SHOULD_SUBSCRIBE;
 
 	constructor(compute: () => void) {
@@ -486,10 +504,14 @@ class Effect {
 		}
 		this._flags |= RUNNING;
 		this._flags &= ~DISPOSED;
+		disposeNestedEffects(this);
 
 		/*@__INLINE__**/ startBatch();
 		const prevContext = evalContext;
-
+		if (prevContext !== undefined) {
+			this._nextNestedEffect = prevContext._effects;
+			prevContext._effects = this;
+		}
 		evalContext = this;
 
 		prepareSources(this);
@@ -499,7 +521,7 @@ class Effect {
 	_notify() {
 		if (!(this._flags & NOTIFIED)) {
 			this._flags |= NOTIFIED;
-			this._nextEffect = batchedEffect;
+			this._nextBatchedEffect = batchedEffect;
 			batchedEffect = this;
 		}
 	}
@@ -511,6 +533,7 @@ class Effect {
 		for (let node = this._sources; node !== undefined; node = node._nextSource) {
 			node._source._unsubscribe(node);
 		}
+		disposeNestedEffects(this);
 		this._sources = undefined;
 		this._flags |= DISPOSED;
 	}


### PR DESCRIPTION
This pull request adds support for auto-disposing nested effects. With the following setup:

```ts
const a = signal("a");
const b = signal("x");
const e = effect(() => {
  console.log("outer effect", a.value);
  effect(() => {
    console.log("inner effect", a.value + b.value);
  });
});

// Console: outer effect a
// Console: inner effect ax
```

Now if we run the outer effect again the previous inner effect is auto-disposed:

```ts
a.value = "b";
// Console: outer effect b
// Console: inner effect bx
```

If we only update the `b` signal only the latest version of the inner effect runs:

```ts
b.value = "y"
// Console: inner effect by
```

When we dispose the outer effect then the inner effect is also disposed:

```ts
e();
a.value = "c";
// Nothing in the console
```

Note that only immediate containing effects are tracked: For example creating an effect inside an computed inside an effect doesn't dispose the innermost effect when the outermost effect is disposed.