### PR TITLE
Implement Effect, Computed and Signal classes as ES5 classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
-		"@babel/core": "^7.18.10",
-		"@babel/preset-env": "^7.18.10",
+		"@babel/core": "^7.19.1",
+		"@babel/preset-env": "^7.19.1",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
+		"@babel/plugin-transform-typescript": "^7.19.1",
 		"@changesets/changelog-github": "^0.4.6",
 		"@changesets/cli": "^2.24.2",
 		"@types/chai": "^4.3.3",
@@ -85,7 +86,8 @@
 	},
 	"pnpm": {
 		"patchedDependencies": {
-			"microbundle@0.15.1": "patches/microbundle@0.15.1.patch"
+			"microbundle@0.15.1": "patches/microbundle@0.15.1.patch",
+			"@babel/plugin-transform-typescript@7.19.1": "patches/@babel__plugin-transform-typescript@7.19.1.patch"
 		}
 	}
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -205,7 +205,7 @@ declare class Signal<T = any> {
 	set value(value: T);
 }
 
-function Signal(this: Signal, value: unknown) {
+function Signal(this: Signal, value?: unknown) {
 	this._value = value;
 	this._version = 0;
 	this._node = undefined;
@@ -379,15 +379,7 @@ declare class Computed<T = any> extends Signal<T> {
 	constructor(compute: () => T);
 
 	/** @internal */
-	_subscribe(node: Node): void;
-
-	/** @internal */
-	_unsubscribe(node: Node): void;
-
-	/** @internal */
 	_notify(): void;
-
-	peek(): T;
 
 	get value(): T;
 }
@@ -402,135 +394,139 @@ function Computed(this: Computed, compute: () => unknown) {
 	this._flags = STALE;
 }
 
-Computed.prototype = Object.create(Signal.prototype);
+// Do this IIFE wrapping thing instead of deriving directly from Signal, to avoid
+// a performance cliff (at least on on Node.js 18.9.0).
+(function(_Signal: typeof Signal) {
+	Computed.prototype = new _Signal() as Computed;
 
-Computed.prototype._subscribe = function(node) {
-	if (this._targets === undefined) {
-		this._flags |= STALE | SHOULD_SUBSCRIBE;
+	Computed.prototype._subscribe = function(node) {
+		if (this._targets === undefined) {
+			this._flags |= STALE | SHOULD_SUBSCRIBE;
 
-		// A computed signal subscribes lazily to its dependencies when the it
-		// gets its first subscriber.
-		for (
-			let node = this._sources;
-			node !== undefined;
-			node = node._nextSource
-		) {
-			node._source._subscribe(node);
-		}
-	}
-	Signal.prototype._subscribe.call(this, node);
-};
-
-Computed.prototype._unsubscribe = function(node) {
-	Signal.prototype._unsubscribe.call(this, node);
-
-	// Computed signal unsubscribes from its dependencies from it loses its last subscriber.
-	if (this._targets === undefined) {
-		this._flags &= ~SHOULD_SUBSCRIBE;
-
-		for (
-			let node = this._sources;
-			node !== undefined;
-			node = node._nextSource
-		) {
-			node._source._unsubscribe(node);
-		}
-	}
-};
-
-Computed.prototype._notify = function() {
-	if (!(this._flags & NOTIFIED)) {
-		this._flags |= STALE | NOTIFIED;
-
-		for (
-			let node = this._targets;
-			node !== undefined;
-			node = node._nextTarget
-		) {
-			node._target._notify();
-		}
-	}
-};
-
-Computed.prototype.peek = function() {
-	this._flags &= ~NOTIFIED;
-
-	if (this._flags & RUNNING) {
-		cycleDetected();
-	}
-	this._flags |= RUNNING;
-
-	if (!(this._flags & STALE) && this._targets !== undefined) {
-		return returnComputed(this);
-	}
-	this._flags &= ~STALE;
-
-	if (this._globalVersion === globalVersion) {
-		return returnComputed(this);
-	}
-	this._globalVersion = globalVersion;
-
-	if (this._version > 0) {
-		// Check current dependencies for changes. The dependency list is already in
-		// order of use. Therefore if >1 dependencies have changed only the first used one
-		// is re-evaluated at this point.
-		let node = this._sources;
-		while (node !== undefined) {
-			if (node._source._version !== node._version) {
-				break;
+			// A computed signal subscribes lazily to its dependencies when the it
+			// gets its first subscriber.
+			for (
+				let node = this._sources;
+				node !== undefined;
+				node = node._nextSource
+			) {
+				node._source._subscribe(node);
 			}
-			try {
-				node._source.peek();
-			} catch {
-				// Failures of current dependencies shouldn't be rethrown here in case the
-				// compute function catches them.
+		}
+		_Signal.prototype._subscribe.call(this, node);
+	};
+
+	Computed.prototype._unsubscribe = function(node) {
+		_Signal.prototype._unsubscribe.call(this, node);
+
+		// Computed signal unsubscribes from its dependencies from it loses its last subscriber.
+		if (this._targets === undefined) {
+			this._flags &= ~SHOULD_SUBSCRIBE;
+
+			for (
+				let node = this._sources;
+				node !== undefined;
+				node = node._nextSource
+			) {
+				node._source._unsubscribe(node);
 			}
-			if (node._source._version !== node._version) {
-				break;
+		}
+	};
+
+	Computed.prototype._notify = function() {
+		if (!(this._flags & NOTIFIED)) {
+			this._flags |= STALE | NOTIFIED;
+
+			for (
+				let node = this._targets;
+				node !== undefined;
+				node = node._nextTarget
+			) {
+				node._target._notify();
 			}
-			node = node._nextSource;
 		}
-		if (node === undefined) {
-			return returnComputed(this);
-		}
-	}
+	};
 
-	disposeNestedEffects(this);
+	Computed.prototype.peek = function() {
+		this._flags &= ~NOTIFIED;
 
-	const prevValue = this._value;
-	const prevFlags = this._flags;
-	const prevContext = evalContext;
-	try {
-		evalContext = this;
-		prepareSources(this);
-		this._value = this._compute();
-		this._flags &= ~HAS_ERROR;
-		if (
-			prevFlags & HAS_ERROR ||
-			this._value !== prevValue ||
-			this._version === 0
-		) {
-			this._version++;
-		}
-	} catch (err) {
-		this._value = err;
-		this._flags |= HAS_ERROR;
-		this._version++;
-	} finally {
-		cleanupSources(this);
-		evalContext = prevContext;
-	}
-	return returnComputed(this);
-};
-
-Object.defineProperty(Computed.prototype, "value", {
-	get() {
 		if (this._flags & RUNNING) {
 			cycleDetected();
 		}
-		return getValue(this);
-	}
-});
+		this._flags |= RUNNING;
+
+		if (!(this._flags & STALE) && this._targets !== undefined) {
+			return returnComputed(this);
+		}
+		this._flags &= ~STALE;
+
+		if (this._globalVersion === globalVersion) {
+			return returnComputed(this);
+		}
+		this._globalVersion = globalVersion;
+
+		if (this._version > 0) {
+			// Check current dependencies for changes. The dependency list is already in
+			// order of use. Therefore if >1 dependencies have changed only the first used one
+			// is re-evaluated at this point.
+			let node = this._sources;
+			while (node !== undefined) {
+				if (node._source._version !== node._version) {
+					break;
+				}
+				try {
+					node._source.peek();
+				} catch {
+					// Failures of current dependencies shouldn't be rethrown here in case the
+					// compute function catches them.
+				}
+				if (node._source._version !== node._version) {
+					break;
+				}
+				node = node._nextSource;
+			}
+			if (node === undefined) {
+				return returnComputed(this);
+			}
+		}
+
+		disposeNestedEffects(this);
+
+		const prevValue = this._value;
+		const prevFlags = this._flags;
+		const prevContext = evalContext;
+		try {
+			evalContext = this;
+			prepareSources(this);
+			this._value = this._compute();
+			this._flags &= ~HAS_ERROR;
+			if (
+				prevFlags & HAS_ERROR ||
+				this._value !== prevValue ||
+				this._version === 0
+			) {
+				this._version++;
+			}
+		} catch (err) {
+			this._value = err;
+			this._flags |= HAS_ERROR;
+			this._version++;
+		} finally {
+			cleanupSources(this);
+			evalContext = prevContext;
+		}
+		return returnComputed(this);
+	};
+
+	Object.defineProperty(Computed.prototype, "value", {
+		get() {
+			if (this._flags & RUNNING) {
+				cycleDetected();
+			}
+			return getValue(this);
+		}
+	});
+})(Signal);
 
 function computed<T>(compute: () => T): Computed<T> {
 	return new Computed(compute);

--- a/patches/@babel__plugin-transform-typescript@7.19.1.patch
+++ b/patches/@babel__plugin-transform-typescript@7.19.1.patch
@@ -1,0 +1,54 @@
+diff --git a/lib/index.js b/lib/index.js
+index 9753d47727d94827bc40a674a721527e50331acd..9c7acc8d88ffd1b588f5c4c9c3a73256892c30dd 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -54,6 +54,20 @@ function registerGlobalType(programScope, name) {
+   GLOBAL_TYPES.get(programScope).add(name);
+ }
+ 
++// A hack to avoid removing the impl Binding when we remove the declare NodePath
++function safeRemove(path) {
++  const ids = path.getBindingIdentifiers();
++  for (const name of Object.keys(ids)) {
++    const binding = path.scope.getBinding(name);
++    if (binding && binding.identifier === ids[name]) {
++      binding.scope.removeBinding(name);
++    }
++  }
++  path.opts.noScope = true;
++  path.remove();
++  path.opts.noScope = false;
++}
++
+ var _default = (0, _helperPluginUtils.declare)((api, opts) => {
+   api.assertVersion(7);
+   const JSX_PRAGMA_REGEX = /\*?\s*@jsx((?:Frag)?)\s+([^\s]+)/;
+@@ -347,16 +361,16 @@ var _default = (0, _helperPluginUtils.declare)((api, opts) => {
+       },
+ 
+       TSDeclareFunction(path) {
+-        path.remove();
++        safeRemove(path)
+       },
+ 
+       TSDeclareMethod(path) {
+-        path.remove();
++        safeRemove(path)
+       },
+ 
+       VariableDeclaration(path) {
+         if (path.node.declare) {
+-          path.remove();
++          safeRemove(path)
+         }
+       },
+ 
+@@ -376,7 +390,7 @@ var _default = (0, _helperPluginUtils.declare)((api, opts) => {
+         } = path;
+ 
+         if (node.declare) {
+-          path.remove();
++          safeRemove(path)
+           return;
+         }
+       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,17 @@ patchedDependencies:
   microbundle@0.15.1:
     hash: yvstdq4ikeml4yz3a6bi3bgrvu
     path: patches/microbundle@0.15.1.patch
+  '@babel/plugin-transform-typescript@7.19.1':
+    hash: tiqrfntt5y3ned567j2lekmz2i
+    path: patches/@babel__plugin-transform-typescript@7.19.1.patch
 
 importers:
 
   .:
     specifiers:
-      '@babel/core': ^7.18.10
-      '@babel/preset-env': ^7.18.10
+      '@babel/core': ^7.19.1
+      '@babel/plugin-transform-typescript': ^7.19.1
+      '@babel/preset-env': ^7.19.1
       '@babel/preset-react': ^7.18.6
       '@babel/preset-typescript': ^7.18.6
       '@changesets/changelog-github': ^0.4.6
@@ -49,10 +53,11 @@ importers:
       sinon-chai: ^3.7.0
       typescript: ^4.7.4
     devDependencies:
-      '@babel/core': 7.18.10
-      '@babel/preset-env': 7.18.10_@babel+core@7.18.10
-      '@babel/preset-react': 7.18.6_@babel+core@7.18.10
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/plugin-transform-typescript': 7.19.1_tiqrfntt5y3ned567j2lekmz2i_@babel+core@7.19.1
+      '@babel/preset-env': 7.19.1_@babel+core@7.19.1
+      '@babel/preset-react': 7.18.6_@babel+core@7.19.1
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.19.1
       '@changesets/changelog-github': 0.4.6
       '@changesets/cli': 2.24.2
       '@types/chai': 4.3.3
@@ -63,7 +68,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.33.0_njno5y7ry2l2lcmiu4tywxkwnq
       '@typescript-eslint/parser': 5.33.0_qugx7qdu5zevzvxaiqyxfiwquq
       babel-plugin-istanbul: 6.1.1
-      babel-plugin-transform-rename-properties: 0.1.0_@babel+core@7.18.10
+      babel-plugin-transform-rename-properties: 0.1.0_@babel+core@7.19.1
       chai: 4.3.6
       cross-env: 7.0.3
       errorstacks: 2.4.0
@@ -175,6 +180,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/compat-data/7.19.1:
+    resolution: {integrity: sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/core/7.18.10:
     resolution: {integrity: sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==}
     engines: {node: '>=6.9.0'}
@@ -198,11 +208,43 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core/7.19.1:
+    resolution: {integrity: sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.19.0
+      '@babel/helper-compilation-targets': 7.19.1_@babel+core@7.19.1
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helpers': 7.19.0
+      '@babel/parser': 7.19.1
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.19.1
+      '@babel/types': 7.19.0
+      convert-source-map: 1.8.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.1
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator/7.18.12:
     resolution: {integrity: sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.10
+      '@jridgewell/gen-mapping': 0.3.2
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator/7.19.0:
+    resolution: {integrity: sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.19.0
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
     dev: true
@@ -219,7 +261,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.18.10
+      '@babel/types': 7.19.0
     dev: true
 
   /@babel/helper-compilation-targets/7.18.9_@babel+core@7.18.10:
@@ -235,31 +277,26 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /@babel/helper-create-class-features-plugin/7.18.9_@babel+core@7.18.10:
-    resolution: {integrity: sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==}
+  /@babel/helper-compilation-targets/7.19.1_@babel+core@7.19.1:
+    resolution: {integrity: sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.18.9
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.18.9
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/compat-data': 7.19.1
+      '@babel/core': 7.19.1
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.3
+      semver: 6.3.0
     dev: true
 
-  /@babel/helper-create-class-features-plugin/7.19.0_@babel+core@7.18.10:
+  /@babel/helper-create-class-features-plugin/7.19.0_@babel+core@7.19.1:
     resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
@@ -271,24 +308,35 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin/7.18.6_@babel+core@7.18.10:
+  /@babel/helper-create-regexp-features-plugin/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-7LcpH1wnQLGrI+4v+nPp+zUvIkF9x0ddv1Hkdue10tg3gmRnLy97DXh4STiOf1qeIInyD69Qv5kKSZzKD8B/7A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.1.0
     dev: true
 
-  /@babel/helper-define-polyfill-provider/0.3.2_@babel+core@7.18.10:
-    resolution: {integrity: sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==}
+  /@babel/helper-create-regexp-features-plugin/7.19.0_@babel+core@7.19.1:
+    resolution: {integrity: sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.1
+      '@babel/helper-annotate-as-pure': 7.18.6
+      regexpu-core: 5.1.0
+    dev: true
+
+  /@babel/helper-define-polyfill-provider/0.3.3_@babel+core@7.19.1:
+    resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-compilation-targets': 7.19.1_@babel+core@7.19.1
       '@babel/helper-plugin-utils': 7.19.0
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -307,7 +355,7 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.10
+      '@babel/types': 7.19.0
     dev: true
 
   /@babel/helper-function-name/7.18.9:
@@ -363,6 +411,22 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-module-transforms/7.19.0:
+    resolution: {integrity: sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-simple-access': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.19.1
+      '@babel/types': 7.19.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
@@ -380,17 +444,17 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.18.10:
+  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.18.11
-      '@babel/types': 7.18.10
+      '@babel/types': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -419,7 +483,7 @@ packages:
     resolution: {integrity: sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.10
+      '@babel/types': 7.19.0
     dev: true
 
   /@babel/helper-split-export-declaration/7.18.6:
@@ -448,10 +512,10 @@ packages:
     resolution: {integrity: sha512-oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.18.9
+      '@babel/helper-function-name': 7.19.0
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.18.11
-      '@babel/types': 7.18.10
+      '@babel/traverse': 7.19.1
+      '@babel/types': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -463,6 +527,17 @@ packages:
       '@babel/template': 7.18.10
       '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helpers/7.19.0:
+    resolution: {integrity: sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.19.1
+      '@babel/types': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -484,306 +559,314 @@ packages:
       '@babel/types': 7.18.10
     dev: true
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.18.10:
+  /@babel/parser/7.19.1:
+    resolution: {integrity: sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.19.0
+    dev: true
+
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-AHrP9jadvH7qlOj6PINbgSuphjQUAK7AOT7DPjBo9EHoLhQTnnK5u45e1Hd4DbSQEO9nqPWtQ89r+XEOWFScKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.18.10
+      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-async-generator-functions/7.18.10_@babel+core@7.18.10:
-    resolution: {integrity: sha512-1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==}
+  /@babel/plugin-proposal-async-generator-functions/7.19.1_@babel+core@7.19.1:
+    resolution: {integrity: sha512-0yu8vNATgLy4ivqMNBIwb1HebCelqN7YX8SL3FDXORv/RqT0zEEWUCH4GH44JsSrvCu6GqnAdR5EBFAPeNBB4Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.18.10
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.18.10:
+  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.19.1:
     resolution: {integrity: sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.1
       '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-class-features-plugin': 7.18.9_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-static-block/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-class-static-block/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-+I3oIiNxrCpup3Gi8n5IGMwj0gOCAjcJUSQEcotNnCCPMEnixawOQ+KeJPlgfjzx+FKQ1QSyZOWe7wmoJp7vhw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-class-features-plugin': 7.18.9_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-logical-assignment-operators/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-proposal-logical-assignment-operators/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-128YbMpjCrP35IOExw2Fq+x55LMP42DzhOhX2aNNIdI9avSWl2PI0yuBWarr3RYpZBSPtabfadkH2yeRiMD61Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-object-rest-spread/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-proposal-object-rest-spread/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-kDDHQ5rflIeY5xl69CEqGEZ0KY369ehsCIEbTGb4siHG5BE9sga/T0r0OUwyZNLMmZE79E1kbsqAjwFCW4ds6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.18.8
-      '@babel/core': 7.18.10
-      '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.18.10
+      '@babel/compat-data': 7.19.1
+      '@babel/core': 7.19.1
+      '@babel/helper-compilation-targets': 7.19.1_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.19.1
+      '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-optional-chaining/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-proposal-optional-chaining/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.10
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-class-features-plugin': 7.18.9_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-private-property-in-object/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.18.9_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.18.10
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.10:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.19.1:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.18.10:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.19.1:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.18.10:
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.19.1:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.18.10:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.19.1:
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.18.10:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.19.1:
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-flow/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-syntax-flow/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-import-assertions/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-syntax-import-assertions/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-/DU3RXad9+bZwrgWJQKbr39gYbJpLJHezqEzRzi/BHRlJ9zsQb4CK2CA/5apllXNomwA1qHwzvHl+AdEmC5krQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.18.10:
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.19.1:
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.18.10:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.19.1:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.10:
@@ -796,146 +879,157 @@ packages:
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.10:
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.19.1:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+    dev: true
+
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.19.1:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.18.10:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.19.1:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.18.10:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.19.1:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.18.10:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.19.1:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.18.10:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.19.1:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.18.10:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.19.1:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.18.10:
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.19.1:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.18.10:
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.19.1:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-syntax-typescript/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-syntax-typescript/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-arrow-functions/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-arrow-functions/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-async-to-generator/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-async-to-generator/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.18.10
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-block-scoping/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-transform-block-scoping/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-5sDIJRV1KtQVEbt/EIBwGy4T01uYIo4KRB3VUqzkhrAIOGx7AoctL9+Ux88btY0zXdDyPJ9mW+bg+v+XEkGmtw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-classes/7.18.9_@babel+core@7.18.10:
-    resolution: {integrity: sha512-EkRQxsxoytpTlKJmSPYrsOMjCILacAjtSVkd4gChEe2kXjFCun3yohhW5I7plXJhCemM0gKsaGMcO8tinvCA5g==}
+  /@babel/plugin-transform-classes/7.19.0_@babel+core@7.19.1:
+    resolution: {integrity: sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-compilation-targets': 7.19.1_@babel+core@7.19.1
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.18.9
+      '@babel/helper-function-name': 7.19.0
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-replace-supers': 7.18.9
       '@babel/helper-split-export-declaration': 7.18.6
       globals: 11.12.0
@@ -943,230 +1037,230 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-computed-properties/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-transform-computed-properties/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-destructuring/7.18.9_@babel+core@7.18.10:
-    resolution: {integrity: sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==}
+  /@babel/plugin-transform-destructuring/7.18.13_@babel+core@7.19.1:
+    resolution: {integrity: sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-flow-strip-types/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-transform-flow-strip-types/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-+G6rp2zRuOAInY5wcggsx4+QVao1qPM0osC9fTUVlAV3zOrzTCnrMAFVnR6+a3T8wz1wFIH7KhYMcMB3u1n80A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.18.10
+      '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.19.1
     dev: true
 
-  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.18.10:
+  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.19.1:
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.18.10
-      '@babel/helper-function-name': 7.18.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-compilation-targets': 7.19.1_@babel+core@7.19.1
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-modules-amd/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-modules-amd/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-Pra5aXsmTsOnjM3IajS8rTaLCy++nGM4v3YR4esk5PCsyg9z8NA5oQLwxzMUtDBd8F+UmVza3VxoAaWCbzH1rg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-module-transforms': 7.18.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-modules-commonjs/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-module-transforms': 7.18.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-simple-access': 7.18.6
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs/7.18.9_@babel+core@7.18.10:
-    resolution: {integrity: sha512-zY/VSIbbqtoRoJKo2cDTewL364jSlZGvn0LKOf9ntbfxOvjfmyrdtEEOAdswOswhZEb8UH3jDkCKHd1sPgsS0A==}
+  /@babel/plugin-transform-modules-systemjs/7.19.0_@babel+core@7.19.1:
+    resolution: {integrity: sha512-x9aiR0WXAWmOWsqcsnrzGR+ieaTMVyGyffPVA7F8cXAGt/UxefYv6uSHZLkAFChN5M5Iy1+wjE+xJuPt22H39A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.18.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-validator-identifier': 7.18.6
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-module-transforms': 7.18.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex/7.18.6_@babel+core@7.18.10:
-    resolution: {integrity: sha512-UmEOGF8XgaIqD74bC8g7iV3RYj8lMf0Bw7NJzvnS9qQhM4mg+1WHKotUIdjxgD2RGrgFLZZPCFPFj3P/kVDYhg==}
+  /@babel/plugin-transform-named-capturing-groups-regex/7.19.1_@babel+core@7.19.1:
+    resolution: {integrity: sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-replace-supers': 7.18.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-parameters/7.18.8_@babel+core@7.18.10:
+  /@babel/plugin-transform-parameters/7.18.8_@babel+core@7.19.1:
     resolution: {integrity: sha512-ivfbE3X2Ss+Fj8nnXvKJS6sjRG4gzwPMsP+taZC+ZzEGjAYlvENixmt1sZ5Ca6tWls+BlKSGKPJ6OOXvXCbkFg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-react-display-name/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-react-display-name/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
@@ -1178,6 +1272,16 @@ packages:
     dependencies:
       '@babel/core': 7.18.10
       '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.18.10
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.19.1:
+    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.1
+      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.19.1
     dev: true
 
   /@babel/plugin-transform-react-jsx/7.18.10_@babel+core@7.18.10:
@@ -1194,260 +1298,275 @@ packages:
       '@babel/types': 7.18.10
     dev: true
 
-  /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-react-jsx/7.18.10_@babel+core@7.19.1:
+    resolution: {integrity: sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.1
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.1
+      '@babel/types': 7.18.10
+    dev: true
+
+  /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
-  /@babel/plugin-transform-regenerator/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-regenerator/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-poqRI2+qiSdeldcz4wTSTXBRryoq3Gc70ye7m7UD5Ww0nE29IXqMl6r7Nd15WBgRd74vloEMlShtH6CKxVzfmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.18.9
       regenerator-transform: 0.15.0
     dev: true
 
-  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-spread/7.18.9_@babel+core@7.18.10:
-    resolution: {integrity: sha512-39Q814wyoOPtIB/qGopNIL9xDChOE1pNU0ZY5dO0owhiVt/5kFm4li+/bBtwc7QotG0u5EPzqhZdjMtmqBqyQA==}
+  /@babel/plugin-transform-spread/7.19.0_@babel+core@7.19.1:
+    resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
     dev: true
 
-  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.18.10:
+  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.19.1:
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-typescript/7.19.0_@babel+core@7.18.10:
-    resolution: {integrity: sha512-DOOIywxPpkQHXijXv+s9MDAyZcLp12oYRl3CMWZ6u7TjSoCBq/KqHR/nNFR3+i2xqheZxoF0H2XyL7B6xeSRuA==}
+  /@babel/plugin-transform-typescript/7.19.1_tiqrfntt5y3ned567j2lekmz2i_@babel+core@7.19.1:
+    resolution: {integrity: sha512-+ILcOU+6mWLlvCwnL920m2Ow3wWx3Wo8n2t5aROQmV55GZt+hOiLvBaa3DNzRjSEHa1aauRs4/YLmkCfFkhhRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.19.1
       '@babel/helper-plugin-utils': 7.19.0
-      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.18.10
+      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
+    patched: true
 
-  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.18.10:
+  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.19.1:
     resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.18.10:
+  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-create-regexp-features-plugin': 7.18.6_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/core': 7.19.1
+      '@babel/helper-create-regexp-features-plugin': 7.19.0_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
-  /@babel/preset-env/7.18.10_@babel+core@7.18.10:
-    resolution: {integrity: sha512-wVxs1yjFdW3Z/XkNfXKoblxoHgbtUF7/l3PvvP4m02Qz9TZ6uZGxRVYjSQeR87oQmHco9zWitW5J82DJ7sCjvA==}
+  /@babel/preset-env/7.19.1_@babel+core@7.19.1:
+    resolution: {integrity: sha512-c8B2c6D16Lp+Nt6HcD+nHl0VbPKVnNPTpszahuxJJnurfMtKeZ80A+qUv48Y7wqvS+dTFuLuaM9oYxyNHbCLWA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.18.8
-      '@babel/core': 7.18.10
-      '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/compat-data': 7.19.1
+      '@babel/core': 7.19.1
+      '@babel/helper-compilation-targets': 7.19.1_@babel+core@7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-proposal-async-generator-functions': 7.18.10_@babel+core@7.18.10
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-class-static-block': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-object-rest-spread': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.18.10
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.18.10
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.18.10
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-syntax-import-assertions': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.10
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.10
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.18.10
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.10
-      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-async-to-generator': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-block-scoping': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-classes': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-computed-properties': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-destructuring': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.18.10
-      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-modules-amd': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-modules-systemjs': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.18.10
-      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-spread': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.18.10
-      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.18.10
-      '@babel/preset-modules': 0.1.5_@babel+core@7.18.10
-      '@babel/types': 7.18.10
-      babel-plugin-polyfill-corejs2: 0.3.2_@babel+core@7.18.10
-      babel-plugin-polyfill-corejs3: 0.5.3_@babel+core@7.18.10
-      babel-plugin-polyfill-regenerator: 0.4.0_@babel+core@7.18.10
-      core-js-compat: 3.24.1
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-proposal-async-generator-functions': 7.19.1_@babel+core@7.19.1
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-class-static-block': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-logical-assignment-operators': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-object-rest-spread': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-private-property-in-object': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.19.1
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.19.1
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.19.1
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.1
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.19.1
+      '@babel/plugin-syntax-import-assertions': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.19.1
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.19.1
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.19.1
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.19.1
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.19.1
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.19.1
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.19.1
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.19.1
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.19.1
+      '@babel/plugin-transform-arrow-functions': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-async-to-generator': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-block-scoping': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-transform-classes': 7.19.0_@babel+core@7.19.1
+      '@babel/plugin-transform-computed-properties': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-transform-destructuring': 7.18.13_@babel+core@7.19.1
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.19.1
+      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-modules-amd': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-modules-systemjs': 7.19.0_@babel+core@7.19.1
+      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.1_@babel+core@7.19.1
+      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.19.1
+      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-spread': 7.19.0_@babel+core@7.19.1
+      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.19.1
+      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.19.1
+      '@babel/preset-modules': 0.1.5_@babel+core@7.19.1
+      '@babel/types': 7.19.0
+      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.19.1
+      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.19.1
+      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.19.1
+      core-js-compat: 3.25.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-flow/7.18.6_@babel+core@7.18.10:
+  /@babel/preset-flow/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-E7BDhL64W6OUqpuyHnSroLnqyRTcG6ZdOBl1OKI/QK/HJfplqK/S3sq1Cckx7oTodJ5yOXyfw7rEADJ6UjoQDQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-flow-strip-types': 7.18.9_@babel+core@7.18.10
+      '@babel/plugin-transform-flow-strip-types': 7.18.9_@babel+core@7.19.1
     dev: true
 
-  /@babel/preset-modules/0.1.5_@babel+core@7.18.10:
+  /@babel/preset-modules/0.1.5_@babel+core@7.19.1:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.18.10
-      '@babel/types': 7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.19.1
+      '@babel/types': 7.19.0
       esutils: 2.0.3
     dev: true
 
-  /@babel/preset-react/7.18.6_@babel+core@7.18.10:
+  /@babel/preset-react/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-react-display-name': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.18.10
-      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.18.10
+      '@babel/plugin-transform-react-display-name': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.19.1
+      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.19.1
     dev: true
 
-  /@babel/preset-typescript/7.18.6_@babel+core@7.18.10:
+  /@babel/preset-typescript/7.18.6_@babel+core@7.19.1:
     resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-typescript': 7.19.0_@babel+core@7.18.10
+      '@babel/plugin-transform-typescript': 7.19.1_tiqrfntt5y3ned567j2lekmz2i_@babel+core@7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1480,6 +1599,24 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.18.11
       '@babel/types': 7.18.10
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/traverse/7.19.1:
+    resolution: {integrity: sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.19.0
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.19.1
+      '@babel/types': 7.19.0
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -1907,7 +2044,7 @@ packages:
       preact: ^10.4.0
       vite: '>=2.0.0-beta.3'
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@prefresh/babel-plugin': 0.4.3
       '@prefresh/core': 1.3.4_preact@10.9.0
       '@prefresh/utils': 1.1.3
@@ -1928,7 +2065,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@rollup/plugin-babel/5.3.1_tui6liyexu3zy4m5r2rytc7ixu:
+  /@rollup/plugin-babel/5.3.1_e2cf77gxpkt7ycgqg2uu5f654q:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -1939,7 +2076,7 @@ packages:
       '@types/babel__core':
         optional: true
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/helper-module-imports': 7.18.6
       '@rollup/pluginutils': 3.1.0_rollup@2.77.2
       rollup: 2.77.2
@@ -2479,38 +2616,38 @@ packages:
       resolve: 1.22.1
     dev: true
 
-  /babel-plugin-polyfill-corejs2/0.3.2_@babel+core@7.18.10:
-    resolution: {integrity: sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==}
+  /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.19.1:
+    resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.18.8
-      '@babel/core': 7.18.10
-      '@babel/helper-define-polyfill-provider': 0.3.2_@babel+core@7.18.10
+      '@babel/compat-data': 7.19.1
+      '@babel/core': 7.19.1
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.19.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3/0.5.3_@babel+core@7.18.10:
-    resolution: {integrity: sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==}
+  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.19.1:
+    resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-define-polyfill-provider': 0.3.2_@babel+core@7.18.10
-      core-js-compat: 3.24.1
+      '@babel/core': 7.19.1
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.19.1
+      core-js-compat: 3.25.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator/0.4.0_@babel+core@7.18.10:
-    resolution: {integrity: sha512-RW1cnryiADFeHmfLS+WW/G431p1PsW5qdRdz0SDRi7TKcUgc7Oh/uXkT7MZ/+tGsT1BkczEAmD5XjUyJ5SWDTw==}
+  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.19.1:
+    resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-define-polyfill-provider': 0.3.2_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2527,21 +2664,21 @@ packages:
       '@babel/core': 7.18.10
     dev: true
 
-  /babel-plugin-transform-rename-properties/0.1.0_@babel+core@7.18.10:
+  /babel-plugin-transform-rename-properties/0.1.0_@babel+core@7.19.1:
     resolution: {integrity: sha512-uBSvAC8qH81TsXsWYD20ME4qg9ICflMLjsNfeuSxrKkJkym4Riqne1BrCCW15lcM/t9lfEiz4FJbVeUoaOVGWA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
     dev: true
 
-  /babel-plugin-transform-replace-expressions/0.2.0_@babel+core@7.18.10:
+  /babel-plugin-transform-replace-expressions/0.2.0_@babel+core@7.19.1:
     resolution: {integrity: sha512-Eh1rRd9hWEYgkgoA3D0kGp7xJ/wgVshgsqmq60iC4HVWD+Lux+fNHSHBa2v1Hsv+dHflShC71qKhiH40OiPtDA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/parser': 7.18.11
+      '@babel/core': 7.19.1
+      '@babel/parser': 7.19.1
     dev: true
 
   /balanced-match/1.0.2:
@@ -2906,11 +3043,10 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /core-js-compat/3.24.1:
-    resolution: {integrity: sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==}
+  /core-js-compat/3.25.1:
+    resolution: {integrity: sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==}
     dependencies:
       browserslist: 4.21.3
-      semver: 7.0.0
     dev: true
 
   /cors/2.8.5:
@@ -4536,7 +4672,7 @@ packages:
     resolution: {integrity: sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.19.1
       '@babel/parser': 7.18.11
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
@@ -5037,18 +5173,18 @@ packages:
     resolution: {integrity: sha512-aAF+nwFbkSIJGfrJk+HyzmJOq3KFaimH6OIFBU6J2DPjQeg1jXIYlIyEv81Gyisb9moUkudn+wj7zLNYMOv75Q==}
     hasBin: true
     dependencies:
-      '@babel/core': 7.18.10
-      '@babel/plugin-proposal-class-properties': 7.12.1_@babel+core@7.18.10
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.18.10
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-flow-strip-types': 7.18.9_@babel+core@7.18.10
-      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.18.10
-      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.18.10
-      '@babel/preset-env': 7.18.10_@babel+core@7.18.10
-      '@babel/preset-flow': 7.18.6_@babel+core@7.18.10
-      '@babel/preset-react': 7.18.6_@babel+core@7.18.10
+      '@babel/core': 7.19.1
+      '@babel/plugin-proposal-class-properties': 7.12.1_@babel+core@7.19.1
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.19.1
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.1
+      '@babel/plugin-transform-flow-strip-types': 7.18.9_@babel+core@7.19.1
+      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.19.1
+      '@babel/plugin-transform-regenerator': 7.18.6_@babel+core@7.19.1
+      '@babel/preset-env': 7.19.1_@babel+core@7.19.1
+      '@babel/preset-flow': 7.18.6_@babel+core@7.19.1
+      '@babel/preset-react': 7.18.6_@babel+core@7.19.1
       '@rollup/plugin-alias': 3.1.9_rollup@2.77.2
-      '@rollup/plugin-babel': 5.3.1_tui6liyexu3zy4m5r2rytc7ixu
+      '@rollup/plugin-babel': 5.3.1_e2cf77gxpkt7ycgqg2uu5f654q
       '@rollup/plugin-commonjs': 17.1.0_rollup@2.77.2
       '@rollup/plugin-json': 4.1.0_rollup@2.77.2
       '@rollup/plugin-node-resolve': 11.2.1_rollup@2.77.2
@@ -5057,7 +5193,7 @@ packages:
       autoprefixer: 10.4.8_postcss@8.4.16
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-async-to-promises: 0.8.18
-      babel-plugin-transform-replace-expressions: 0.2.0_@babel+core@7.18.10
+      babel-plugin-transform-replace-expressions: 0.2.0_@babel+core@7.19.1
       brotli-size: 4.0.0
       builtin-modules: 3.3.0
       camelcase: 6.3.0
@@ -6375,11 +6511,6 @@ packages:
 
   /semver/6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
-    hasBin: true
-    dev: true
-
-  /semver/7.0.0:
-    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
This pull request implements the Effect, Computed and Signal classes as ES5 classes.

Added a workaround for a weird performance cliff that I encountered with Node.js 18.9.0. The workaround itself is in commit 64d0ab0844a4d50ee09d564b8748127e8a957049. For some reason the TypeScript compiled version was faster than the hand-rolled ES5 classes when running this benchmark:

```ts
import * as core from "@/preact/signals-core";

{
  const count = core.signal(0);
  const double = core.computed(() => count.value * 2);
  core.effect(() => double.value + count.value);
  core.effect(() => double.value + count.value);
  core.effect(() => double.value + count.value);

  console.time("core");

  for (let i = 0; i < 20000000; i++) {
    count.value++;
    double.value;
  }

  console.timeEnd("core");
}
```

In the end it turned out that TypeScript wrapped the Computed prototype definitions into an IIFE. Adding that same IIFE to the hand-rolled ES5 version boosted the performance back to TypeScript-compiled levels 🫠