### PR TITLE
Update Preact VNode adapter

### DIFF
--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -45,6 +45,6 @@
 	},
 	"devDependencies": {
 		"preact": "10.9.0",
-		"preact-render-to-string": "^5.2.4"
+		"preact-render-to-string": "^5.2.5"
 	}
 }

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -97,7 +97,7 @@ function Text(this: AugmentedComponent, { data }: { data: Signal }) {
 Text.displayName = "_st";
 
 Object.defineProperties(Signal.prototype, {
-	constructor: { configurable: true },
+	constructor: { configurable: true, value: undefined },
 	type: { configurable: true, value: Text },
 	props: {
 		configurable: true,

--- a/packages/preact/test/index.test.tsx
+++ b/packages/preact/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { signal, useComputed } from "@preact/signals";
+import { signal, computed, useComputed, Signal } from "@preact/signals";
 import { createElement, render } from "preact";
 import { setupRerender, act } from "preact/test-utils";
 
@@ -15,6 +15,16 @@ describe("@preact/signals", () => {
 
 	afterEach(() => {
 		render(null, scratch);
+	});
+
+	describe("inheritance", () => {
+		it("should have signals inherit from Signal", () => {
+			expect(signal(0)).to.be.instanceof(Signal);
+		});
+
+		it("should have computed inherit from Signal", () => {
+			expect(computed(() => 0)).to.be.instanceof(Signal);
+		});
 	});
 
 	describe("Text bindings", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,12 +138,12 @@ importers:
     specifiers:
       '@preact/signals-core': workspace:^1.2.2
       preact: 10.9.0
-      preact-render-to-string: ^5.2.4
+      preact-render-to-string: ^5.2.5
     dependencies:
       '@preact/signals-core': link:../core
     devDependencies:
       preact: 10.9.0
-      preact-render-to-string: 5.2.4_preact@10.9.0
+      preact-render-to-string: 5.2.6_preact@10.9.0
 
   packages/react:
     specifiers:
@@ -6113,8 +6113,8 @@ packages:
       pretty-format: 3.8.0
     dev: false
 
-  /preact-render-to-string/5.2.4_preact@10.9.0:
-    resolution: {integrity: sha512-iIPHb3BXUQ3Za6KNhkjN/waq11Oh+QWWtAgN3id3LrL+cszH3DYh8TxJPNQ6Aogsbu4JsqdJLBZltwPFpG6N6w==}
+  /preact-render-to-string/5.2.6_preact@10.9.0:
+    resolution: {integrity: sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==}
     peerDependencies:
       preact: '>=10'
     dependencies:


### PR DESCRIPTION
Preact expects VNodes to have an undefined constructor. This PR updates the Preact adapter so that signal objects match this expectation. The undefined constructor will only affect signal **objects** while the Signal Prototype is unaffected.

Fixes #256