### PR TITLE
Revert react integration to tracking current dispatcher

### DIFF
--- a/.changeset/angry-papayas-accept.md
+++ b/.changeset/angry-papayas-accept.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": minor
+---
+
+Revert react integration to tracking current dispatcher

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@babel/core": "^7.19.1",
+		"@babel/plugin-transform-typescript": "^7.19.1",
 		"@babel/preset-env": "^7.19.1",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@babel/plugin-transform-typescript": "^7.19.1",
 		"@changesets/changelog-github": "^0.4.6",
 		"@changesets/cli": "^2.24.2",
 		"@types/chai": "^4.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,6 +49,7 @@
 		"@types/react-dom": "^18.0.6",
 		"@types/use-sync-external-store": "^0.0.3",
 		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
+		"react-dom": "^18.2.0",
+		"react-router-dom": "^6.9.0"
 	}
 }

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -11,6 +11,7 @@ import {
 	createElement,
 	forwardRef,
 	useMemo,
+	useReducer,
 	memo,
 	StrictMode,
 	createRef,
@@ -268,6 +269,48 @@ describe("@preact/signals-react", () => {
 					`<code>${count.value}</code><code>${count.value}</code>`
 				);
 			}
+		});
+
+		it("should correctly render components that have useReducer()", async () => {
+			const count = signal(0);
+
+			let increment: () => void;
+			const Test = () => {
+				const [state, dispatch] = useReducer(
+					(state: number, action: number) => {
+						return state + action;
+					},
+					1
+				);
+
+				increment = () => dispatch(1);
+
+				return (
+					<pre>
+						<code>{state}</code>
+						<code>{count}</code>
+					</pre>
+				);
+			};
+
+			let state = 1;
+			for (let i = 0; i < 3; i++) {
+				await act(async () => {
+					count.value += 1;
+					await render(<Test />);
+				});
+				expect(scratch.innerHTML).to.equal(
+					`<pre><code>${state}</code><code>${count.value}</code></pre>`
+				);
+			}
+
+			await act(() => {
+				increment();
+				state += 1;
+			});
+			expect(scratch.innerHTML).to.equal(
+				`<pre><code>${state}</code><code>${count.value}</code></pre>`
+			);
 		});
 	});
 

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -292,10 +292,12 @@ describe("@preact/signals-react", () => {
 
 				increment = () => dispatch(1);
 
+				const doubled = count.value * 2;
+
 				return (
 					<pre>
 						<code>{state}</code>
-						<code>{count}</code>
+						<code>{doubled}</code>
 					</pre>
 				);
 			};
@@ -310,7 +312,7 @@ describe("@preact/signals-react", () => {
 					count.value += 1;
 				});
 				expect(scratch.innerHTML).to.equal(
-					`<pre><code>-2</code><code>${count.value}</code></pre>`
+					`<pre><code>-2</code><code>${count.value * 2}</code></pre>`
 				);
 			}
 
