### PR TITLE
useSignal: Use 'useRef()' instead of 'useMemo()' to wrap the signal

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -332,7 +332,7 @@ Component.prototype.shouldComponentUpdate = function (
 };
 
 export function useSignal<T>(value: T) {
-	return useMemo(() => signal<T>(value), []);
+	return useRef(signal<T>(value)).current;
 }
 
 export function useComputed<T>(compute: () => T) {


### PR DESCRIPTION
This is a minor change so that `useSignal()` is a wrapper around `useRef()` instead of `useMemo()`.

More on the change:
https://mastodon.social/@rgadellaa/109863125430115425