### PR TITLE
Allow disposing currently running effects

### DIFF
--- a/.changeset/twelve-suits-smell.md
+++ b/.changeset/twelve-suits-smell.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": minor
+---
+
+Allow disposing a currently running effect

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,8 +118,11 @@ function getValue<T>(signal: Signal<T>): T {
 				_flags: 0,
 				_version: 0,
 				_source: signal,
+				_prevSource: undefined,
 				_nextSource: evalContext._sources,
 				_target: evalContext,
+				_prevTarget: undefined,
+				_nextTarget: undefined,
 				_rollbackNode: node,
 			};
 			evalContext._sources = node;
@@ -515,6 +518,11 @@ class Effect {
 
 	constructor(compute: () => void) {
 		this._compute = compute;
+
+		if (evalContext !== undefined) {
+			this._nextNestedEffect = evalContext._effects;
+			evalContext._effects = this;
+		}
 	}
 
 	_callback() {
@@ -536,10 +544,6 @@ class Effect {
 
 		/*@__INLINE__**/ startBatch();
 		const prevContext = evalContext;
-		if (prevContext !== undefined) {
-			this._nextNestedEffect = prevContext._effects;
-			prevContext._effects = this;
-		}
 		evalContext = this;
 
 		prepareSources(this);

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -248,16 +248,20 @@ describe("effect()", () => {
 		expect(() => dispose()).to.throw;
 	});
 
-	it("should throw when disposing a running effect", () => {
+	it("should allow disposing a running effect", () => {
 		const a = signal(0);
+		const spy = sinon.spy();
 		const dispose = effect(() => {
 			if (a.value === 1) {
 				dispose();
+				spy();
 			}
 		});
-		expect(() => {
-			a.value = 1;
-		}).to.throw("Effect still running");
+		expect(spy).not.to.be.called;
+		a.value = 1;
+		expect(spy).to.be.calledOnce;
+		a.value = 2;
+		expect(spy).to.be.calledOnce;
 	});
 
 	it("should not run if it's first been triggered and then disposed in a batch", () => {


### PR DESCRIPTION
This pull request adds the support for disposing currently running effects. The reasoning for this is that it's convenient, and ends up saving a couple of bytes in some bundle versions.

Disposing the effect while running just delays the full disposal until the run has finished.