@@ -318,7 +320,7 @@ describe("@preact/signals-react", () => {
 				increment();
 			});
 			expect(scratch.innerHTML).to.equal(
-				`<pre><code>-1</code><code>${count.value}</code></pre>`
+				`<pre><code>-1</code><code>${count.value * 2}</code></pre>`
 			);
 		});
 	});

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -212,7 +212,7 @@ describe("@preact/signals-react", () => {
 		});
 
 		it("should consistently rerender in strict mode", async () => {
-			const sig = signal<string>(null!);
+			const sig = signal(-1);
 
 			const Test = () => <p>{sig.value}</p>;
 			const App = () => (
@@ -221,18 +221,19 @@ describe("@preact/signals-react", () => {
 				</StrictMode>
 			);
 
-			for (let i = 0; i < 3; i++) {
-				const value = `${i}`;
+			await render(<App />);
+			expect(scratch.textContent).to.equal("-1");
 
+			for (let i = 0; i < 3; i++) {
 				await act(async () => {
-					sig.value = value;
-					await render(<App />);
+					sig.value = i;
 				});
-				expect(scratch.textContent).to.equal(value);
+				expect(scratch.textContent).to.equal("" + i);
 			}
 		});
+
 		it("should consistently rerender in strict mode (with memo)", async () => {
-			const sig = signal<string>(null!);
+			const sig = signal(-1);
 
 			const Test = memo(() => <p>{sig.value}</p>);
 			const App = () => (
@@ -241,16 +242,17 @@ describe("@preact/signals-react", () => {
 				</StrictMode>
 			);
 
-			for (let i = 0; i < 3; i++) {
-				const value = `${i}`;
+			await render(<App />);
+			expect(scratch.textContent).to.equal("-1");
 
+			for (let i = 0; i < 3; i++) {
 				await act(async () => {
-					sig.value = value;
-					await render(<App />);
+					sig.value = i;
 				});
-				expect(scratch.textContent).to.equal(value);
+				expect(scratch.textContent).to.equal("" + i);
 			}
 		});
+
 		it("should render static markup of a component", async () => {
 			const count = signal(0);
 
@@ -262,10 +264,13 @@ describe("@preact/signals-react", () => {
 					</pre>
 				);
 			};
+
+			await render(<Test />);
+			expect(scratch.textContent).to.equal("<code>0</code><code>0</code>");
+
 			for (let i = 0; i < 3; i++) {
 				await act(async () => {
 					count.value += 1;
-					await render(<Test />);
 				});
 				expect(scratch.textContent).to.equal(
 					`<code>${count.value}</code><code>${count.value}</code>`
@@ -282,7 +287,7 @@ describe("@preact/signals-react", () => {
 					(state: number, action: number) => {
 						return state + action;
 					},
-					1
+					-2
 				);
 
 				increment = () => dispatch(1);
@@ -295,23 +300,25 @@ describe("@preact/signals-react", () => {
 				);
 			};
 
-			let state = 1;
+			await render(<Test />);
+			expect(scratch.innerHTML).to.equal(
+				"<pre><code>-2</code><code>0</code></pre>"
+			);
+
 			for (let i = 0; i < 3; i++) {
 				await act(async () => {
 					count.value += 1;
-					await render(<Test />);
 				});
 				expect(scratch.innerHTML).to.equal(
-					`<pre><code>${state}</code><code>${count.value}</code></pre>`
+					`<pre><code>-2</code><code>${count.value}</code></pre>`
 				);
 			}
 
 			await act(() => {
 				increment();
-				state += 1;
 			});
 			expect(scratch.innerHTML).to.equal(
-				`<pre><code>${state}</code><code>${count.value}</code></pre>`
+				`<pre><code>-1</code><code>${count.value}</code></pre>`
 			);
 		});
 	});

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -6,6 +6,8 @@ import {
 	computed,
 	useComputed,
 	useSignalEffect,
+	useSignal,
+	Signal,
 } from "@preact/signals-react";
 import {
 	createElement,
@@ -311,6 +313,28 @@ describe("@preact/signals-react", () => {
 			expect(scratch.innerHTML).to.equal(
 				`<pre><code>${state}</code><code>${count.value}</code></pre>`
 			);
+		});
+	});
+
+	describe("useSignal()", () => {
+		it("should create a signal from a primitive value", async () => {
+			function App() {
+				const count = useSignal(1);
+				return (
+					<div>
+						{count}
+						<button onClick={() => count.value++}>Increment</button>
+					</div>
+				);
+			}
+
+			await render(<App />);
+			expect(scratch.textContent).to.equal("1Increment");
+
+			await act(() => {
+				scratch.querySelector("button")!.click();
+			});
+			expect(scratch.textContent).to.equal("2Increment");
 		});
 	});
 

--- a/packages/react/test/react-router.test.tsx
+++ b/packages/react/test/react-router.test.tsx
@@ -1,0 +1,48 @@
+// @ts-ignore-next-line
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { signal } from "@preact/signals-react";
+import { createElement } from "react";
+import { Route, Routes, MemoryRouter } from "react-router-dom";
+
+import { createRoot, Root } from "react-dom/client";
+import { act, checkHangingAct } from "./utils";
+
+describe("@preact/signals-react", () => {
+	let scratch: HTMLDivElement;
+	let root: Root;
+	async function render(element: Parameters<Root["render"]>[0]) {
+		await act(() => root.render(element));
+	}
+
+	beforeEach(() => {
+		scratch = document.createElement("div");
+		root = createRoot(scratch);
+	});
+
+	afterEach(async () => {
+		checkHangingAct();
+		await act(() => root.unmount());
+	});
+
+	describe("react-router-dom", () => {
+		it("Route component should render", async () => {
+			const name = signal("World")!;
+
+			function App() {
+				return (
+					<MemoryRouter>
+						<Routes>
+							<Route path="/page1" element={<div>Page 1</div>}></Route>
+							<Route path="*" element={<div>Hello {name}!</div>}></Route>
+						</Routes>
+					</MemoryRouter>
+				);
+			}
+
+			await render(<App />);
+
+			expect(scratch.innerHTML).to.equal("<div>Hello World!</div>");
+		});
+	});
+});

--- a/packages/react/test/react-router.test.tsx
+++ b/packages/react/test/react-router.test.tsx
@@ -5,8 +5,7 @@ import { signal } from "@preact/signals-react";
 import { createElement } from "react";
 import { Route, Routes, MemoryRouter } from "react-router-dom";
 
-import { createRoot, Root } from "react-dom/client";
-import { act, checkHangingAct } from "./utils";
+import { act, checkHangingAct, createRoot, Root } from "./utils";
 
 describe("@preact/signals-react", () => {
 	let scratch: HTMLDivElement;
@@ -15,14 +14,16 @@ describe("@preact/signals-react", () => {
 		await act(() => root.render(element));
 	}
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		scratch = document.createElement("div");
-		root = createRoot(scratch);
+		document.body.appendChild(scratch);
+		root = await createRoot(scratch);
 	});
 
 	afterEach(async () => {
 		checkHangingAct();
 		await act(() => root.unmount());
+		scratch.remove();
 	});
 
 	describe("react-router-dom", () => {

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -1,0 +1,32 @@
+import { act as realAct } from "react-dom/test-utils";
+
+// When testing using react's production build, we can't use act (React
+// explicitly throws an error in this situation). So instead we'll fake act by
+// just waiting 10ms for React's concurrent rerendering to flush. We'll make a
+// best effort to throw a helpful error in afterEach if we detect that act() was
+// called but not awaited.
+const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+let acting = 0;
+async function prodActShim(cb: () => void | Promise<void>): Promise<void> {
+	acting++;
+	try {
+		await cb();
+		await delay(10);
+	} finally {
+		acting--;
+	}
+}
+
+export function checkHangingAct() {
+	if (acting > 0) {
+		throw new Error(
+			`It appears act() was called but not awaited. This could happen if a test threw an Error or if a test forgot to await a call to act. Make sure to await act() calls in tests.`
+		);
+	}
+}
+
+export const act =
+	process.env.NODE_ENV === "production"
+		? (prodActShim as typeof realAct)
+		: realAct;

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -1,5 +1,40 @@
 import { act as realAct } from "react-dom/test-utils";
 
+export interface Root {
+	render(element: JSX.Element | null): void;
+	unmount(): void;
+}
+
+// We need to use createRoot() if it's available, but it's only available in
+// React 18. To enable local testing with React 16 & 17, we'll create a fake
+// createRoot() that uses render() and unmountComponentAtNode() instead.
+let createRootCache: ((container: Element) => Root) | undefined;
+export async function createRoot(container: Element): Promise<Root> {
+	if (!createRootCache) {
+		try {
+			// @ts-expect-error ESBuild will replace this import with a require() call
+			// if it resolves react-dom/client. If it doesn't, it will leave the
+			// import untouched causing a runtime error we'll handle below.
+			const { createRoot } = await import("react-dom/client");
+			createRootCache = createRoot;
+		} catch (e) {
+			// @ts-expect-error ESBuild will replace this import with a require() call
+			// if it resolves react-dom.
+			const { render, unmountComponentAtNode } = await import("react-dom");
+			createRootCache = (container: Element) => ({
+				render(element: JSX.Element) {
+					render(element, container);
+				},
+				unmount() {
+					unmountComponentAtNode(container);
+				},
+			});
+		}
+	}
+
+	return createRootCache(container);
+}
+
 // When testing using react's production build, we can't use act (React
 // explicitly throws an error in this situation). So instead we'll fake act by
 // just waiting 10ms for React's concurrent rerendering to flush. We'll make a

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,12 @@
 lockfileVersion: 5.4
 
 patchedDependencies:
-  microbundle@0.15.1:
-    hash: yvstdq4ikeml4yz3a6bi3bgrvu
-    path: patches/microbundle@0.15.1.patch
   '@babel/plugin-transform-typescript@7.19.1':
     hash: tiqrfntt5y3ned567j2lekmz2i
     path: patches/@babel__plugin-transform-typescript@7.19.1.patch
+  microbundle@0.15.1:
+    hash: yvstdq4ikeml4yz3a6bi3bgrvu
+    path: patches/microbundle@0.15.1.patch
 
 importers:
 
@@ -153,6 +153,7 @@ importers:
       '@types/use-sync-external-store': ^0.0.3
       react: ^18.2.0
       react-dom: ^18.2.0
+      react-router-dom: ^6.9.0
       use-sync-external-store: ^1.2.0
     dependencies:
       '@preact/signals-core': link:../core
@@ -163,6 +164,7 @@ importers:
       '@types/use-sync-external-store': 0.0.3
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+      react-router-dom: 6.10.0_biqbaboplfbrettd7655fr4n2y
 
 packages:
 
@@ -2059,6 +2061,11 @@ packages:
       vite: 3.0.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@remix-run/router/1.5.0:
+    resolution: {integrity: sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==}
+    engines: {node: '>=14'}
     dev: true
 
   /@rollup/plugin-alias/3.1.9_rollup@2.77.2:
@@ -6231,6 +6238,29 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  /react-router-dom/6.10.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.5.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-router: 6.10.0_react@18.2.0
+    dev: true
+
+  /react-router/6.10.0_react@18.2.0:
+    resolution: {integrity: sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.5.0
+      react: 18.2.0
+    dev: true
 
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}


### PR DESCRIPTION
Revert our react integration back to setting up signal subscription tracking by watching changes in the ReactCurrentDispatcher instead of proxying function Component calls in createElement so it works with more ecosystem libraries such as react-router-dom.

Check the comment in the source for a deeper discussion of the implementation details and choices.

Fixes #251 
Fixes #330 