### PR TITLE
Proposal: Implement Vue-style effect cleanups

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -342,8 +342,11 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 	callback.current = cb;
 
 	useEffect(() => {
-		return effect(() => {
-			callback.current();
+		return effect(cleanup => {
+			const cb = callback.current();
+			if (typeof cb === "function") {
+				cleanup(cb);
+			}
 		});
 	}, []);
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -169,8 +169,11 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 	callback.current = cb;
 
 	useEffect(() => {
-		return effect(() => {
-			return callback.current();
+		return effect(cleanup => {
+			const cb = callback.current();
+			if (typeof cb === "function") {
+				cleanup(cb);
+			}
 		});
 	}, []);
 }


### PR DESCRIPTION
This pull request suggest the following middle point between having and not havig autodisposed effects. It also modifies effect cleanups introduced in #183, allowing scheduling multiple effect cleanups during the same effect run:

```ts
import { signal, effect } from "@preact/signals-core";

effect((cleanup) => {
  cleanup(() => {
    console.log("this will run the next time the effect rerun or disposed");
  });
  cleanup(() => {
    console.log("ditto");
  });
});
```

Effects aren't parented to their contexts by default anymore, and there is no autodisposal. It's pretty easy to achieve a similar effect:

```ts
import { signal, effect } from "@preact/signals-core";

effect((cleanup) => {
  cleanup(effect(() => {
    console.log("this effect will be autodisposed, sort of");
  }));
});
```

This version avoids autodisposal's "spooky action by distance" (accidentally binding an effect's lifetime to another one) by making the disposals explicit, while getting most of autodisposal's benefits. It also requires a bit less code 🙂