### PR TITLE
Dispose effects more thoroughly, add tests for computed() GC behavior

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,6 +25,7 @@ var localLaunchers = {
 			"--no-gpu",
 			// Without a remote debugging port, Google Chrome exits immediately.
 			"--remote-debugging-port=9333",
+			"--js-flags=--expose-gc",
 		],
 	},
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -579,6 +579,7 @@ function disposeEffect(effect: Effect) {
 	) {
 		node._source._unsubscribe(node);
 	}
+	effect._compute = undefined;
 	effect._sources = undefined;
 
 	cleanupEffect(effect);
@@ -599,7 +600,7 @@ function endEffect(this: Effect, prevContext?: Computed | Effect) {
 }
 
 declare class Effect {
-	_compute: () => unknown;
+	_compute?: () => unknown;
 	_cleanup?: unknown;
 	_sources?: Node;
 	_nextBatchedEffect?: Effect;
@@ -624,7 +625,7 @@ function Effect(this: Effect, compute: () => void) {
 Effect.prototype._callback = function () {
 	const finish = this._start();
 	try {
-		if (!(this._flags & DISPOSED)) {
+		if (!(this._flags & DISPOSED) && this._compute !== undefined) {
 			this._cleanup = this._compute();
 		}
 	} finally {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
+    "lib": ["ES2021.WeakRef"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
This pull request adds the following things:
 * Tests that computed signals are indeed garbage collectable when they have no listeners (either they never had or the listeners have been disposed).
 * Fix for effect disposal, releasing the effect function that may still hold a reference to the surrounding scope, and through that to a computed signal. I noticed this behavior after writing the second test.

Points that probably need special attention during review:
 * Modified Karma config to add `--js-flags=--expose-gc` to the Chromium launch arguments. This was done to enable forcing the garbage collection via `globals.gc`/`window.gc`. The tests are get skipped if `global.gc`/`window.gc` is not available, so that it's easier to run them in another contexts.
 * Added `"lib": ["ES2021.WeakRef"]` to tsconfig.json so that TS won't hilight WeakRef that's used in the tests.
 * I'm not 100% sure about the `gc(); await sleep(0);` (to paraphrase) cycle to force garbage collection. It does seem to work in my environment, but if someout out there has some advice whether this is appropriate and whether there are better ways to do this, I would gladly take it 🙂