### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
 	"name": "preact-signals",
-	"version": "1.0.0",
-	"description": "Manage state with style in every framework",
-	"main": "index.js",
 	"private": true,
 	"scripts": {
 		"prebuild": "rimraf packages/core/dist/ packages/preact/dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "preact-signals",
 	"version": "1.0.0",
-	"description": "",
+	"description": "Manage state with style in every framework",
 	"main": "index.js",
 	"private": true,
 	"scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
 	"name": "@preact/signals-core",
 	"version": "1.2.2",
 	"license": "MIT",
-	"description": "",
+	"description": "Manage state with style in every framework",
 	"keywords": [],
 	"authors": [
 		"The Preact Authors (https://github.com/preactjs/signals/contributors)"

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -2,7 +2,7 @@
 	"name": "@preact/signals",
 	"version": "1.1.2",
 	"license": "MIT",
-	"description": "",
+	"description": "Manage state with style in every framework",
 	"keywords": [],
 	"authors": [
 		"The Preact Authors (https://github.com/preactjs/signals/contributors)"

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -2,7 +2,7 @@
 	"name": "@preact/signals",
 	"version": "1.1.2",
 	"license": "MIT",
-	"description": "Manage state with style in every framework",
+	"description": "Manage state with style in Preact",
 	"keywords": [],
 	"authors": [
 		"The Preact Authors (https://github.com/preactjs/signals/contributors)"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
 	"name": "@preact/signals-react",
 	"version": "1.2.1",
 	"license": "MIT",
-	"description": "Manage state with style in every framework",
+	"description": "Manage state with style in React",
 	"keywords": [],
 	"authors": [
 		"The Preact Authors (https://github.com/preactjs/signals/contributors)"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
 	"name": "@preact/signals-react",
 	"version": "1.2.1",
 	"license": "MIT",
-	"description": "",
+	"description": "Manage state with style in every framework",
 	"keywords": [],
 	"authors": [
 		"The Preact Authors (https://github.com/preactjs/signals/contributors)"


### PR DESCRIPTION
Add the description to `package.json`, so something shows up when I look at dependencies on github.

<img width="1016" alt="Screen Shot 2022-12-04 at 1 42 06 PM" src="https://user-images.githubusercontent.com/5776508/205511942-bfdfbb07-c3b7-4a1e-bee6-2734ad9fa976.png">
