### PR TITLE
Allow react ^16.14.0 as a peer dependency

### DIFF
--- a/.changeset/fluffy-pillows-shout.md
+++ b/.changeset/fluffy-pillows-shout.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+Allow React ^16.14.0 as a peer dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,7 @@
 		"use-sync-external-store": "^1.2.0"
 	},
 	"peerDependencies": {
-		"react": "17.x || 18.x"
+		"react": "^16.14.0 || 17.x || 18.x"
 	},
 	"devDependencies": {
 		"@types/react": "^18.0.18",


### PR DESCRIPTION
Is there any reason we can't support ^16.14.0? [According to npmfs.com](https://npmfs.com/package/react/16.14.0/), the react 16.14.0 package is the first version that contains the `jsx-runtime` and `jsx-dev-runtime` files so it shouldn't cause any errors. Running the tests locally on 16.14.0 pass as well.