### PR TITLE
Refactor how signal values are revalidated

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -19,7 +19,6 @@
     },
     "compress": {
       "conditionals": false,
-      "evaluate": false,
       "loops": false,
       "sequences": false
     }
@@ -36,6 +35,7 @@
       "$_nextTarget": "x",
       "$_rollbackNode": "r",
       "core: Signal": "",
+      "$_refresh": "h",
       "$_value": "v",
       "$_node": "n",
       "$_targets": "t",


### PR DESCRIPTION
This pull request splits Computed value refreshing and `.peek()` into two separate phases, which in turn allows flattening the call stack and removing a recursing try-catch section inside `Computed.peek()`.

In the end this seems to make the code much less sensitive to specific compression & mangling setting, so the "evaluate" compression setting could be enabled again without any performance penalty. Also the previous weird performance issue (solved by wrapping Compute.prototype creation into an IIFE) didn't manifest itself anymore, so the IIFE could be removed. These make the bundled code size smaller, and the benchmarks seem to give a bit better results as well.