### PR TITLE
Alternative solution to duplicate prop assignment

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -124,7 +124,7 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 			if (value instanceof Signal) {
 				if (!signalProps) vnode.__np = signalProps = {};
 				signalProps[i] = value;
-				props[i] = value.peek();
+				props[i] = undefined;
 			}
 		}
 	}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -336,16 +336,8 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 	callback.current = cb;
 
 	useEffect(() => {
-		let cleanup: (() => void) | undefined;
 		return effect(() => {
-			if (cleanup) {
-				cleanup();
-				cleanup = undefined;
-			}
-			const result = callback.current();
-			if (typeof result == "function") {
-				cleanup = result;
-			}
+			callback.current();
 		});
 	}, []);
 }

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -134,6 +134,8 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 
 /** Set up Updater before rendering a component */
 hook(OptionsTypes.RENDER, (old, vnode) => {
+	setCurrentUpdater();
+
 	let updater;
 
 	let component = vnode.__c;

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -32,6 +32,8 @@ export interface VNode<P = any> extends preact.VNode<P> {
 	__e?: Element | Text;
 	/** Props that had Signal values before diffing (used after diffing to subscribe) */
 	__np?: Record<string, any> | null;
+	/** VNode._depth is a number during CSR, undefined during renderToString() */
+	__b?: number;
 }
 
 export const enum OptionsTypes {

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -9,7 +9,7 @@ export interface Effect {
 }
 
 export interface PropertyUpdater {
-	_signal: Signal<Signal>;
+	_update: (newSignal: Signal, newProps: Record<string, any>) => void;
 	_dispose: () => void;
 }
 
@@ -32,8 +32,6 @@ export interface VNode<P = any> extends preact.VNode<P> {
 	__e?: Element | Text;
 	/** Props that had Signal values before diffing (used after diffing to subscribe) */
 	__np?: Record<string, any> | null;
-	/** VNode._depth is a number during CSR, undefined during renderToString() */
-	__b?: number;
 }
 
 export const enum OptionsTypes {


### PR DESCRIPTION
This is an alternative to the duplicate prop assignment fix in #177 ([60b41b9](https://github.com/preactjs/signals/pull/177/commits/60b41b9fe105bc21fcea00d10b85caf3c3c92328)). Instead of detecting `renderToString` vs `render` to do Signal-only updates on the client, it allows VDOM updates to render all props (including peek'd signal values), then uses the rendered prop values to determine whether the next Signal-based update should be skipped. Signal updates also mutate their associated VNode props to have the received value, bypassing future VDOM re-rendering of a prop if its value has not changed.