### PR TITLE
Implement hooks without using hooks

### DIFF
--- a/docs/demos/animation/style.css
+++ b/docs/demos/animation/style.css
@@ -21,8 +21,7 @@
 	border: 2px solid #f00;
 	border-radius: 50%;
 	transform-origin: 50% 50%;
-	transition: all 250ms ease;
-	transition-property: width, height, margin;
+	transition: transform 250ms ease;
 	pointer-events: none;
 	overflow: hidden;
 	font-size: 9px;
@@ -35,9 +34,7 @@
 	}
 
 	&.big {
-		width: 24px;
-		height: 24px;
-		margin: -13px 0 0 -13px;
+		transform: scale(2);
 	}
 
 	& > .label {

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -90,10 +90,10 @@ function Text(this: AugmentedComponent, { data }: { data: Signal }) {
 	currentSignal.value = data;
 
 	const s = useComputed(() => {
-			let data = currentSignal.value;
-			let s = data.value;
-			return s === 0 ? 0 : s === true ? "" : s || "";
-		});
+		let data = currentSignal.value;
+		let s = data.value;
+		return s === 0 ? 0 : s === true ? "" : s || "";
+	});
 
 	return s.value;
 }
@@ -334,6 +334,9 @@ Component.prototype.shouldComponentUpdate = function (
 
 	// @ts-ignore
 	for (let i in state) return true;
+
+	// if no new props were received, this is a purely Signal component:
+	// if (props === this.props) return false;
 
 	// if any non-Signal props changed, update:
 	for (let i in props) {

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -1,11 +1,19 @@
 import { Component } from "preact";
-import { Signal } from "@preact/signals-core";
+import { ReadonlySignal, Signal } from "@preact/signals-core";
 
 export interface Effect {
 	_sources: object | undefined;
+	/** The effect's user-defined callback */
+	_compute(): void;
+	/** Begins an effectful read (returns the end() function) */
 	_start(): () => void;
+	/** Runs the effect */
 	_callback(): void;
 	_dispose(): void;
+}
+
+export interface Computed<T = any> extends ReadonlySignal<T> {
+	_compute: () => T;
 }
 
 export interface PropertyUpdater {
@@ -18,7 +26,12 @@ export interface AugmentedElement extends HTMLElement {
 }
 
 export interface AugmentedComponent extends Component<any, any> {
+	/** Component's most recent owner VNode */
 	__v: VNode;
+	/** _renderCallbacks */
+	__h: (() => void)[];
+	/** "mini-hooks" slots for useSignal/useComputed/useEffect */
+	_slots?: (Signal | Computed | Effect)[];
 	_updater?: Effect;
 	_updateFlags: number;
 }
@@ -44,7 +57,11 @@ export const enum OptionsTypes {
 }
 
 export interface OptionsType {
-	[OptionsTypes.HOOK](component: Component, index: number, type: number): void;
+	[OptionsTypes.HOOK](
+		component: AugmentedComponent,
+		index: number,
+		type: number
+	): void;
 	[OptionsTypes.DIFF](vnode: VNode): void;
 	[OptionsTypes.DIFFED](vnode: VNode): void;
 	[OptionsTypes.RENDER](vnode: VNode): void;


### PR DESCRIPTION
This PR reimplements `useSignal()`, `useComputed()` and `useEffect()` without using `preact/hooks`. This should offer some performance advantages, because the three hooks we provide can all be implemented using the same very simple "indexed slot" mechanism, effectively an inline implementation of the `useMemo` hook.

There are some possible drawbacks here though:  I don't know if this will mess up DevTools, and it's possible it would make Prefresh's job more difficult (though I also wonder if it gives Prefresh a useful way to differentiate between Signals and Hooks?).