### PR TITLE
feat(signals-preact): add possibility of deferring effect execution to the next frame

### DIFF
--- a/.changeset/fair-moles-sin.md
+++ b/.changeset/fair-moles-sin.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": minor
+---
+
+Add support for delaying effect execution to the next frame

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -390,9 +390,9 @@ export function useSignalEffect(cb: () => void | (() => void), options?: EffectO
 		const execute = () => callback.current();
 		const notify = () => {
 			if (mode === 'afterPaint') {
-				afterNextFrame(execute)
+				afterNextFrame(eff.flush)
 			} else {
-				callback.current();
+				eff.flush();
 			}
 		}
 		const eff = createFlusher(execute, notify);

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -4,6 +4,7 @@ import { Signal } from "@preact/signals-core";
 export interface Effect {
 	_sources: object | undefined;
 	_start(): () => void;
+	_compute(): void;
 	_callback(): void;
 	_dispose(): void;
 }


### PR DESCRIPTION
Resolve https://github.com/preactjs/signals/issues/228

This currently adds support for `useEffect` like execution to the `useSignalEffect`, this is supported by means of a new `options` second argument, which is an object that allows you to pass in a property named `mode`. By default we will do `sync` execution which is the behavior we have seen before, but we also allow for a new type of behavior, namely `afterPaint` which is the same method used as `useEffect`.

Currently I did not really see a need to add `useLayoutEffect` but we could in the future, for React we could implement this like the following:

```js
export const useSignalEffect = (cb, opts) => {
  const [effectTrigger, setEffect] = useState(0);

  const effectFlush = useRef();
  const callback = useRef(cb);
  callback.current = cb;

  useEffect(() => {
    const notify = () => {
	if (mode === 'afterPaint') {
		setEffect((e) => e + 1)
	} else {
		eff.flush();
	}      
    }
    const eff = createFlusher(() => callback.current(), notify);
    effectFlush.current = eff.flush;
    return eff.dispose
  }, Empty);
  
  useEffect(() => {
    if (effectTrigger > 0) {
      effectFlush.current()
    }
  }, [effectTrigger]);
}
```

Do note that this would only trigger after updating the DOM-node if the relevant property is used on a DOM-node as well

[demo](https://codesandbox.io/s/cool-brown-72judb?file=/src/index.js)