### PR TITLE
Proposal: use watcher

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -353,6 +353,12 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 	}, []);
 }
 
+export function useWatcher<T>(value: T) {
+	const watcher = useSignal(value);
+	watcher.value = value;
+	return watcher as ReadonlySignal<T>;
+}
+
 /**
  * @todo Determine which Reactive implementation we'll be using.
  * @internal

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -31,7 +31,7 @@ export interface VNode<P = any> extends preact.VNode<P> {
 	/** The DOM node for this VNode */
 	__e?: Element | Text;
 	/** Props that had Signal values before diffing (used after diffing to subscribe) */
-	__np?: Record<string, any> | null;
+	__np?: Record<string, Signal> | null;
 }
 
 export const enum OptionsTypes {

--- a/packages/preact/test/index.test.tsx
+++ b/packages/preact/test/index.test.tsx
@@ -376,5 +376,20 @@ describe("@preact/signals", () => {
 			render(<App value={4} />, scratch);
 			expect(scratch.textContent).to.equal("8");
 		});
+
+		it("should not cascade rerenders", () => {
+			const spy = sinon.spy();
+			function App({ value = 0 }) {
+				const $value = useWatcher(value);
+				const timesTwo = useComputed(() => $value.value * 2);
+				spy();
+				return <p>{timesTwo.value}</p>;
+			}
+
+			render(<App value={1} />, scratch);
+			render(<App value={4} />, scratch);
+
+			expect(spy).to.be.calledTwice;
+		});
 	});
 });

--- a/packages/preact/test/index.test.tsx
+++ b/packages/preact/test/index.test.tsx
@@ -391,5 +391,54 @@ describe("@preact/signals", () => {
 
 			expect(spy).to.be.calledTwice;
 		});
+
+		it("should update all silblings", () => {
+			function Test({ value }: { value: number }) {
+				const $value = useWatcher(value);
+				return <span>{$value.value}</span>;
+			}
+
+			function App({ value = 0 }) {
+				return (
+					<div>
+						<Test value={value} />
+						<Test value={value} />
+					</div>
+				);
+			}
+
+			const firstChild = () => scratch.firstChild?.firstChild;
+
+			render(<App value={1} />, scratch);
+			expect(firstChild()?.textContent).to.be.equal("1");
+			expect(firstChild()?.nextSibling?.textContent).to.be.equal("1");
+
+			render(<App value={4} />, scratch);
+			expect(firstChild()?.textContent).to.be.equal("4");
+			expect(firstChild()?.nextSibling?.textContent).to.be.equal("4");
+		});
+
+		it("should not rerender siblings", () => {
+			const spy = sinon.spy();
+			function Test({ value }: { value: number }) {
+				const $value = useWatcher(value);
+				spy();
+				return <span>{$value.value}</span>;
+			}
+
+			function App({ value = 0 }) {
+				return (
+					<div>
+						<Test value={value} />
+						<Test value={value} />
+					</div>
+				);
+			}
+
+			render(<App value={1} />, scratch);
+			render(<App value={4} />, scratch);
+
+			expect(spy).to.be.callCount(4);
+		});
 	});
 });

--- a/packages/preact/test/index.test.tsx
+++ b/packages/preact/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { signal, useComputed } from "@preact/signals";
+import { signal, useComputed, useWatcher } from "@preact/signals";
 import { createElement, render } from "preact";
 import { setupRerender, act } from "preact/test-utils";
 
@@ -334,6 +334,47 @@ describe("@preact/signals", () => {
 				// This should not crash
 				s.value = "scale(1, 2)";
 			});
+		});
+	});
+
+	describe("use watcher hook", () => {
+		it("should set the initial value of the checked property", () => {
+			function App({ checked = false }) {
+				const $checked = useWatcher(checked);
+				// @ts-ignore
+				return <input checked={$checked} />;
+			}
+
+			render(<App checked={true} />, scratch);
+			expect(scratch.firstChild).to.have.property("checked", true);
+		});
+
+		it("should update the checked property on change", () => {
+			function App({ checked = false }) {
+				const $checked = useWatcher(checked);
+				// @ts-ignore
+				return <input checked={$checked} />;
+			}
+
+			render(<App checked={true} />, scratch);
+			expect(scratch.firstChild).to.have.property("checked", true);
+
+			render(<App checked={false} />, scratch);
+			expect(scratch.firstChild).to.have.property("checked", false);
+		});
+
+		it("should update computed signal", () => {
+			function App({ value = 0 }) {
+				const $value = useWatcher(value);
+				const timesTwo = useComputed(() => $value.value * 2);
+				return <p>{timesTwo}</p>;
+			}
+
+			render(<App value={1} />, scratch);
+			expect(scratch.textContent).to.equal("2");
+
+			render(<App value={4} />, scratch);
+			expect(scratch.textContent).to.equal("8");
 		});
 	});
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -234,3 +234,9 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 		});
 	}, Empty);
 }
