### PR TITLE
Performance improvement: Preserve order of sources

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,18 +110,32 @@ function addDependency(signal: Signal): Node | undefined {
 
 	let node = signal._node;
 	if (node === undefined || node._target !== evalContext) {
-		// `signal` is a new dependency. Create a new node dependency node, move it
-		//  to the front of the current context's dependency list.
+		/**
+		 * `signal` is a new dependency. Create a new dependency node, and set it
+		 * as the tail of the current context's dependency list. e.g:
+		 *
+		 * { A <-> B       }
+		 *         ↑     ↑
+		 *        tail  node (new)
+		 *               ↓
+		 * { A <-> B <-> C }
+		 *               ↑
+		 *              tail (evalContext._sources)
+		 */
 		node = {
 			_version: 0,
 			_source: signal,
-			_prevSource: undefined,
-			_nextSource: evalContext._sources,
+			_prevSource: evalContext._sources,
+			_nextSource: undefined,
 			_target: evalContext,
 			_prevTarget: undefined,
 			_nextTarget: undefined,
 			_rollbackNode: node,
 		};
+
+		if (evalContext._sources !== undefined) {
+			evalContext._sources._nextSource = node;
+		}
 		evalContext._sources = node;
 		signal._node = node;
 
@@ -135,18 +149,30 @@ function addDependency(signal: Signal): Node | undefined {
 		// `signal` is an existing dependency from a previous evaluation. Reuse it.
 		node._version = 0;
 
-		// If `node` is not already the current head of the dependency list (i.e.
-		// there is a previous node in the list), then make `node` the new head.
-		if (node._prevSource !== undefined) {
-			node._prevSource._nextSource = node._nextSource;
-			if (node._nextSource !== undefined) {
-				node._nextSource._prevSource = node._prevSource;
+		/**
+		 * If `node` is not already the current tail of the dependency list (i.e.
+		 * there is a next node in the list), then make the `node` the new tail. e.g:
+		 *
+		 * { A <-> B <-> C <-> D }
+		 *         ↑           ↑
+		 *        node   ┌─── tail (evalContext._sources)
+		 *         └─────│─────┐
+		 *               ↓     ↓
+		 * { A <-> C <-> D <-> B }
+		 *                     ↑
+		 *                    tail (evalContext._sources)
+		 */
+		if (node._nextSource !== undefined) {
+			node._nextSource._prevSource = node._prevSource;
+
+			if (node._prevSource !== undefined) {
+				node._prevSource._nextSource = node._nextSource;
 			}
-			node._prevSource = undefined;
-			node._nextSource = evalContext._sources;
-			// evalCotext._sources must be !== undefined (and !== node), because
-			// `node` was originally pointing to some previous node.
-			evalContext._sources!._prevSource = node;
+
+			node._prevSource = evalContext._sources;
+			node._nextSource = undefined;
+
+			evalContext._sources!._nextSource = node;
 			evalContext._sources = node;
 		}
 
@@ -161,7 +187,8 @@ declare class Signal<T = any> {
 	/** @internal */
 	_value: unknown;
 
-	/** @internal
+	/**
+	 * @internal
 	 * Version numbers should always be >= 0, because the special value -1 is used
 	 * by Nodes to signify potentially unused but recyclable notes.
 	 */
@@ -318,12 +345,24 @@ function needsToRecompute(target: Computed | Effect): boolean {
 			return true;
 		}
 	}
-	// If none of the dependencies have changed values since last recompute then the
+	// If none of the dependencies have changed values since last recompute then
 	// there's no need to recompute.
 	return false;
 }
 
 function prepareSources(target: Computed | Effect) {
+	/**
+	 * 1. Mark all current sources as re-usable nodes (version: -1)
+	 * 2. Set a rollback node if the current node is being used in a different context
+	 * 3. Point 'target._sources' to the tail of the doubly-linked list, e.g:
+	 *
+	 *    { undefined <- A <-> B <-> C -> undefined }
+	 *                   ↑           ↑
+	 *                   │           └──────┐
+	 * target._sources = A; (node is head)  │
+	 *                   ↓                  │
+	 * target._sources = C; (node is tail) ─┘
+	 */
 	for (
 		let node = target._sources;
 		node !== undefined;
@@ -335,39 +374,66 @@ function prepareSources(target: Computed | Effect) {
 		}
 		node._source._node = node;
 		node._version = -1;
+
+		if (node._nextSource === undefined) {
+			target._sources = node;
+			break;
+		}
 	}
 }
 
 function cleanupSources(target: Computed | Effect) {
-	// At this point target._sources is a mishmash of current & former dependencies.
-	// The current dependencies are also in a reverse order of use.
-	// Therefore build a new, reverted list of dependencies containing only the current
-	// dependencies in a proper order of use.
-	// Drop former dependencies from the list and unsubscribe from their change notifications.
-
 	let node = target._sources;
-	let sources = undefined;
+	let head = undefined;
+
+	/**
+	 * At this point 'target._sources' points to the tail of the doubly-linked list.
+	 * It contains all existing sources + new sources in order of use.
+	 * Iterate backwards until we find the head node while dropping old dependencies.
+	 */
 	while (node !== undefined) {
-		const next = node._nextSource;
+		const prev = node._prevSource;
+
+		/**
+		 * The node was not re-used, unsubscribe from its change notifications and remove itself
+		 * from the doubly-linked list. e.g:
+		 *
+		 * { A <-> B <-> C }
+		 *         ↓
+		 *    { A <-> C }
+		 */
 		if (node._version === -1) {
 			node._source._unsubscribe(node);
-			node._nextSource = undefined;
-		} else {
-			if (sources !== undefined) {
-				sources._prevSource = node;
+
+			if (prev !== undefined) {
+				prev._nextSource = node._nextSource;
 			}
-			node._prevSource = undefined;
-			node._nextSource = sources;
-			sources = node;
+			if (node._nextSource !== undefined) {
+				node._nextSource._prevSource = prev;
+			}
+		} else {
+			/**
+			 * The new head is the last node seen which wasn't removed/unsubscribed
+			 * from the doubly-linked list. e.g:
+			 *
+			 * { A <-> B <-> C }
+			 *   ↑     ↑     ↑
+			 *   │     │     └ head = node
+			 *   │     └ head = node
+			 *   └ head = node
+			 */
+			head = node;
 		}
 
 		node._source._node = node._rollbackNode;
 		if (node._rollbackNode !== undefined) {
 			node._rollbackNode = undefined;
 		}
-		node = next;
+
+		node = prev;
 	}
-	target._sources = sources;
+
+	target._sources = head;
 }
 
 declare class Computed<T = any> extends Signal<T> {
@@ -414,7 +480,7 @@ Computed.prototype._refresh = function () {
 	this._globalVersion = globalVersion;
 
 	// Mark this computed signal running before checking the dependencies for value
-	// changes, so that the RUNNIN flag can be used to notice cyclical dependencies.
+	// changes, so that the RUNNING flag can be used to notice cyclical dependencies.
 	this._flags |= RUNNING;
 	if (this._version > 0 && !needsToRecompute(this)) {
 		this._flags &= ~RUNNING;


### PR DESCRIPTION
# Description

Currently, the dependencies are in reverse order of use when it needs to do the `cleanupSources`. There is quite some time spent doing so.

While doing some experiments on a project on mine I found out that it'd perform faster if the dependencies order didn't need to be built in reverse order. The way to achieve this is by doing two things:
1. On `prepareSources`, make `target._sources` point to the tail instead of the head
2. On `cleanupSources`, walk from tail to head **while** dropping old dependencies and reverting to the rollback node

The advantage of doing so is that, if there are no nodes to drop (nodes with `version: -1`) then we're just walking the list backwards without setting any properties.

New nodes are added directly to the tail, and the new node becomes the tail. If old nodes were re-used, then adding new nodes to the tail is cheap and also means that `cleanupSource` only needs to walk backwards until it finds the head without setting properties (that's besides rollback node).

I commented the code with examples so it'd also be easier to understand for new people looking at it 😅 (it took me a bit to grasp how it works).

## Benchmarks

Benchmarked on `v8` binary, Node.js (diff V8 version), and SpiderMonkey (`sm -m` as module). I'm unable to benchmark on JavaScriptCore (can't find a built [trusted] binary).

```diff
v8 (10.9.84)
====================================
Signals  Core - Simple x 25,555,234 ops/sec ±1.07% (487177 runs sampled)
Signals  Core - Unchanged sources x 53,590 ops/sec ±0.47% (1042 runs sampled)
Signals  Core - Unchanged sources + Effect x 50,580 ops/sec ±0.55% (983 runs sampled)
Signals  Core - Conditional Sources x 78,645 ops/sec ±0.57% (1529 runs sampled)
Signals  Core - Conditional Sources + Effect x 73,532 ops/sec ±0.44% (1429 runs sampled)

! Signals Local - Simple x 26,272,524 ops/sec ±0.19% (498317 runs sampled)
! Signals Local - Unchanged sources x 57,449 ops/sec ±0.49% (1117 runs sampled)
! Signals Local - Unchanged sources + Effect x 55,694 ops/sec ±0.53% (1083 runs sampled)
! Signals Local - Conditional Sources x 83,705 ops/sec ±0.50% (1628 runs sampled)
! Signals Local - Conditional Sources + Effect x 80,809 ops/sec ±0.55% (1571 runs sampled)

Node (18.11.0, V8: 10.2.154.15-node.12)
====================================
Signals  Core - Simple x 25,533,845 ops/sec ±0.09% (484112 runs sampled)
Signals  Core - Unchanged sources x 47,989 ops/sec ±0.57% (933 runs sampled)
Signals  Core - Unchanged sources + Effect x 49,957 ops/sec ±0.50% (972 runs sampled)
Signals  Core - Conditional Sources x 80,676 ops/sec ±0.60% (1569 runs sampled)
Signals  Core - Conditional Sources + Effect x 78,402 ops/sec ±0.58% (1525 runs sampled)

! Signals Local - Simple x 25,713,380 ops/sec ±0.09% (487306 runs sampled)
! Signals Local - Unchanged sources x 50,811 ops/sec ±0.62% (987 runs sampled)
! Signals Local - Unchanged sources + Effect x 52,418 ops/sec ±0.54% (1019 runs sampled)
! Signals Local - Conditional Sources x 92,738 ops/sec ±0.57% (1804 runs sampled)
! Signals Local - Conditional Sources + Effect x 81,292 ops/sec ±0.53% (1581 runs sampled)

SpiderMonkey (JavaScript-C107.0)
====================================
Signals  Core - Simple x 11,124,584 ops/sec ±0.11% (214318 runs sampled)
Signals  Core - Unchanged sources x 30,535 ops/sec ±0.61% (594 runs sampled)
Signals  Core - Unchanged sources + Effect x 21,317 ops/sec ±0.54% (415 runs sampled)
Signals  Core - Conditional Sources x 51,024 ops/sec ±0.46% (992 runs sampled)
Signals  Core - Conditional Sources + Effect x 43,003 ops/sec ±0.47% (837 runs sampled)

! Signals Local - Simple x 11,198,532 ops/sec ±0.10% (215715 runs sampled)
! Signals Local - Unchanged sources x 32,117 ops/sec ±0.53% (625 runs sampled)
! Signals Local - Unchanged sources + Effect x 23,483 ops/sec ±0.60% (457 runs sampled)
! Signals Local - Conditional Sources x 58,449 ops/sec ±0.51% (1137 runs sampled)
! Signals Local - Conditional Sources + Effect x 46,252 ops/sec ±0.49% (900 runs sampled)
```

And one un-proper naive benchmark 😅 
```ts
const count = s[250];
const compt = computed(() => {
	for (let i = 0; i < 1000; i++) {
		const sig = s[i];
		sig.value;
	}

	s1.value; // s[1] and so on (check already seen node)
	s2.value;
	s3.value;
	s4.value;
	s5.value;
	s6.value;
	s7.value;
	s8.value;

	return count.value * 2;
});

console.time("Naive:  Core");
for (let i = 0; i < 200000; i++) {
	count.value++;
	compt.value;
}
console.timeEnd("Naive:  Core");
```

```diff
console.timeEnd: Naive:  Core, 3886.450000
console.timeEnd: Naive: Local, 3515.682000
```