### PR TITLE
Remove Signal.prototype.toString

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -268,10 +268,6 @@ Signal.prototype.valueOf = function () {
 	return this.value;
 };
 
-Signal.prototype.toString = function () {
-	return this.value + "";
-};
-
 Signal.prototype.peek = function () {
 	return this._value;
 };

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -11,11 +11,6 @@ describe("signal", () => {
 		expect(signal(0)).to.be.instanceOf(Signal);
 	});
 
-	it("should support .toString()", () => {
-		const s = signal(123);
-		expect(s.toString()).equal("123");
-	});
-
 	it("should support .valueOf()", () => {
 		const s = signal(123);
 		expect(s).to.have.property("valueOf");


### PR DESCRIPTION
This pull request removes the Signal.prototype.toString method. This is based on discussion on the Preact Slack, where there was no 100% certainty for this change yet, so feel free to close this PR if toString is deemed necessary.