### PR TITLE
Support forwardRef in @preact/signals-react

### DIFF
--- a/.changeset/thin-coats-wash.md
+++ b/.changeset/thin-coats-wash.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+Support forwardRef in @preact/signals-react

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,6 +24,7 @@ export { signal, computed, batch, effect, Signal, type ReadonlySignal };
 const Empty = [] as const;
 const ReactElemType = Symbol.for("react.element"); // https://github.com/facebook/react/blob/346c7d4c43a0717302d446da9e7423a8e28d8996/packages/shared/ReactSymbols.js#L15
 const ReactMemoType = Symbol.for("react.memo"); // https://github.com/facebook/react/blob/346c7d4c43a0717302d446da9e7423a8e28d8996/packages/shared/ReactSymbols.js#L30
+const ReactForwardRefType = Symbol.for("react.forward_ref"); // https://github.com/facebook/react/blob/346c7d4c43a0717302d446da9e7423a8e28d8996/packages/shared/ReactSymbols.js#L25
 const ProxyInstance = new WeakMap<FunctionComponent<any>, FunctionComponent<any>>();
 const SupportsProxy = typeof Proxy === "function";
 
@@ -158,9 +159,14 @@ function WrapJsx<T>(jsx: T): T {
 			return jsx.call(jsx, ProxyFunctionalComponent(type), props, ...rest);
 		}
 
-		if (type && typeof type === "object" && type.$$typeof === ReactMemoType) {
-			type.type = ProxyFunctionalComponent(type.type);
-			return jsx.call(jsx, type, props, ...rest);
+		if (type && typeof type === "object") {
+			if (type.$$typeof === ReactMemoType) {
+				type.type = ProxyFunctionalComponent(type.type);
+				return jsx.call(jsx, type, props, ...rest);
+			} else if (type.$$typeof === ReactForwardRefType) {
+				type.render = ProxyFunctionalComponent(type.render);
+				return jsx.call(jsx, type, props, ...rest);
+			}
 		}
 
 		if (typeof type === "string" && props) {

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -2,7 +2,7 @@
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 import { signal, useComputed } from "@preact/signals-react";
-import { createElement, useMemo, memo, StrictMode } from "react";
+import { createElement, forwardRef, memo, StrictMode, useMemo } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { act } from "react-dom/test-utils";
@@ -149,6 +149,26 @@ describe("@preact/signals-react", () => {
 			function App() {
 				sig.value;
 				return useMemo(() => <Inner foo={1} />, []);
+			}
+
+			render(<App />);
+			expect(scratch.textContent).to.equal("foo");
+
+			act(() => {
+				sig.value = "bar";
+			});
+			expect(scratch.textContent).to.equal("bar");
+		});
+
+		it("should update forwardRef'ed component via signals", async () => {
+			const sig = signal("foo");
+
+			const Inner = forwardRef(() => {
+				return <p>{sig.value}</p>;
+			});
+
+			function App() {
+				return <Inner />;
 			}
 
 			render(<App />);


### PR DESCRIPTION
The latest version of @preact/signals-react not work with forwardRef when use with `{xxx.value}`.
This is the demo({count} works, but {count.value} not):
https://codesandbox.io/s/preact-signals-react-forwardref-not-work-k5pcry?file=/src/App.js

This PR fixes this.