### PR TITLE
Proposal: Multi-value Signal using bitmaps (bit arrays)

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -6,6 +6,7 @@ import {
 	batch,
 	effect,
 	Signal,
+	reader,
 	type ReadonlySignal,
 } from "@preact/signals-core";
 import {
@@ -18,7 +19,7 @@ import {
 	AugmentedElement as Element,
 } from "./internal";
 
-export { signal, computed, batch, effect, Signal, type ReadonlySignal };
+export { signal, computed, batch, effect, reader, Signal, type ReadonlySignal };
 
 const HAS_PENDING_UPDATE = 1 << 0;
 const HAS_HOOK_STATE = 1 << 1;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -13,11 +13,12 @@ import {
 	batch,
 	effect,
 	Signal,
+	reader,
 	type ReadonlySignal,
 } from "@preact/signals-core";
 import { Effect, ReactOwner, ReactDispatcher } from "./internal";
 
-export { signal, computed, batch, effect, Signal, type ReadonlySignal };
+export { signal, computed, batch, effect, Signal, reader, type ReadonlySignal };
 
 /**
  * Install a middleware into React.createElement to replace any Signals in props with their value.


### PR DESCRIPTION
Hi 👋, this is a PoC of #213 😄 (all tests still passing 😅)

# Description

The basic idea of this PR is demonstrate how Signals could be improved to keep track of multiple values (up to 32) using 1 single node to reduce memory footprint and possibly improve performance when multiple (related) values are accessed within a `computed` or `effect`.

In this PoC, assume a Signal can have - instead of value - properties `signal[0] (alias for signal.value)` to `signal[31]`. Just because numeric properties seem to be accessed faster than string properties (it could have been `signal.value0 .. signal.value31` but it's not relevant).

For every `get`, we keep track of the index - in a bit array - of the accessed property:
```ts
get(this: Signal) {
  // ...
  node._version = this._version;
  node._fields |= 1 << i; // i -> 0..31 -> signal[0]..signal[31]
  // ...
  return this._value[i];
}
```

And every `set` operation checks whether the node is watching the property whose value is changed:
```ts
set(this: Signal, value) {
  // ...
  this._value[i] = value; // i -> 0..31
  // ...
  if (node._fields & (1 << i)) node._target._notify(); // < Notify ONLY if property is watched
}
```

With this as base, we can create signals that have multiple values (up to 32) and create a lot less nodes if all the accessed properties within a `computed` belong to the same Signal, for example:

```ts
computed(() => signal[0] + signal[1] + signal[2]);
computed(() => signal[1] + signal[5] + signal[31]);
```

In this particular example, all properties in both `computed` belong to the same signal, so a single node should be created with bitmap set to `fields = (1 << 0) | (1 << 1) | (1 << 2)` (for the first). This means that, for example, if `value[0]` changes, then the second `computed` won't run even though both use the same signal.

Now, the DX is awkward so this PoC doesn't attempt to be a final version but rather to suggest creating an even lower primitive than Signal. A Signal could be an abstraction for this new primitive where it only uses one field `value[0]`.

An example for such abstraction is the `reader` function which I included in the code. Which allows creating signals in this manner:
```ts
const group = reader({
  foo: "",
  bar: "",
});
// group.foo;
// group.bar;
// group._signals = [Signal]
// group._size = 2;
```
( Please check the test cases for `reader` 😄 )

A Signal could look like:
```ts
function signal(value) {
  const s = reader({ value });
  s.peek = function() {
    return s._signals[0][0];
  }
}
```
Of course, this example is just an illustration since better optimizations can be made but I think it conveys the point 😅 

## But Why?

I want to create a factory which creates classes, sort of like this:
```ts
class User extends Factory({
  username: t.String(),
  // ... many other fields
}) {}
```
Where `t.String` is a config object which is converted to a property descriptor with getter/setter which _would_ use a signal. However, this consumes a lot of memory and it's (relatively) slow if multiple related properties are accessed within a `computed`.

I think this could be improved by using a single Signal to watch multiple related properties (well, up to 32). As in the `reader` PoC example, in one of the tests, you can see that 93 properties can be used with just 3 signals instead of defining 93 signals.

My implementation is just a PoC, at its current state I just hope to spawn some discussion around this if it's interesting enough to move forward within preact/signals (Please check the new test cases).

I think this could also be interesting for #4 . I don't think all this logic should belong to `Signal` 😅 to be honest, it was just easier to implement it there for a PoC PR.