### PR TITLE
Run test suite agains React's production build

### DIFF
--- a/.changeset/thick-news-raise.md
+++ b/.changeset/thick-news-raise.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+Run test suite agains React's production build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,3 +50,6 @@ jobs:
 
       - name: Test production build
         run: pnpm test:minify
+
+      - name: Test react production build
+        run: pnpm test:prod

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"test": "cross-env COVERAGE=true karma start karma.conf.js --single-run",
 		"test:minify": "cross-env COVERAGE=true MINIFY=true karma start karma.conf.js --single-run",
 		"test:watch": "karma start karma.conf.js --no-single-run",
+		"test:prod": "cross-env MINIFY=true NODE_ENV=production karma start karma.conf.js --single-run",
+		"test:prod:watch": "cross-env NODE_ENV=production karma start karma.conf.js --no-single-run",
 		"docs:start": "cd docs && pnpm start",
 		"docs:build": "cd docs && pnpm build",
 		"docs:preview": "cd docs && pnpm preview",


### PR DESCRIPTION
This PR adds an additional test command and run in CI that runs our test suite against React's production build.

I'm working on the react adapter and there are different behaviors between React's dev and prod builds so I'm adding this capability now so any future work I do doesn't regress functionality against React's prod build.