### PR TITLE
Change mapping updaters to owners to map to the reducer, fixing not working in production

### DIFF
--- a/packages/react/src/internal.d.ts
+++ b/packages/react/src/internal.d.ts
@@ -7,10 +7,6 @@ export interface Effect {
 	_dispose(): void;
 }
 
-export interface ReactOwner {
-	_: never;
-}
-
 export interface ReactDispatcher {
 	useCallback(): unknown;
 }


### PR DESCRIPTION
As I mentioned in https://github.com/preactjs/signals/issues/155, tracking the current owner is unstable and doesn't work in production. I think the purpose of that was to keep a unique updater for each component. I found that can also be done by just using the rerender callback as the key for the map since it is consistent and unique to each component's render.

This change also changes the invalid hook check to just "Invalid" which works in React Native too (its hook warnings are slightly different).

The tests still pass, and this method is working well in Legend-State (https://github.com/LegendApp/legend-state/blob/main/src/react/enableLegendStateReact.ts#L70) in production and React Native.