### PR TITLE
Type Signal as valid React JSX

### DIFF
--- a/.changeset/metal-emus-design.md
+++ b/.changeset/metal-emus-design.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+type Signal as a React Element

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,11 +157,13 @@ function addDependency(signal: Signal): Node | undefined {
 	return undefined;
 }
 
+// @ts-ignore internal Signal is viewed as a function
 declare class Signal<T = any> {
 	/** @internal */
 	_value: unknown;
 
-	/** @internal
+	/**
+	 * @internal
 	 * Version numbers should always be >= 0, because the special value -1 is used
 	 * by Nodes to signify potentially unused but recyclable notes.
 	 */
@@ -197,6 +199,7 @@ declare class Signal<T = any> {
 }
 
 /** @internal */
+// @ts-ignore internal Signal is viewed as function
 function Signal(this: Signal, value?: unknown) {
 	this._value = value;
 	this._version = 0;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@ import {
 	useEffect,
 	Component,
 	type FunctionComponent,
+	type ReactElement,
 } from "react";
 import React from "react";
 import jsxRuntime from "react/jsx-runtime";
@@ -193,6 +194,10 @@ JsxDev.jsxs && /*  */ (JsxDev.jsxs = WrapJsx(JsxDev.jsxs));
 JsxPro.jsxs && /*  */ (JsxPro.jsxs = WrapJsx(JsxPro.jsxs));
 JsxDev.jsxDEV && /**/ (JsxDev.jsxDEV = WrapJsx(JsxDev.jsxDEV));
 JsxPro.jsxDEV && /**/ (JsxPro.jsxDEV = WrapJsx(JsxPro.jsxDEV));
+
+declare module "@preact/signals-core" {
+	interface Signal extends ReactElement {}
+}
 
 /**
  * A wrapper component that renders a Signal's value directly as a Text node.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -50,6 +50,7 @@ const ProxyHandlers = {
 		try {
 			const children = Component.apply(thisArg, argumentsList);
 			return children;
+			// eslint-disable-next-line no-useless-catch
 		} catch (e) {
 			// Re-throwing promises that'll be handled by suspense
 			// or an actual error.
@@ -196,6 +197,8 @@ JsxDev.jsxDEV && /**/ (JsxDev.jsxDEV = WrapJsx(JsxDev.jsxDEV));
 JsxPro.jsxDEV && /**/ (JsxPro.jsxDEV = WrapJsx(JsxPro.jsxDEV));
 
 declare module "@preact/signals-core" {
+	// @ts-ignore internal Signal is viewed as function
+	// eslint-disable-next-line @typescript-eslint/no-empty-interface
 	interface Signal extends ReactElement {}
 }
 

--- a/packages/react/src/internal.d.ts
+++ b/packages/react/src/internal.d.ts
@@ -1,13 +1,9 @@
-import { Signal } from "@preact/signals-core";
-
 export interface Effect {
 	_sources: object | undefined;
 	_start(): () => void;
 	_callback(): void;
 	_dispose(): void;
 }
-
-export type Updater = Signal<unknown>;
 
 export interface JsxRuntimeModule {
 	jsx?(type: any, ...rest: any[]): unknown;

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -148,7 +148,7 @@ describe("@preact/signals-react", () => {
 
 			function App() {
 				sig.value;
-				return useMemo(() => <Inner foo={1} />, []);
+				return useMemo(() => <Inner />, []);
 			}
 
 			render(<App />);

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -1,7 +1,7 @@
 // @ts-ignore-next-line
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-import { signal, useComputed } from "@preact/signals-react";
+import { signal, computed, useComputed } from "@preact/signals-react";
 import { createElement, useMemo, memo, StrictMode } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -38,6 +38,16 @@ describe("@preact/signals-react", () => {
 			expect(span).to.have.property("firstChild").that.is.an.instanceOf(Text);
 			const text = span?.firstChild;
 			expect(text).to.have.property("data", "test");
+		});
+
+		it("should render computed as Text", () => {
+			const sig = signal("test");
+			const comp = computed(() => `${sig} ${sig}`);
+			render(<span>{comp}</span>);
+			const span = scratch.firstChild;
+			expect(span).to.have.property("firstChild").that.is.an.instanceOf(Text);
+			const text = span?.firstChild;
+			expect(text).to.have.property("data", "test test");
 		});
 
 		it("should update Signal-based Text (no parent component)", () => {


### PR DESCRIPTION
This PR updates the typing of the React signal adapter to enable the text binding. General refactors to the React adapter typing are also included.

The reason for this change is because the implementation of the React signal adapter [supports direct text binding](https://github.com/preactjs/signals/blob/55d5becbb41c2faec62b9588937f8c74f0d65152/packages/react/test/index.test.tsx#L34-L40).

A couple `@ts-ignore` were also added to the core package to account for how Typescript interprets ES5 classes.

Fixes #261 