### PR TITLE
Fix hook names being mangled

### DIFF
--- a/.changeset/funny-geese-hear.md
+++ b/.changeset/funny-geese-hear.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals": patch
+"@preact/signals-react": patch
+---
+
+Fix hook names being mangled

--- a/mangle.json
+++ b/mangle.json
@@ -5,6 +5,11 @@
   },
   "minify": {
     "mangle": {
+      "reserved": [
+        "useSignal",
+        "useComputed",
+        "useSignalEffect"
+      ],
       "keep_classnames": true,
       "properties": {
         "regex": "^_[^_]",


### PR DESCRIPTION
Before:

<img width="250" alt="Screenshot 2022-10-01 at 04 52 49" src="https://user-images.githubusercontent.com/1062408/193382850-398c42e7-3cba-4c99-870e-884cd22532f2.png">

After:

<img width="236" alt="Screenshot 2022-10-01 at 04 54 15" src="https://user-images.githubusercontent.com/1062408/193382895-ae97aa7c-4419-4048-bf69-fb9f76125bef.png">
