### PR TITLE
feat(core): support `.set(val)` on a signal

### DIFF
--- a/.changeset/forty-lobsters-film.md
+++ b/.changeset/forty-lobsters-film.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": minor
+---
+
+Support `.set(val)` on a signal

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -286,32 +286,7 @@ Signal.prototype.subscribe = function (fn) {
 };
 
 Signal.prototype.set = function (value) {
-	const signal = this;
-	if (evalContext instanceof Computed) {
-		mutationDetected();
-	}
-	if (value !== signal._value) {
-		if (batchIteration > 100) {
-			cycleDetected();
-		}
-
-		signal._value = value;
-		signal._version++;
-		globalVersion++;
-
-		/**@__INLINE__*/ startBatch();
-		try {
-			for (
-				let node = signal._targets;
-				node !== undefined;
-				node = node._nextTarget
-			) {
-				node._target._notify();
-			}
-		} finally {
-			endBatch();
-		}
-	}
+	this.value = value
 };
 
 Signal.prototype.valueOf = function () {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -147,6 +147,20 @@ describe("signal", () => {
 			expect(spy).not.to.be.called;
 		});
 	});
+
+	describe(".set()", () => {
+		it("should notify subscribers after set", () => {
+			const spy = sinon.spy();
+			const a = signal(1);
+
+			a.subscribe(spy);
+			expect(spy).to.be.calledWith(1);
+
+			a.set(2)
+			expect(spy).to.be.calledWith(2);
+			expect(a.peek()).to.equal(2);
+		});
+	});
 });
 
 describe("effect()", () => {


### PR DESCRIPTION
Resolves https://github.com/preactjs/signals/issues/299

This implements `.set()` to conform to the Svelte store contract as we have already implemented `.subscribe()` this felt logical.

[Svelte Ref](https://github.com/sveltejs/svelte/blob/master/src/runtime/store/index.ts#L34)