### PR TITLE
Fix typos and other small changes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -163,7 +163,7 @@ declare class Signal<T = any> {
 
 	/** @internal
 	 * Version numbers should always be >= 0, because the special value -1 is used
-	 * by Nodes to signify potentially unused but recyclable notes.
+	 * by Nodes to signify potentially unused but recyclable nodes.
 	 */
 	_version: number;
 

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -129,7 +129,7 @@ describe("signal", () => {
 			expect(spy).not.to.be.called;
 		});
 
-		it("should not cause surrounding effect subscribe to changes to a signal accessed in the callback", () => {
+		it("should not cause surrounding effect to subscribe to changes to a signal accessed in the callback", () => {
 			const spy = sinon.spy();
 			const a = signal(0);
 			const b = signal(0);
@@ -663,7 +663,7 @@ describe("effect()", () => {
 			expect(newSpy).to.be.called;
 		});
 
-		it("should returns a function for closing the effect scope from _start", () => {
+		it("should return a function for closing the effect scope from _start", () => {
 			const s = signal(0);
 
 			let e: any;
@@ -749,7 +749,7 @@ describe("effect()", () => {
 			spy.resetHistory();
 
 			e._dispose();
-			s.value = 2;
+			s.value = 3;
 			expect(spy).not.to.be.called;
 		});
 
@@ -849,7 +849,7 @@ describe("computed()", () => {
 		expect(spy).to.be.calledTwice;
 	});
 
-	it("should computed only when dependency has changed at some point", () => {
+	it("should be computed only when a dependency has changed at some point", () => {
 		const a = signal("a");
 		const spy = sinon.spy(() => {
 			return a.value;
@@ -1193,7 +1193,7 @@ describe("computed()", () => {
 			expect(spy).not.to.be.called;
 		});
 
-		it("should not subscribe a surrounding computed depend on peeked computed's dependencies", () => {
+		it("should not make surrounding computed depend on peeked computed's dependencies", () => {
 			const a = signal(1);
 			const b = computed(() => a.value);
 			const spy = sinon.spy();
@@ -1449,7 +1449,7 @@ describe("computed()", () => {
 		});
 
 		it("should only subscribe to signals listened to", () => {
-			// Here both "B" and "C" are active in the beginnning, but
+			// Here both "B" and "C" are active in the beginning, but
 			// "B" becomes inactive later. At that point it should
 			// not receive any updates anymore.
 			//    *A
@@ -1621,7 +1621,7 @@ describe("batch/transaction", () => {
 		expect(batch(() => 1)).to.equal(1);
 	});
 
-	it("should throw errors throws from the callback", () => {
+	it("should throw errors thrown from the callback", () => {
 		expect(() =>
 			batch(() => {
 				throw Error("hello");


### PR DESCRIPTION
Mainly typo fixes, but also made a change to [this test](https://github.com/preactjs/signals/blob/main/packages/core/test/signal.test.tsx#L752). I noticed that setting `s.value = 2;` after `e._dispose();` wasn't actually testing if the dispose function worked because the value of `s` was already 2 at that point. I verified this by commenting out the `e._dispose();` line and the tests still passed. So I changed that line to `s.value = 3;` which now makes the test only pass if `e._dispose();` is called.

Also, I edited a part of [one of the test diagrams](https://github.com/preactjs/signals/blob/main/packages/core/test/signal.test.tsx#L1457) from `D <- we don't listen to C` to `D <- we don't listen to D`, but I wasn't sure if that diagram should actually be changed more. I noticed that the diagram was probably copied from the test above it and maybe that note of `we don't listen to D` should actually be removed because we actually do listen to `D` in parts of that test. Or maybe it could be changed to `D <- the event never listens to C`, since it's the event that tracks the changes we are testing. But I wasn't sure the best way to change it other than just fixing the `C` to `D` typo. If you want me to update this PR with an alternative correction for that diagram, let me know.