### PR TITLE
Fix effect disposal when cleanup throws

### DIFF
--- a/.changeset/rare-bulldogs-sin.md
+++ b/.changeset/rare-bulldogs-sin.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Fix effect disposal when cleanup throws

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -556,6 +556,8 @@ function cleanupEffect(effect: Effect) {
 			cleanup();
 		} catch (err) {
 			effect._flags &= ~RUNNING;
+			effect._flags |= DISPOSED;
+			disposeEffect(effect);
 			throw err;
 		} finally {
 			evalContext = prevContext;
@@ -631,8 +633,8 @@ Effect.prototype._start = function () {
 	}
 	this._flags |= RUNNING;
 	this._flags &= ~DISPOSED;
-	prepareSources(this);
 	cleanupEffect(this);
+	prepareSources(this);
 
 	/*@__INLINE__**/ startBatch();
 	this._flags &= ~OUTDATED;

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -446,6 +446,8 @@ describe("effect()", () => {
 		expect(spy).not.to.be.called;
 		expect(() => a.value++).to.throw("hello");
 		expect(spy).not.to.be.called;
+		a.value++;
+		expect(spy).not.to.be.called;
 	});
 
 	it("should run cleanups outside any evaluation context", () => {


### PR DESCRIPTION
This pull request fixes the case when an effect cleanup throws. There was a test for this case, but it should have been more thorough. The test is stricter now as well.