### PR TITLE
Reuse computed signal dependency checks also for effects

### DIFF
--- a/.changeset/grumpy-experts-cover.md
+++ b/.changeset/grumpy-experts-cover.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Use the same tracking logic for both effects and computeds. This ensures that effects are only called whenever any of their dependencies changes. If they all stay the same, then the effect will not be invoked.


### PR DESCRIPTION
After the v1.2.0 update, effects didn't check whether their direct dependencies have actually changed before rerunning. For example in the following scenario the effect would run twice:

```ts
const s = signal(0);
const c = computed(() => {
  s.value;
  return 0;
});
effect(() => {
  console.log("effect running");
  c.value;
}); // Console: effect running

s.value = 1; // Console: effect running
```

This pull reuses the computed signal dependency checks for effects. It also adds tests specific to this feature, as well as tests tangentially related parts to effect & computed signal dependency checking.