+
+export function useWatcher<T>(value: T) {
+	const watcher = useSignal(value);
+	watcher.value;
+	return watcher as ReadonlySignal<T>;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -97,6 +97,8 @@ function WrapWithProxy(Component: FunctionComponent<any>) {
 	return WrappedComponent;
 }
 
+let renderDepth = 0;
+
 /**
  * A redux-like store whose store value is a positive 32bit integer (a 'version').
  *
@@ -115,10 +117,24 @@ function createEffectStore() {
 	let version = 0;
 	let onChangeNotifyReact: (() => void) | undefined;
 
-	let unsubscribe = effect(function (this: Effect) {
+	const unsubscribe = effect(function (this: Effect) {
 		updater = this;
 	});
+
+	const oldStart = updater._start;
+
+	updater._start = function () {
+		renderDepth++;
+		const finish = oldStart.call(updater);
+		return function () {
+			finish();
+			renderDepth--;
+		};
+	};
+
 	updater._callback = function () {
+		// only notify React of state changes when not rendering in a component
+		if (renderDepth > 0) return;
 		version = (version + 1) | 0;
 		if (onChangeNotifyReact) onChangeNotifyReact();
 	};
@@ -237,6 +253,6 @@ export function useSignalEffect(cb: () => void | (() => void)) {
 
 export function useWatcher<T>(value: T) {
 	const watcher = useSignal(value);
-	watcher.value;
+	watcher.value = value;
 	return watcher as ReadonlySignal<T>;
 }

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -295,5 +295,54 @@ describe("@preact/signals-react", () => {
 
 			expect(spy).to.be.calledTwice;
 		});
+
+		it("should update all silblings", () => {
+			function Test({ value }: { value: number }) {
+				const $value = useWatcher(value);
+				return <span>{$value.value}</span>;
+			}
+
+			function App({ value = 0 }) {
+				return (
+					<div>
+						<Test value={value} />
+						<Test value={value} />
+					</div>
+				);
+			}
+
+			const firstChild = () => scratch.firstChild?.firstChild;
+
+			render(<App value={1} />);
+			expect(firstChild()?.textContent).to.be.equal("1");
+			expect(firstChild()?.nextSibling?.textContent).to.be.equal("1");
+
+			render(<App value={4} />);
+			expect(firstChild()?.textContent).to.be.equal("4");
+			expect(firstChild()?.nextSibling?.textContent).to.be.equal("4");
+		});
+
+		it("should not rerender siblings", () => {
+			const spy = sinon.spy();
+			function Test({ value }: { value: number }) {
+				const $value = useWatcher(value);
+				spy();
+				return <span>{$value.value}</span>;
+			}
+
+			function App({ value = 0 }) {
+				return (
+					<div>
+						<Test value={value} />
+						<Test value={value} />
+					</div>
+				);
+			}
+
+			render(<App value={1} />);
+			render(<App value={4} />);
+
+			expect(spy).to.be.callCount(4);
+		});
 	});
 });


### PR DESCRIPTION
As discussed in #247, this PR introduces a new hook, `useWatcher`, which converts a non-signal value into a signal.

### Motivation

Signals are a powerful primitive, but one main restriction of them is that signal dependencies can only be established between other signals. This means that deriving values between a non-signal and a signal can potentially not update correctly:

```ts
function Foo({ s, n }: { s: ReadonlySignal<number>, n: number }) {

    const combined = useComputed(() => s.value * n * n);
    // combined only recomputes if s is modified

    return <p>{combined}</p>;
}
```

Specific scenarios where this limitation is apparent is when using third-party libraries that do not store state with signals. The `useWatcher` hook is a solution to this restriction, as it essentially wraps a non-signal value in a signal. This as a result allows for changes to the non-signal value to be seen by other signals:

```ts
function Foo({ s, n }: { s: ReadonlySignal<number>, n: number }) {
    const $n = useWatcher(n);

    const combined = useComputed(() => s.value * $n.value * $n.value);
    // combined now updates correctly

    return <p>{combined}</p>;
}
```

While this hook could just be created by end-users, the most optimal implementation of the `useWatcher` breaks typical React convention, which can lead to pitfalls for said end-users.

### Implementation

While all current testcases are passing, one area of uncertainty is with the Preact adapter. Setting the signal `.value` in `useWatcher` may cause extra Component updates to trigger when they shouldn't, so some verification on that end would be appreciated.

Resolves #247
