### PR TITLE
Fix signals aborting context updates

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -61,6 +61,7 @@
       "$_subscribe": "S",
       "$_unsubscribe": "U",
       "preact": "",
+      "$_prevValue": "_pv",
       "$_signal": "s",
       "$_updater": "__$u",
       "$_updateFlags": "__$f",

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -313,7 +313,7 @@ Component.prototype.shouldComponentUpdate = function (
 	// }
 
 	// Ensure context updates propagate through
-	let didHaveContextUpdate = false;
+	let hasContextUpdate = false;
 	const hooks = this.__H && this.__H.__;
 	if (hooks) {
 		for (let h = hooks.length; h--; ) {
@@ -329,11 +329,11 @@ Component.prototype.shouldComponentUpdate = function (
 			const nextVal = context[id].props.value;
 			// note: we never bail out early here, because we need
 			// to ensure _prevValue is updated for all context subscriptions.
-			if (nextVal !== hook._prevValue) didHaveContextUpdate = true;
+			if (nextVal !== hook._prevValue) hasContextUpdate = true;
 			hook._prevValue = nextVal;
 		}
 	}
-	if (didHaveContextUpdate) return true;
+	if (hasContextUpdate) return true;
 
 	// if this component used no signals or computeds, update:
 	if (!hasSignals && !(this._updateFlags & HAS_COMPUTEDS)) return true;

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -326,6 +326,8 @@ Component.prototype.shouldComponentUpdate = function (
 			// Nothing to track if no provider is present
 			if (!(id in context)) continue;
 
+			console.log(id, context[id].props.value, hook._prevValue);
+
 			const nextVal = context[id].props.value;
 			// note: we never bail out early here, because we need
 			// to ensure _prevValue is updated for all context subscriptions.
@@ -333,6 +335,7 @@ Component.prototype.shouldComponentUpdate = function (
 			hook._prevValue = nextVal;
 		}
 	}
+	console.log({ c: this.constructor.name, hasContextUpdate });
 	if (hasContextUpdate) return true;
 
 	// if this component used no signals or computeds, update:

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -323,6 +323,9 @@ Component.prototype.shouldComponentUpdate = function (
 			if (!("c" in hook)) continue;
 
 			const id = hook.c.__c;
+			// Nothing to track if no provider is present
+			if (!(id in context)) continue;
+
 			const nextVal = context[id].props.value;
 			// note: we never bail out early here, because we need
 			// to ensure _prevValue is updated for all context subscriptions.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -318,13 +318,16 @@ Component.prototype.shouldComponentUpdate = function (
 	if (hooks) {
 		for (let h = hooks.length; h--; ) {
 			const hook = hooks[h];
+
+			// Skip hook if it's not `useContext`
 			if (!("c" in hook)) continue;
+
 			const id = hook.c.__c;
 			const nextVal = context[id].props.value;
 			// note: we never bail out early here, because we need
-			// to ensure _pv is updated for all context subscriptions.
-			if (nextVal !== hook._pv) didHaveContextUpdate = true;
-			hook._pv = nextVal;
+			// to ensure _prevValue is updated for all context subscriptions.
+			if (nextVal !== hook._prevValue) didHaveContextUpdate = true;
+			hook._prevValue = nextVal;
 		}
 	}
 	if (didHaveContextUpdate) return true;

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -21,6 +21,9 @@ export interface AugmentedComponent extends Component<any, any> {
 	__v: VNode;
 	_updater?: Effect;
 	_updateFlags: number;
+	__H: {
+		__: { c?: any; _pv?: any }[];
+	};
 }
 
 export interface VNode<P = any> extends preact.VNode<P> {

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -22,7 +22,7 @@ export interface AugmentedComponent extends Component<any, any> {
 	_updater?: Effect;
 	_updateFlags: number;
 	__H: {
-		__: { c?: any; _pv?: any }[];
+		__: { c?: any; _prevValue?: any }[];
 	};
 }
 


### PR DESCRIPTION
We noticed that a component that subscribes to a signal may block updates in a scenario where the signal didn't update, but context values did.

Authored together with @developit and @mdentremont in a paring session.