### PR TITLE
Run .subscribe callbacks in an untracked context

### DIFF
--- a/.changeset/chatty-buckets-try.md
+++ b/.changeset/chatty-buckets-try.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Fix `.subscribe()` unexpectedly tracking signal access

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -253,7 +253,17 @@ Signal.prototype._unsubscribe = function (node) {
 };
 
 Signal.prototype.subscribe = function (fn) {
-	return effect(() => fn(this.value));
+	const signal = this;
+	return effect(function (this: Effect) {
+		const value = signal.value;
+		const flag = this._flags & AUTO_SUBSCRIBE;
+		this._flags &= ~AUTO_SUBSCRIBE;
+		try {
+			fn(value);
+		} finally {
+			this._flags |= flag;
+		}
+	});
 };
 
 Signal.prototype.valueOf = function () {


### PR DESCRIPTION
This pull request modifies `Signal.subscribe(fn)` to run `fn` in an untracked context. The subscribe function was implemented with `effect`. Therefore if `fn` accessed some signal values it caused the surrounding effect to start following those signals too.

Added also relevant tests for `.subscribe`.