### PR TITLE
Add typing for effect cleanup

### DIFF
--- a/.changeset/polite-ghosts-yell.md
+++ b/.changeset/polite-ghosts-yell.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Add typing for effect cleanup

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -582,13 +582,13 @@ function endEffect(this: Effect, prevContext?: Computed | Effect) {
 }
 
 declare class Effect {
-	_compute?: () => unknown;
-	_cleanup?: unknown;
+	_compute?: () => void | (() => void);
+	_cleanup?: () => void;
 	_sources?: Node;
 	_nextBatchedEffect?: Effect;
 	_flags: number;
 
-	constructor(compute: () => void);
+	constructor(compute: () => void | (() => void));
 
 	_callback(): void;
 	_start(): () => void;
@@ -596,7 +596,7 @@ declare class Effect {
 	_dispose(): void;
 }
 
-function Effect(this: Effect, compute: () => void) {
+function Effect(this: Effect, compute: () => void | (() => void)) {
 	this._compute = compute;
 	this._cleanup = undefined;
 	this._sources = undefined;
@@ -607,8 +607,12 @@ function Effect(this: Effect, compute: () => void) {
 Effect.prototype._callback = function () {
 	const finish = this._start();
 	try {
-		if (!(this._flags & DISPOSED) && this._compute !== undefined) {
-			this._cleanup = this._compute();
+		if (this._flags & DISPOSED) return;
+		if (this._compute === undefined) return;
+
+		const cleanup = this._compute();
+		if (typeof cleanup === "function") {
+			this._cleanup = cleanup;
 		}
 	} finally {
 		finish();
@@ -646,7 +650,7 @@ Effect.prototype._dispose = function () {
 	}
 };
 
-function effect(compute: () => unknown): () => void {
+function effect(compute: () => void | (() => void)): () => void {
 	const effect = new Effect(compute);
 	try {
 		effect._callback();

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -348,7 +348,7 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 
 	useEffect(() => {
 		return effect(() => {
-			callback.current();
+			return callback.current();
 		});
 	}, []);
 }


### PR DESCRIPTION
The `effect` function signature is changed in order to more closely match the `useSignalEffect` signature, and also remove the ambiguity of the `unknown` typing.

Edit: useSignalEffect cleanup was resolved in #282