### PR TITLE
Allow Customizing Diff Logic (via new `shouldUpdate` method)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"esbuild": "^0.14.54",
 		"eslint": "^8.21.0",
 		"eslint-config-prettier": "^8.5.0",
+		"fast-deep-equal": "^3.1.3",
 		"husky": "^8.0.1",
 		"karma": "6.3.16",
 		"karma-chai-sinon": "^0.1.5",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,6 +206,9 @@ declare class Signal<T = any> {
 
 	peek(): T;
 
+	/** if true, triggers an update with the new incoming value */
+	shouldUpdate(oldValue: T, newValue: T): boolean;
+
 	get value(): T;
 	set value(value: T);
 }
@@ -280,6 +283,10 @@ Signal.prototype.peek = function () {
 	return this._value;
 };
 
+Signal.prototype.shouldUpdate = (oldValue, newValue) => {
+	return newValue !== oldValue;
+};
+
 Object.defineProperty(Signal.prototype, "value", {
 	get() {
 		const node = addDependency(this);
@@ -289,7 +296,9 @@ Object.defineProperty(Signal.prototype, "value", {
 		return this._value;
 	},
 	set(value) {
-		if (value !== this._value) {
+		const shouldUpdate = this.shouldUpdate(this._value, value);
+
+		if (shouldUpdate) {
 			if (batchIteration > 100) {
 				cycleDetected();
 			}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ importers:
       esbuild: ^0.14.54
       eslint: ^8.21.0
       eslint-config-prettier: ^8.5.0
+      fast-deep-equal: ^3.1.3
       husky: ^8.0.1
       karma: 6.3.16
       karma-chai-sinon: ^0.1.5
@@ -75,6 +76,7 @@ importers:
       esbuild: 0.14.54
       eslint: 8.21.0
       eslint-config-prettier: 8.5.0_eslint@8.21.0
+      fast-deep-equal: 3.1.3
       husky: 8.0.1
       karma: 6.3.16
       karma-chai-sinon: 0.1.5_4327255nuu22k6utwpuk2rzg54


### PR DESCRIPTION
This PR provides a way to (optionally) customize how incoming values are evaluated (ie. has this value _actually_ changed) via the new `shouldUpdate` method; a very similar use case to #103 that I also ran into!

Also adds a new test to demonstrate before vs after behavior + a tiny usage example.