### PR TITLE
React: Fix ERR_UNSUPPORTED_DIR_IMPORT when importing `use-sync-external-store/shim` #237

### DIFF
--- a/.changeset/strange-beans-attend.md
+++ b/.changeset/strange-beans-attend.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+Fix ERR_UNSUPPORTED_DIR_IMPORT error when importing `use-sync-external-store/shim` from ESM build

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,7 +8,7 @@ import {
 import React from "react";
 import jsxRuntime from "react/jsx-runtime";
 import jsxRuntimeDev from "react/jsx-dev-runtime";
-import { useSyncExternalStore } from "use-sync-external-store/shim";
+import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
 import {
 	signal,
 	computed,


### PR DESCRIPTION
# Description

Importing the `use-sync-external-store/shim` from the `signals.mjs` fails with `ERR_UNSUPPORTED_DIR_IMPORT` because the shim doesn't have an `exports` map in `package.json` so it needs to be imported explicitly including the `/index.js` file.

Resolves #237 

Tested by installing `@preact/signals-react: 1.2.0` and manually modifying the dist `signals.mjs` import 😛 