### PR TITLE
Run test suite against React 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,10 @@ jobs:
 
       - name: Test react production build
         run: pnpm test:prod
+
+      - name: Test React 16
+        working-directory: packages/react
+        run: |
+          pnpm i react@16 react-dom@16 react-router-dom@5
+          pnpm -w test:minify
+          pnpm -w test:prod

--- a/packages/react/test/react-router.test.tsx
+++ b/packages/react/test/react-router.test.tsx
@@ -3,9 +3,23 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 import { signal } from "@preact/signals-react";
 import { createElement } from "react";
-import { Route, Routes, MemoryRouter } from "react-router-dom";
+import * as ReactRouter from "react-router-dom";
 
 import { act, checkHangingAct, createRoot, Root } from "./utils";
+
+const MemoryRouter = ReactRouter.MemoryRouter;
+const Routes = ReactRouter.Routes
+	? ReactRouter.Routes
+	: (ReactRouter as any).Switch; // react-router-dom v5
+
+// @ts-expect-error We are doing a check for react-router-dom v5 vs v6 here, so
+// while TS thinks ReactRouter.Routes will always be here, it isn't in v5.
+const Route = ReactRouter.Routes
+	? ReactRouter.Route
+	: // react-router-dom v5 requires the element prop to be passed as children.
+	  ({ element, ...props }: any) => (
+			<ReactRouter.Route {...props}>{element}</ReactRouter.Route>
+	  );
 
 describe("@preact/signals-react", () => {
 	let scratch: HTMLDivElement;

--- a/packages/react/test/utils.ts
+++ b/packages/react/test/utils.ts
@@ -1,9 +1,13 @@
+import React from "react";
 import { act as realAct } from "react-dom/test-utils";
 
 export interface Root {
 	render(element: JSX.Element | null): void;
 	unmount(): void;
 }
+
+export const isProd = process.env.NODE_ENV === "production";
+export const isReact16 = React.version.startsWith("16.");
 
 // We need to use createRoot() if it's available, but it's only available in
 // React 18. To enable local testing with React 16 & 17, we'll create a fake


### PR DESCRIPTION
React 16 and React 18 have different enough behavior I'd like to run tests against both to ensure no regressions