### PR TITLE
Disallow side-effects in computed

### DIFF
--- a/.changeset/happy-pants-rhyme.md
+++ b/.changeset/happy-pants-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": minor
+---
+
+Disallow side-effects in computed

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,9 +13,6 @@ const DISPOSED = 1 << 3;
 const HAS_ERROR = 1 << 4;
 const TRACKING = 1 << 5;
 
-// Flags that identify the kind of Signal
-const COMPUTED_KIND = 1 << 6;
-
 // Flags for Nodes.
 const NODE_FREE = 1 << 0;
 const NODE_SUBSCRIBED = 1 << 1;
@@ -291,7 +288,7 @@ Object.defineProperty(Signal.prototype, "value", {
 		return this._value;
 	},
 	set(this: Signal, value) {
-		if (evalContext && evalContext._flags & COMPUTED_KIND) {
+		if (evalContext instanceof Computed) {
 			mutationDetected();
 		}
 
@@ -412,7 +409,7 @@ function Computed(this: Computed, compute: () => unknown) {
 	this._compute = compute;
 	this._sources = undefined;
 	this._globalVersion = globalVersion - 1;
-	this._flags = OUTDATED | COMPUTED_KIND;
+	this._flags = OUTDATED;
 }
 
 Computed.prototype = new Signal() as Computed;

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -827,16 +827,13 @@ describe("computed()", () => {
 		expect(spy).to.be.calledOnce;
 	});
 
-	it("should recompute if a dependency changes during computation after becoming a dependency", () => {
-		const a = signal(0);
-		const spy = sinon.spy(() => {
-			a.value++;
-		});
-		const c = computed(spy);
-		c.value;
-		expect(spy).to.be.calledOnce;
-		c.value;
-		expect(spy).to.be.calledTwice;
+	it("should disallow setting signal's value", () => {
+		const v: number = 123;
+		const a: Signal = signal(v);
+		const c: Signal = computed(() => a.value++);
+
+		expect(() => c.value).to.throw(/Computed cannot have side-effects/);
+		expect(a.value).to.equal(v);
 	});
 
 	it("should detect simple dependency cycles", () => {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -524,7 +524,7 @@ describe("effect()", () => {
 		expect(fn).to.throw(/Cycle detected/);
 	});
 
-	it("should throw on indirect cycles", () => {
+	it("should throw if a computed tries to set a signal's value", () => {
 		const a = signal(0);
 		let i = 0;
 
@@ -543,7 +543,7 @@ describe("effect()", () => {
 				c.value;
 			});
 
-		expect(fn).to.throw(/Cycle detected/);
+		expect(fn).to.throw(/Computed cannot have side-effects/);
 	});
 
 	it("should allow disposing the effect multiple times", () => {


### PR DESCRIPTION
# Description

From Slack discussion, this PR disallows side-effects in `computed`. That is, setting signal's values:
```ts
const c = computed(() => a.value++)
```

I used a bit flag instead of `instanceof` operator because it's faster to check if a bit is set than walking the prototype to lookup for a constructor. I initially thought to add a new `_type` property to Signal but it also seems a waste of space/memory if it's only used to check if a Signal is a computed type.