### PR TITLE
Fix #274: Avoid cascading unsubscribes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -219,18 +219,21 @@ Signal.prototype._subscribe = function (node) {
 };
 
 Signal.prototype._unsubscribe = function (node) {
-	const prev = node._prevTarget;
-	const next = node._nextTarget;
-	if (prev !== undefined) {
-		prev._nextTarget = next;
-		node._prevTarget = undefined;
-	}
-	if (next !== undefined) {
-		next._prevTarget = prev;
-		node._nextTarget = undefined;
-	}
-	if (node === this._targets) {
-		this._targets = next;
+	// Only run the unsubscribe step if the signal has any subscribers to begin with.
+	if (this._targets !== undefined) {
+		const prev = node._prevTarget;
+		const next = node._nextTarget;
+		if (prev !== undefined) {
+			prev._nextTarget = next;
+			node._prevTarget = undefined;
+		}
+		if (next !== undefined) {
+			next._prevTarget = prev;
+			node._nextTarget = undefined;
+		}
+		if (node === this._targets) {
+			this._targets = next;
+		}
 	}
 };
 
@@ -464,18 +467,22 @@ Computed.prototype._subscribe = function (node) {
 };
 
 Computed.prototype._unsubscribe = function (node) {
-	Signal.prototype._unsubscribe.call(this, node);
+	// Only run the unsubscribe step if the computed signal has any subscribers.
+	if (this._targets !== undefined) {
+		Signal.prototype._unsubscribe.call(this, node);
 
-	// Computed signal unsubscribes from its dependencies from it loses its last subscriber.
-	if (this._targets === undefined) {
-		this._flags &= ~TRACKING;
+		// Computed signal unsubscribes from its dependencies when it loses its last subscriber.
+		// This makes it possible for unreferences subgraphs of computed signals to get garbage collected.
+		if (this._targets === undefined) {
+			this._flags &= ~TRACKING;
 
-		for (
-			let node = this._sources;
-			node !== undefined;
-			node = node._nextSource
-		) {
-			node._source._unsubscribe(node);
+			for (
+				let node = this._sources;
+				node !== undefined;
+				node = node._nextSource
+			) {
+				node._source._unsubscribe(node);
+			}
 		}
 	}
 };


### PR DESCRIPTION
This pull request fixes issue #274 spotted by @modderme123. The root cause for the exponential slowdown was the fact that the _unsubscribe method was always run for every computed/signal that's dropped from the dependency graph - even when there was no need. This in turn caused an avalanche of unnecessary work.

Before this change the [Stackblitz benchmark](https://stackblitz.com/edit/preact-signals-slowdown) took ~15.8 seconds to complete on my machine. After this change it took around 3 milliseconds.

Huge thanks to @modderme123 for spotting this, and for the excellent issue description. The Stackblitz example made the reproduction phase trivial 👍