### PR TITLE
Implement effect cleanups

### DIFF
--- a/.changeset/tidy-buses-do.md
+++ b/.changeset/tidy-buses-do.md
@@ -1,0 +1,16 @@
+---
+"@preact/signals-core": minor
+"@preact/signals": minor
+"@preact/signals-react": minor
+---
+
+Add ability to run custom cleanup logic when an effect is disposed.
+
+```js
+effect(() => {
+  console.log("This runs whenever a dependency changes");
+  return () => {
+    console.log("This runs when the effect is disposed");
+  });
+});
+```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -597,12 +597,12 @@ function endEffect(this: Effect, prevContext?: Computed | Effect) {
 	}
 	cleanupSources(this);
 	evalContext = prevContext;
-	endBatch();
 
 	this._flags &= ~RUNNING;
 	if (this._flags & DISPOSED) {
 		disposeEffect(this);
 	}
+	endBatch();
 }
 
 declare class Effect {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -379,6 +379,11 @@ function cleanupContext(context: Computed | Effect) {
 
 		if (typeof cleanup === "function") {
 			/*@__INLINE__**/ startBatch();
+
+			// Run cleanup functions always outside of any context.
+			const prevContext = evalContext;
+			evalContext = undefined;
+
 			try {
 				cleanup();
 			} catch (err) {
@@ -386,6 +391,8 @@ function cleanupContext(context: Computed | Effect) {
 				error = err;
 				context._flags &= ~RUNNING;
 			}
+
+			evalContext = prevContext;
 			endBatch();
 		}
 	}

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -327,6 +327,22 @@ describe("effect()", () => {
 		expect(spy).not.to.be.called;
 	});
 
+	it("should run nested cleanups before their own", () => {
+		const spy1 = sinon.spy();
+		const spy2 = sinon.spy();
+
+		const dispose = effect(() => {
+			effect(() => {
+				return spy1;
+			});
+			return spy2;
+		});
+		expect(spy1).not.to.be.called;
+		expect(spy2).not.to.be.called;
+		dispose();
+		expect(spy2).to.be.calledAfter(spy1);
+	});
+
 	it("should run all cleanups even if some of them fail", () => {
 		const spy1 = sinon.spy();
 		const spy2 = sinon.spy();

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -161,6 +161,172 @@ describe("effect()", () => {
 		expect(spy).to.be.calledOnce;
 	});
 
+	it("should call the cleanup callback before the next run", () => {
+		const a = signal(0);
+		const spy = sinon.spy();
+
+		effect(() => {
+			a.value;
+			return spy;
+		});
+		expect(spy).not.to.be.called;
+		a.value = 1;
+		expect(spy).to.be.calledOnce;
+		a.value = 2;
+		expect(spy).to.be.calledTwice;
+	});
+
+	it("should call only the callback from the previous run", () => {
+		const spy1 = sinon.spy();
+		const spy2 = sinon.spy();
+		const spy3 = sinon.spy();
+		const a = signal(spy1);
+
+		effect(() => {
+			return a.value;
+		});
+
+		expect(spy1).not.to.be.called;
+		expect(spy2).not.to.be.called;
+		expect(spy3).not.to.be.called;
+
+		a.value = spy2;
+		expect(spy1).to.be.calledOnce;
+		expect(spy2).not.to.be.called;
+		expect(spy3).not.to.be.called;
+
+		a.value = spy3;
+		expect(spy1).to.be.calledOnce;
+		expect(spy2).to.be.calledOnce;
+		expect(spy3).not.to.be.called;
+	});
+
+	it("should call the cleanup callback function when disposed", () => {
+		const spy = sinon.spy();
+
+		const dispose = effect(() => {
+			return spy;
+		});
+		expect(spy).not.to.be.called;
+		dispose();
+		expect(spy).to.be.calledOnce;
+	});
+
+	it("should run the cleanup in a batch", () => {
+		const a = signal(0);
+		const b = signal("a");
+		const c = signal("b");
+		const spy = sinon.spy();
+
+		effect(() => {
+			b.value;
+			c.value;
+			spy(b.value + c.value);
+		});
+
+		effect(() => {
+			a.value;
+			return () => {
+				b.value = "x";
+				c.value = "y";
+			};
+		});
+
+		expect(spy).to.be.calledOnce;
+		spy.resetHistory();
+
+		a.value = 1;
+		expect(spy).to.be.calledOnce;
+		expect(spy).to.be.calledWith("xy");
+	});
+
+	it("should not retrigger the effect if the cleanup modifies one of the dependencies", () => {
+		const a = signal(0);
+		const spy = sinon.spy();
+
+		effect(() => {
+			spy(a.value);
+			return () => {
+				a.value = 2;
+			};
+		});
+		expect(spy).to.be.calledOnce;
+		spy.resetHistory();
+
+		a.value = 1;
+		expect(spy).to.be.calledOnce;
+		expect(spy).to.be.calledWith(2);
+	});
+
+	it("should run the cleanup if the effect is disposes itself", () => {
+		const a = signal(0);
+		const spy = sinon.spy();
+
+		const dispose = effect(() => {
+			if (a.value > 0) {
+				dispose();
+				return spy;
+			}
+		});
+		expect(spy).not.to.be.called;
+		a.value = 1;
+		expect(spy).to.be.calledOnce;
+		a.value = 2;
+		expect(spy).to.be.calledOnce;
+	});
+
+	it("should not run the effect if the cleanup function disposes it", () => {
+		const a = signal(0);
+		const spy = sinon.spy();
+
+		const dispose = effect(() => {
+			a.value;
+			spy();
+			return () => {
+				dispose();
+			};
+		});
+		expect(spy).to.be.calledOnce;
+		a.value = 1;
+		expect(spy).to.be.calledOnce;
+	});
+
+	it("should clear the cleanup if the effect throws", () => {
+		const a = signal(0);
+		const spy = sinon.spy();
+
+		effect(() => {
+			if (a.value === 0) {
+				return spy;
+			} else {
+				throw new Error("hello");
+			}
+		});
+		expect(spy).not.to.be.called;
+		expect(() => a.value = 1).to.throw("hello");
+		expect(spy).to.be.calledOnce;
+		a.value = 0;
+		expect(spy).to.be.calledOnce;
+	});
+
+	it("should dispose the effect if the cleanup callback throws", () => {
+		const a = signal(0);
+		const spy = sinon.spy();
+
+		effect(() => {
+			if (a.value === 0) {
+				return () => {
+					throw new Error("hello");
+				}
+			} else {
+				spy();
+			}
+		});
+		expect(spy).not.to.be.called;
+		expect(() => a.value++).to.throw("hello");
+		expect(spy).not.to.be.called;
+	});
+
 	it("should throw on cycles", () => {
 		const a = signal(0);
 		let i = 0;

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -327,6 +327,35 @@ describe("effect()", () => {
 		expect(spy).not.to.be.called;
 	});
 
+	it("should run cleanups outside any evaluation context", () => {
+		const spy = sinon.spy();
+		const a = signal(0);
+		const b = signal(0);
+		const c = computed(() => {
+			if (a.value === 0) {
+				effect(() => {
+					return () => {
+						b.value;
+					};
+				});
+			}
+		});
+
+		effect(() => {
+			spy();
+			c.value;
+		});
+		expect(spy).to.be.calledOnce;
+		spy.resetHistory();
+
+		a.value = 1;
+		expect(spy).to.be.calledOnce;
+		spy.resetHistory();
+
+		b.value = 1;
+		expect(spy).not.to.be.called;
+	});
+
 	it("should run nested cleanups before their own", () => {
 		const spy1 = sinon.spy();
 		const spy2 = sinon.spy();

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -367,7 +367,7 @@ describe("effect()", () => {
 				};
 			});
 		});
-		expect(dispose).to.throw(/hello (1|2)/)
+		expect(dispose).to.throw(/error (1|2)/)
 	});
 
 	it("should throw on cycles", () => {
@@ -930,9 +930,11 @@ describe("computed()", () => {
 		expect(spy).not.to.be.called;
 
 		a.value++;
+		c.value;
 		expect(spy).to.be.calledOnce;
 
 		a.value++;
+		c.value;
 		expect(spy).to.be.calledOnce;
 	});
 

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -316,17 +316,9 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 	callback.current = cb;
 
 	useEffect(() => {
-		let cleanup: (() => void) | undefined;
 		return effect(() => {
-			if (cleanup) {
-				cleanup();
-				cleanup = undefined
-			}
-			const result = callback.current();
-			if (typeof result == 'function') {
-				cleanup = result
-			}
-		})
+			return callback.current();
+		});
 	}, []);
 }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -169,16 +169,8 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 	callback.current = cb;
 
 	useEffect(() => {
-		let cleanup: (() => void) | undefined;
 		return effect(() => {
-			if (cleanup) {
-				cleanup();
-				cleanup = undefined
-			}
-			const result = callback.current();
-			if (typeof result == 'function') {
-				cleanup = result
-			}
-		})
+			return callback.current();
+		});
 	}, []);
 }


