### PR TITLE
Optimize dependency value change checks by allowing earlier exists from the loop

### DIFF
--- a/.changeset/tall-onions-deny.md
+++ b/.changeset/tall-onions-deny.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Optimize dependency value change checks by allowing earlier exists from the loop

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -324,9 +324,14 @@ function needsToRecompute(target: Computed | Effect): boolean {
 	// the first used dependency is re-evaluated at this point.
 	let node = target._sources;
 	while (node !== undefined) {
-		// If a dependency has something blocking it from refreshing (e.g. a dependency
-		// cycle) or there's a new version of the dependency, then we need to recompute.
-		if (!node._source._refresh() || node._source._version !== node._version) {
+		// If there's a new version of the dependency before or after refreshing,
+		// or the dependency has something blocking it from refreshing at all (e.g. a
+		// dependency cycle), then we need to recompute.
+		if (
+			node._source._version !== node._version ||
+			!node._source._refresh() ||
+			node._source._version !== node._version
+		) {
 			break;
 		}
 		node = node._nextSource;


### PR DESCRIPTION
This pull request modifies the dependency version change check used by computed & effect. Before the change each dependency's `._refresh()` was called before checking the dependency's version number. After this change the version number is checked first, then `._refresh()` is called, and then the version number is checked again. In practice this allows the dependency checks break the loop earlier, avoiding calls to `_refresh()` for a) plain signals that have changed and b) computed values that get repeated reads.

The following benchmark demonstrates the impact in a scenario that contains both a) and b):

```ts
import * as core from "@preact/signals-core";

const count = core.signal(0);
const double = core.computed(() => count.value * 2);
core.effect(() => double.value + count.value);
core.effect(() => double.value + count.value);
core.effect(() => double.value + count.value);

console.time("core");

for (let i = 0; i < 20000000; i++) {
count.value++;
double.value;
}

console.timeEnd("core");
```

The results before the change:
```
core: 2.616s
```

And after the change:
```
core: 2.196s
```