### PR TITLE
Add more tests

### DIFF
--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -287,6 +287,28 @@ describe("effect()", () => {
 		expect(spy).not.to.be.called;
 	});
 
+	it("should not recompute dependencies unnecessarily", () => {
+		const spy = sinon.spy();
+		const a = signal(0);
+		const b = signal(0);
+		const c = computed(() => {
+			b.value;
+			spy();
+		});
+		effect(() => {
+			if (a.value === 0) {
+				c.value;
+			}
+		});
+		expect(spy).to.be.calledOnce;
+
+		batch(() => {
+			b.value = 1;
+			a.value = 1;
+		});
+		expect(spy).to.be.calledOnce;
+	});
+
 	it("should not recompute dependencies out of order", () => {
 		const a = signal(1);
 		const b = signal(1);
@@ -886,7 +908,7 @@ describe("computed()", () => {
 		expect(c.value).to.equal("ok");
 	});
 
-	it("should propagate invalidation even right after first subscription", () => {
+	it("should propagate notifications even right after first subscription", () => {
 		const a = signal(0);
 		const b = computed(() => a.value);
 		const c = computed(() => b.value);
@@ -902,6 +924,18 @@ describe("computed()", () => {
 
 		a.value = 1;
 		expect(spy).to.be.calledOnce;
+	});
+
+	it("should get marked as outdated right after first subscription", () => {
+		const s = signal(0);
+		const c = computed(() => s.value);
+		c.value;
+
+		s.value = 1;
+		effect(() => {
+			c.value;
+		});
+		expect(c.value).to.equal(1);
 	});
 
 	it("should not recompute dependencies out of order", () => {
@@ -937,6 +971,30 @@ describe("computed()", () => {
 		e.value;
 		expect(spy).not.to.be.called;
 		spy.resetHistory();
+	});
+
+	it("should not recompute dependencies unnecessarily", () => {
+		const spy = sinon.spy();
+		const a = signal(0);
+		const b = signal(0);
+		const c = computed(() => {
+			b.value;
+			spy();
+		});
+		const d = computed(() => {
+			if (a.value === 0) {
+				c.value;
+			}
+		});
+		d.value;
+		expect(spy).to.be.calledOnce;
+
+		batch(() => {
+			b.value = 1;
+			a.value = 1;
+		});
+		d.value;
+		expect(spy).to.be.calledOnce;
 	});
 
 	describe("graph updates", () => {


### PR DESCRIPTION
This pull request adds three new tests for Signals Core:

 * Test that an effects and computed signals don't force dependencies get recomputed unnecessarily.
 * Test computed signal behavior right after getting its first active subscriber.