### PR DESCRIPTION
This pull request implements effect cleanup functions. An effect callback can return a function that's then run the next time the effect either gets rerun or disposed. This pull request also converts the `useSignalEffect` hook for the Preact and React integrations to use effect cleanups.

The `effect(compute: () => void)` signature is modified to `effect(compute: () => unknown)`:

```ts
const s = signal(0);

const dispose = effect(() => {
  if (s.value === 0) {
    effect(() => () => console.log("hello"));
  } else {
    effect(() => () => console.log("what a"));
  }

  return () => console.log("world");
});

s.value++; // Prints "hello" & "world"
dispose(); // Prints "what a" & "world"
```

Apart from testing basic functionality, the tests try to cover several corner cases and specific behaviors:
 * The cleanup functions of nested effects are run before the parent effect's cleanup.
 * When an effect or computed signal is running its nested effect cleanups, and one of the cleanups throws, the rest of the cleanups are still completed and the error is only then thrown upwards.
 * If one of effect's nested cleanups throws the effect's own cleanup function still gets called.
 * If an effect's own cleanup or one of its nested cleanups throw, the effect becomes essentially disposed. The error is thrown up the stack.
 * If a computed signal's nested effects fail when the computed value is being revalidated, all of the computed signal's dependency links are severed. Accessing the computed's value from thereon throws the error.
 * If an effect throws an error then its cleanup function is assumed to be undefined.
 * Effects can be disposed and retriggered during their own cleanups or nested cleanups.