### PR TITLE
React: Replace useReducer with useSyncExternalStore

### DIFF
--- a/.changeset/brown-wombats-brush.md
+++ b/.changeset/brown-wombats-brush.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": minor
+---
+
+Replace useReducer with useSyncExternalStore

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,18 +38,17 @@
 		"prepublishOnly": "cd ../.. && pnpm build:react"
 	},
 	"dependencies": {
-		"@preact/signals-core": "workspace:^1.2.1"
+		"@preact/signals-core": "workspace:^1.2.1",
+		"use-sync-external-store": "^1.2.0"
 	},
 	"peerDependencies": {
-		"react": "17.x || 18.x",
-		"use-sync-external-store": "^1.2.0"
+		"react": "17.x || 18.x"
 	},
 	"devDependencies": {
 		"@types/react": "^18.0.18",
 		"@types/react-dom": "^18.0.6",
 		"@types/use-sync-external-store": "^0.0.3",
 		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
-		"use-sync-external-store": "^1.2.0"
+		"react-dom": "^18.2.0"
 	}
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,12 +41,15 @@
 		"@preact/signals-core": "workspace:^1.2.1"
 	},
 	"peerDependencies": {
-		"react": "17.x || 18.x"
+		"react": "17.x || 18.x",
+		"use-sync-external-store": "^1.2.0"
 	},
 	"devDependencies": {
+		"@types/react": "^18.0.18",
+		"@types/react-dom": "^18.0.6",
+		"@types/use-sync-external-store": "^0.0.3",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"@types/react": "^18.0.18",
-		"@types/react-dom": "^18.0.6"
+		"use-sync-external-store": "^1.2.0"
 	}
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@ import {
 	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as internals,
 } from "react";
 import React from "react";
+import {useSyncExternalStore} from "use-sync-external-store/shim"
 import {
 	signal,
 	computed,
@@ -75,7 +76,7 @@ function setCurrentUpdater(updater?: Effect) {
  *
  * [1]
  * @see https://reactjs.org/docs/hooks-reference.html#usesyncexternalstore
- * @see https://github.com/reactwg/react-18/discussions/86
+ * @see https://github.com/reactjs/rfcs/blob/main/text/0214-use-sync-external-store.md
  */
 function createEffectStore() {
 	let updater!: Effect;
@@ -140,7 +141,7 @@ Object.defineProperty(internals.ReactCurrentDispatcher, "current", {
 
 			const store = api.useMemo(createEffectStore, Empty);
 
-			api.useSyncExternalStore(
+			useSyncExternalStore(
 				store.subscribe,
 				store.getSnapshot,
 				store.getSnapshot

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,7 +20,7 @@ import { Effect, ReactDispatcher } from "./internal";
 
 export { signal, computed, batch, effect, Signal, type ReadonlySignal };
 
-const Empty = Object.freeze([]);
+const Empty = [] as const;
 
 /**
  * React uses a different entry-point depending on NODE_ENV env var
@@ -91,7 +91,6 @@ function createEffectStore() {
 	const unsubscribe = effect(function (this: Effect) {
 		updater = this;
 	});
-
 
 	updater._callback = function () {
 		if (!onChangeNotifyReact) {

--- a/packages/react/src/internal.d.ts
+++ b/packages/react/src/internal.d.ts
@@ -1,4 +1,5 @@
 import { Signal } from "@preact/signals-core";
+import type { useCallback, useMemo, useSyncExternalStore } from "react"
 
 export interface Effect {
 	_sources: object | undefined;
@@ -8,7 +9,9 @@ export interface Effect {
 }
 
 export interface ReactDispatcher {
-	useCallback(): unknown;
+	useCallback: typeof useCallback;
+	useMemo: typeof useMemo;
+	useSyncExternalStore: typeof useSyncExternalStore;
 }
 
 export type Updater = Signal<unknown>;

--- a/packages/react/src/internal.d.ts
+++ b/packages/react/src/internal.d.ts
@@ -1,5 +1,4 @@
 import { Signal } from "@preact/signals-core";
-import type { useCallback, useMemo, useSyncExternalStore } from "react"
 
 export interface Effect {
 	_sources: object | undefined;
@@ -8,10 +7,10 @@ export interface Effect {
 	_dispose(): void;
 }
 
-export interface ReactDispatcher {
-	useCallback: typeof useCallback;
-	useMemo: typeof useMemo;
-	useSyncExternalStore: typeof useSyncExternalStore;
-}
-
 export type Updater = Signal<unknown>;
+
+export interface JsxRuntimeModule {
+	jsx?(type: any, ...rest: any[]): unknown;
+	jsxs?(type: any, ...rest: any[]): unknown;
+	jsxDEV?(type: any, ...rest: any[]): unknown;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,15 +150,19 @@ importers:
       '@preact/signals-core': workspace:^1.2.1
       '@types/react': ^18.0.18
       '@types/react-dom': ^18.0.6
+      '@types/use-sync-external-store': ^0.0.3
       react: ^18.2.0
       react-dom: ^18.2.0
+      use-sync-external-store: ^1.2.0
     dependencies:
       '@preact/signals-core': link:../core
     devDependencies:
       '@types/react': 18.0.18
       '@types/react-dom': 18.0.6
+      '@types/use-sync-external-store': 0.0.3
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
 
 packages:
 
@@ -2287,6 +2291,10 @@ packages:
 
   /@types/sinonjs__fake-timers/8.1.2:
     resolution: {integrity: sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==}
+    dev: true
+
+  /@types/use-sync-external-store/0.0.3:
+    resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
     dev: true
 
   /@typescript-eslint/eslint-plugin/5.33.0_njno5y7ry2l2lcmiu4tywxkwnq:
@@ -7170,6 +7178,14 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
+    dev: true
+
+  /use-sync-external-store/1.2.0_react@18.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
     dev: true
 
   /util-deprecate/1.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,13 +156,13 @@ importers:
       use-sync-external-store: ^1.2.0
     dependencies:
       '@preact/signals-core': link:../core
+      use-sync-external-store: 1.2.0_react@18.2.0
     devDependencies:
       '@types/react': 18.0.18
       '@types/react-dom': 18.0.6
       '@types/use-sync-external-store': 0.0.3
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      use-sync-external-store: 1.2.0_react@18.2.0
 
 packages:
 
@@ -7186,7 +7186,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
-    dev: true
+    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}


### PR DESCRIPTION
From Preact Slack discussion 😄 

# Description

`useSyncExternalStore` is the suggested way by React to subscribe to state that lives outside of React which is compatible with their concurrent mode and time-slicing features.

This PR also removes the need to track current owner because hooks run in the context of the current owner so there is no need to really do it. Please check the comments in the code.