### PR TITLE
Simplify effect change checking (and make effect cycle detection more accurate as a side-effect)

### DIFF
--- a/.changeset/pretty-students-look.md
+++ b/.changeset/pretty-students-look.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Simplify effect change checking (and make effect cycle detection more accurate as a side-effect)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,11 +66,7 @@ function endBatch() {
 			effect._nextBatchedEffect = undefined;
 			effect._flags &= ~NOTIFIED;
 
-			if (
-				!(effect._flags & DISPOSED) &&
-				effect._flags & OUTDATED &&
-				needsToRecompute(effect)
-			) {
+			if (!(effect._flags & DISPOSED) && needsToRecompute(effect)) {
 				try {
 					effect._callback();
 				} catch (err) {
@@ -619,7 +615,7 @@ function Effect(this: Effect, compute: () => void) {
 	this._cleanup = undefined;
 	this._sources = undefined;
 	this._nextBatchedEffect = undefined;
-	this._flags = OUTDATED | TRACKING;
+	this._flags = TRACKING;
 }
 
 Effect.prototype._callback = function () {
@@ -643,7 +639,6 @@ Effect.prototype._start = function () {
 	prepareSources(this);
 
 	/*@__INLINE__**/ startBatch();
-	this._flags &= ~OUTDATED;
 	const prevContext = evalContext;
 	evalContext = this;
 	return endEffect.bind(this, prevContext);
@@ -651,7 +646,7 @@ Effect.prototype._start = function () {
 
 Effect.prototype._notify = function () {
 	if (!(this._flags & NOTIFIED)) {
-		this._flags |= NOTIFIED | OUTDATED;
+		this._flags |= NOTIFIED;
 		this._nextBatchedEffect = batchedEffect;
 		batchedEffect = this;
 	}

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -524,6 +524,28 @@ describe("effect()", () => {
 		expect(fn).to.throw(/Cycle detected/);
 	});
 
+	it("should throw on indirect cycles", () => {
+		const a = signal(0);
+		let i = 0;
+
+		const c = computed(() => {
+			a.value;
+			a.value = NaN;
+			return NaN;
+		});
+
+		const fn = () =>
+			effect(() => {
+				// Prevent test suite from spinning if limit is not hit
+				if (i++ > 200) {
+					throw new Error("test failed");
+				}
+				c.value;
+			});
+
+		expect(fn).to.throw(/Cycle detected/);
+	});
+
 	it("should allow disposing the effect multiple times", () => {
 		const dispose = effect(() => undefined);
 		dispose();


### PR DESCRIPTION
This pull request simplifies effect change checking by removing the OUTDATED flag usage from effects. The flag itself can't be completely removed from the codebase, as computed signals still use it. Still, there are some delicious byte size savings gained from this change.

The OUTDATED flag became unnecessary after the changes introduced in #205.

As a nice side-effect the effect cycle detection is now more accurate. There is a new test case for that. The test case does collide with #231, and should be removed if/when that pull request is merged. The code simplifications are still valid regardless.