### PR TITLE
Tune mangle.json

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -18,14 +18,17 @@
       }
     },
     "compress": {
-      "reduce_funcs": false
+      "conditionals": false,
+      "evaluate": false,
+      "loops": false,
+      "sequences": false
     }
   },
   "props": {
     "cname": 6,
     "props": {
       "core: Node": "",
-      "$_source": "s",
+      "$_source": "S",
       "$_prevSource": "p",
       "$_nextSource": "n",
       "$_target": "t",


### PR DESCRIPTION
This pull request tunes the settings in mangle.json to make the core faster (by ~50% in a specific benchmark) and bundle size smaller (about -20 B).

> This also illustrates how it's a good idea to run the benchmarks with the production builds, as Terser seems to be able to have a big impact in the (micro level) performance depending on the compression + mangling settings.

For some reason mangling core's Node._source to Node.s adds a significant performance hit (on a small micro-benchmark). Renaming it to Node.S instead helps to boost performance by 20% or so.

Another setting causing another ~20% performance hit is the "evaluate" compression option. Turning it off helps performance, but raises the build bundle size a bit.

To compensate for that turning off "conditionals", "loops" and "sequences" compression options reduce the bundle size quite a bit.

The end result ends up being ~50% core performance reduction in particular microbenchmarks. The core bundle size ends up reduced by around 20 bytes across the board.

The microbenchmark in question:

```ts
import * as core from "@preact/signals-core";

{
  const count = core.signal(0);
  const double = core.computed(() => count.value * 2);
  core.effect(() => double.value + count.value);
  core.effect(() => double.value + count.value);
  core.effect(() => double.value + count.value);

  console.time("core");

  for (let i = 0; i < 20000000; i++) {
    count.value++;
    double.value;
  }

  console.timeEnd("core");
}
```

Here are the results after each step. These seem consistent no matter whether the code is using TS-compiled classes or hand-rolled ES5 classes:

| Version  | core.js.gz size | benchmark time |
| --- | --- | --- |
| baseline  | 1614 B | 3.211s |
| + Node.S  | 1613 B | 2.836s |
| + "evaluate": false | 1627 B | 2.348s |
| + rest of the PR | 1594 B | 2.422s |
