### PR TITLE
Fix "should allow disposing the effect multiple times" test

### DIFF
--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -434,7 +434,7 @@ describe("effect()", () => {
 	it("should allow disposing the effect multiple times", () => {
 		const dispose = effect(() => undefined);
 		dispose();
-		expect(() => dispose()).to.throw;
+		expect(() => dispose()).not.to.throw();
 	});
 
 	it("should allow disposing a running effect", () => {


### PR DESCRIPTION
This pull request fixes the test "should allow disposing the effect multiple times", spotted by @cevr. Luckily the test still passes, but now it at least does something 😀