### PR TITLE
chore: Remove unused entries in root pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
 	"name": "preact-signals",
-	"version": "1.0.0",
-	"description": "",
-	"main": "index.js",
 	"private": true,
 	"scripts": {
 		"prebuild": "rimraf packages/core/dist/ packages/preact/dist",
@@ -25,8 +22,9 @@
 		"ci:test": "pnpm lint && pnpm test",
 		"release": "pnpm changeset version && pnpm install && git add -A && git commit -m 'Version Packages' && changeset tag && pnpm publish -r"
 	},
-	"keywords": [],
-	"author": "",
+	"authors": [
+		"The Preact Authors (https://github.com/preactjs/signals/contributors)"
+	],
 	"license": "MIT",
 	"devDependencies": {
 		"@babel/core": "^7.19.1",


### PR DESCRIPTION
#278 tipped me off to having a few junk/leftover entries from initial scaffolding in all likelihood. No point in keeping them around and (as shown) they can trip up users looking to PR a correction to one of the actual packages.

I copied over `authors`, figures that goes along with the license as being a nice-to-have in the root even if it doesn't necessarily get used.