### PR TITLE
Use WeakMap to hold proxy map in react

### DIFF
--- a/.changeset/breezy-ants-trade.md
+++ b/.changeset/breezy-ants-trade.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+Replace `Map` useage with `WeakMap`

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,7 +24,7 @@ export { signal, computed, batch, effect, Signal, type ReadonlySignal };
 const Empty = [] as const;
 const ReactElemType = Symbol.for("react.element"); // https://github.com/facebook/react/blob/346c7d4c43a0717302d446da9e7423a8e28d8996/packages/shared/ReactSymbols.js#L15
 const ReactMemoType = Symbol.for("react.memo"); // https://github.com/facebook/react/blob/346c7d4c43a0717302d446da9e7423a8e28d8996/packages/shared/ReactSymbols.js#L30
-const ProxyInstance = new Map<FunctionComponent<any>, FunctionComponent<any>>();
+const ProxyInstance = new WeakMap<FunctionComponent<any>, FunctionComponent<any>>();
 const SupportsProxy = typeof Proxy === "function";
 
 const ProxyHandlers = {


### PR DESCRIPTION
A Regular `Map` is being used to hold a map of proxied components , this can lead to unbounded memory leaks if for example a component is created within another.

ie:

```
function OutterComponent(props) {
   function InnerComponent(props) {...}

   return <InnerComponent />
}

```

Leads to a new entry in the map on each render of `OutterComponent` with no way to collect. `WeakMap` should do the trick here.