### PR TITLE
Add "sideEffects": false to core's package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
 	"unpkg": "dist/signals-core.min.js",
 	"types": "dist/signals-core.d.ts",
 	"source": "src/index.ts",
+	"sideEffects": false,
 	"exports": {
 		".": {
 			"types": "./dist/signals-core.d.ts",


### PR DESCRIPTION
This pull request add `"sideEffects": false` to the package.json of @preact/signal-core.