### PR TITLE
Add batch tests

### DIFF
--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -1272,4 +1272,14 @@ describe("batch/transaction", () => {
 		expect(spy1).to.be.calledOnce;
 		expect(spy2).to.be.calledOnce;
 	});
+
+	it("should run effect's first run immediately even inside a batch", () => {
+		let callCount = 0;
+		const spy = sinon.spy();
+		batch(() => {
+			effect(spy);
+			callCount = spy.callCount;
+		});
+		expect(callCount).to.equal(1);
+	});
 });

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -285,8 +285,9 @@ describe("effect()", () => {
 		spy.resetHistory();
 
 		batch(() => {
-			a.value = 2;
+			a.value = 1;
 			dispose();
+			a.value = 2;
 		});
 
 		expect(spy).not.to.be.called;


### PR DESCRIPTION
This pull request adds some tests for `batch()`, focusing on how `batch()` handles different return values and thrown errors from batch callbacks and effects.