### PR TITLE
Remove prettier override so editorconfig is applied

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,11 @@
 {
-	"$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
-	"changelog": ["@changesets/changelog-github", { "repo": "preactjs/signals" }],
-	"commit": false,
-	"fixed": [],
-	"linked": [],
-	"access": "public",
-	"baseBranch": "main",
-	"updateInternalDependencies": "patch",
-	"ignore": []
+  "$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
+  "changelog": ["@changesets/changelog-github", { "repo": "preactjs/signals" }],
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,17 @@
 {
-	"name": "preact/signals",
-	"build": {
-		"dockerfile": "Dockerfile"
-	},
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"editor.defaultFormatter": "esbenp.prettier-vscode",
-				"explorer.excludeGitIgnore": true
-			},
-			"extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
-		}
-	},
-	"postCreateCommand": "pnpm i",
-	"remoteUser": "node"
+  "name": "preact/signals",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "explorer.excludeGitIgnore": true
+      },
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  },
+  "postCreateCommand": "pnpm i",
+  "remoteUser": "node"
 }

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -19,7 +19,6 @@ jobs:
       - name: compressed-size-action
         uses: preactjs/compressed-size-action@v2
         with:
-          pattern: '{packages/*/dist/!(*.module|*.min).{js,mjs},docs/dist/**/*.{js,css}}'
-          build-script: 'ci:build'
+          pattern: "{packages/*/dist/!(*.module|*.min).{js,mjs},docs/dist/**/*.{js,css}}"
+          build-script: "ci:build"
           strip-hash: "[.-](\\w{8,9})\\.(?:js|css)$"
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Signals
 
 Signals is a performant state management library with two primary goals:
@@ -22,17 +21,17 @@ npm install @preact/signals-core
 ```
 
 - [Guide / API](#guide--api)
-	- [`signal(initialValue)`](#signalinitialvalue)
-		- [`signal.peek()`](#signalpeek)
-	- [`computed(fn)`](#computedfn)
-	- [`effect(fn)`](#effectfn)
-	- [`batch(fn)`](#batchfn)
+  - [`signal(initialValue)`](#signalinitialvalue)
+    - [`signal.peek()`](#signalpeek)
+  - [`computed(fn)`](#computedfn)
+  - [`effect(fn)`](#effectfn)
+  - [`batch(fn)`](#batchfn)
 - [Preact Integration](./packages/preact/README.md#preact-integration)
-	- [Hooks](./packages/preact/README.md#hooks)
-	- [Rendering optimizations](./packages/preact/README.md#rendering-optimizations)
-		- [Attribute optimization (experimental)](./packages/preact/README.md#attribute-optimization-experimental)
+  - [Hooks](./packages/preact/README.md#hooks)
+  - [Rendering optimizations](./packages/preact/README.md#rendering-optimizations)
+    - [Attribute optimization (experimental)](./packages/preact/README.md#attribute-optimization-experimental)
 - [React Integration](./packages/react/README.md#react-integration)
-	- [Hooks](./packages/react/README.md#hooks)
+  - [Hooks](./packages/react/README.md#hooks)
 - [License](#license)
 
 ## Guide / API

--- a/docs/demos/react/tsconfig.json
+++ b/docs/demos/react/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsxImportSource": "react",
+    "jsxImportSource": "react"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,34 +1,34 @@
 {
-	"name": "demo",
-	"private": true,
-	"scripts": {
-		"start": "vite",
-		"build": "vite build",
-		"preview": "vite preview"
-	},
-	"postcss": {
-		"plugins": {
-			"postcss-nesting": {}
-		}
-	},
-	"dependencies": {
-		"preact": "10.9.0",
-		"preact-iso": "^2.3.0",
-		"preact-render-to-string": "^5.2.1",
-		"@preact/signals-core": "workspace:../packages/core",
-		"@preact/signals": "workspace:../packages/preact",
-		"@preact/signals-react": "workspace:../packages/react",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
-	},
-	"devDependencies": {
-		"@babel/core": "^7.18.10",
-		"@preact/preset-vite": "^2.3.0",
-		"@types/react": "^18.0.18",
-		"@types/react-dom": "^18.0.6",
-		"postcss": "^8.4.16",
-		"postcss-nesting": "^10.1.10",
-		"tiny-glob": "^0.2.9",
-		"vite": "^3.0.7"
-	}
+  "name": "demo",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "postcss": {
+    "plugins": {
+      "postcss-nesting": {}
+    }
+  },
+  "dependencies": {
+    "preact": "10.9.0",
+    "preact-iso": "^2.3.0",
+    "preact-render-to-string": "^5.2.1",
+    "@preact/signals-core": "workspace:../packages/core",
+    "@preact/signals": "workspace:../packages/preact",
+    "@preact/signals-react": "workspace:../packages/react",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.18.10",
+    "@preact/preset-vite": "^2.3.0",
+    "@types/react": "^18.0.18",
+    "@types/react-dom": "^18.0.6",
+    "postcss": "^8.4.16",
+    "postcss-nesting": "^10.1.10",
+    "tiny-glob": "^0.2.9",
+    "vite": "^3.0.7"
+  }
 }

--- a/mangle.json
+++ b/mangle.json
@@ -5,11 +5,7 @@
   },
   "minify": {
     "mangle": {
-      "reserved": [
-        "useSignal",
-        "useComputed",
-        "useSignalEffect"
-      ],
+      "reserved": ["useSignal", "useComputed", "useSignalEffect"],
       "keep_classnames": true,
       "properties": {
         "regex": "^_[^_]",

--- a/package.json
+++ b/package.json
@@ -1,99 +1,99 @@
 {
-	"name": "preact-signals",
-	"private": true,
-	"scripts": {
-		"prebuild": "rimraf packages/core/dist/ packages/preact/dist",
-		"build": "pnpm build:core && pnpm build:preact && pnpm build:react",
-		"build:core": "microbundle --raw --cwd packages/core && pnpm postbuild:core",
-		"build:preact": "microbundle --raw --cwd packages/preact && pnpm postbuild:preact",
-		"build:react": "microbundle --raw --cwd packages/react && pnpm postbuild:react",
-		"postbuild:core": "cd packages/core/dist && mv -f index.d.ts signals-core.d.ts",
-		"postbuild:preact": "cd packages/preact/dist && mv -f preact/src/index.d.ts signals.d.ts && rm -dr preact",
-		"postbuild:react": "cd packages/react/dist && mv -f react/src/index.d.ts signals.d.ts && rm -dr react",
-		"postbuild": "node ./scripts/node-13-exports.js",
-		"lint": "eslint 'packages/**/*.{ts,tsx,js,jsx}'",
-		"test": "pnpm test:karma && pnpm test:mocha",
-		"test:minify": "pnpm test:karma:minify && pnpm test:mocha",
-		"test:prod": "pnpm test:karma:prod && pnpm test:mocha:prod",
-		"test:karma": "cross-env COVERAGE=true karma start karma.conf.js --single-run",
-		"test:karma:minify": "cross-env COVERAGE=true MINIFY=true karma start karma.conf.js --single-run",
-		"test:karma:watch": "karma start karma.conf.js --no-single-run",
-		"test:karma:prod": "cross-env MINIFY=true NODE_ENV=production karma start karma.conf.js --single-run",
-		"test:karma:prod:watch": "cross-env NODE_ENV=production karma start karma.conf.js --no-single-run",
-		"test:mocha": "cross-env COVERAGE=true mocha --require packages/react/test/node/setup.js --recursive packages/react/test/node/**.test.tsx",
-		"test:mocha:prod": "cross-env COVERAGE=true NODE_ENV=production mocha --require packages/react/test/node/setup.js --recursive packages/react/test/node/**.test.tsx",
-		"docs:start": "cd docs && pnpm start",
-		"docs:build": "cd docs && pnpm build",
-		"docs:preview": "cd docs && pnpm preview",
-		"ci:build": "pnpm build && pnpm docs:build",
-		"ci:test": "pnpm lint && pnpm test",
-		"release": "pnpm changeset version && pnpm install && git add -A && git commit -m 'Version Packages' && changeset tag && pnpm publish -r"
-	},
-	"authors": [
-		"The Preact Authors (https://github.com/preactjs/signals/contributors)"
-	],
-	"license": "MIT",
-	"devDependencies": {
-		"@babel/core": "^7.19.1",
-		"@babel/plugin-transform-typescript": "^7.19.1",
-		"@babel/preset-env": "^7.19.1",
-		"@babel/preset-react": "^7.18.6",
-		"@babel/preset-typescript": "^7.18.6",
-		"@babel/register": "^7.21.0",
-		"@changesets/changelog-github": "^0.4.6",
-		"@changesets/cli": "^2.24.2",
-		"@types/chai": "^4.3.3",
-		"@types/mocha": "^9.1.1",
-		"@types/node": "^18.6.5",
-		"@types/sinon": "^10.0.13",
-		"@types/sinon-chai": "^3.2.8",
-		"@typescript-eslint/eslint-plugin": "^5.33.0",
-		"@typescript-eslint/parser": "^5.33.0",
-		"babel-plugin-istanbul": "^6.1.1",
-		"babel-plugin-transform-rename-properties": "^0.1.0",
-		"chai": "^4.3.6",
-		"cross-env": "^7.0.3",
-		"errorstacks": "^2.4.0",
-		"esbuild": "^0.14.54",
-		"eslint": "^8.21.0",
-		"eslint-config-prettier": "^8.5.0",
-		"husky": "^8.0.1",
-		"karma": "6.3.16",
-		"karma-chai-sinon": "^0.1.5",
-		"karma-chrome-launcher": "^3.1.1",
-		"karma-coverage": "^2.2.0",
-		"karma-esbuild": "^2.2.5",
-		"karma-mocha": "^2.0.1",
-		"karma-mocha-reporter": "^2.2.5",
-		"karma-sinon": "^1.0.5",
-		"kolorist": "^1.5.1",
-		"lint-staged": "^13.0.3",
-		"microbundle": "^0.15.1",
-		"mocha": "^10.0.0",
-		"prettier": "^2.7.1",
-		"rimraf": "^3.0.2",
-		"sinon": "^14.0.0",
-		"sinon-chai": "^3.7.0",
-		"typescript": "^4.7.4"
-	},
-	"lint-staged": {
-		"**/*.{js,jsx,ts,tsx,yml}": [
-			"prettier --write"
-		]
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
-	},
-	"prettier": {
-		"useTabs": true,
-		"arrowParens": "avoid"
-	},
-	"pnpm": {
-		"patchedDependencies": {
-			"microbundle@0.15.1": "patches/microbundle@0.15.1.patch",
-			"@babel/plugin-transform-typescript@7.19.1": "patches/@babel__plugin-transform-typescript@7.19.1.patch"
-		}
-	}
+  "name": "preact-signals",
+  "private": true,
+  "scripts": {
+    "prebuild": "rimraf packages/core/dist/ packages/preact/dist",
+    "build": "pnpm build:core && pnpm build:preact && pnpm build:react",
+    "build:core": "microbundle --raw --cwd packages/core && pnpm postbuild:core",
+    "build:preact": "microbundle --raw --cwd packages/preact && pnpm postbuild:preact",
+    "build:react": "microbundle --raw --cwd packages/react && pnpm postbuild:react",
+    "postbuild:core": "cd packages/core/dist && mv -f index.d.ts signals-core.d.ts",
+    "postbuild:preact": "cd packages/preact/dist && mv -f preact/src/index.d.ts signals.d.ts && rm -dr preact",
+    "postbuild:react": "cd packages/react/dist && mv -f react/src/index.d.ts signals.d.ts && rm -dr react",
+    "postbuild": "node ./scripts/node-13-exports.js",
+    "lint": "eslint 'packages/**/*.{ts,tsx,js,jsx}'",
+    "test": "pnpm test:karma && pnpm test:mocha",
+    "test:minify": "pnpm test:karma:minify && pnpm test:mocha",
+    "test:prod": "pnpm test:karma:prod && pnpm test:mocha:prod",
+    "test:karma": "cross-env COVERAGE=true karma start karma.conf.js --single-run",
+    "test:karma:minify": "cross-env COVERAGE=true MINIFY=true karma start karma.conf.js --single-run",
+    "test:karma:watch": "karma start karma.conf.js --no-single-run",
+    "test:karma:prod": "cross-env MINIFY=true NODE_ENV=production karma start karma.conf.js --single-run",
+    "test:karma:prod:watch": "cross-env NODE_ENV=production karma start karma.conf.js --no-single-run",
+    "test:mocha": "cross-env COVERAGE=true mocha --require packages/react/test/node/setup.js --recursive packages/react/test/node/**.test.tsx",
+    "test:mocha:prod": "cross-env COVERAGE=true NODE_ENV=production mocha --require packages/react/test/node/setup.js --recursive packages/react/test/node/**.test.tsx",
+    "docs:start": "cd docs && pnpm start",
+    "docs:build": "cd docs && pnpm build",
+    "docs:preview": "cd docs && pnpm preview",
+    "ci:build": "pnpm build && pnpm docs:build",
+    "ci:test": "pnpm lint && pnpm test",
+    "release": "pnpm changeset version && pnpm install && git add -A && git commit -m 'Version Packages' && changeset tag && pnpm publish -r",
+    "format": "prettier --ignore-path .gitignore --write '**/*.{js,jsx,ts,tsx,yml,json,md}'"
+  },
+  "authors": [
+    "The Preact Authors (https://github.com/preactjs/signals/contributors)"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/core": "^7.19.1",
+    "@babel/plugin-transform-typescript": "^7.19.1",
+    "@babel/preset-env": "^7.19.1",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.18.6",
+    "@babel/register": "^7.21.0",
+    "@changesets/changelog-github": "^0.4.6",
+    "@changesets/cli": "^2.24.2",
+    "@types/chai": "^4.3.3",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^18.6.5",
+    "@types/sinon": "^10.0.13",
+    "@types/sinon-chai": "^3.2.8",
+    "@typescript-eslint/eslint-plugin": "^5.33.0",
+    "@typescript-eslint/parser": "^5.33.0",
+    "babel-plugin-istanbul": "^6.1.1",
+    "babel-plugin-transform-rename-properties": "^0.1.0",
+    "chai": "^4.3.6",
+    "cross-env": "^7.0.3",
+    "errorstacks": "^2.4.0",
+    "esbuild": "^0.14.54",
+    "eslint": "^8.21.0",
+    "eslint-config-prettier": "^8.5.0",
+    "husky": "^8.0.1",
+    "karma": "6.3.16",
+    "karma-chai-sinon": "^0.1.5",
+    "karma-chrome-launcher": "^3.1.1",
+    "karma-coverage": "^2.2.0",
+    "karma-esbuild": "^2.2.5",
+    "karma-mocha": "^2.0.1",
+    "karma-mocha-reporter": "^2.2.5",
+    "karma-sinon": "^1.0.5",
+    "kolorist": "^1.5.1",
+    "lint-staged": "^13.0.3",
+    "microbundle": "^0.15.1",
+    "mocha": "^10.0.0",
+    "prettier": "^2.7.1",
+    "rimraf": "^3.0.2",
+    "sinon": "^14.0.0",
+    "sinon-chai": "^3.7.0",
+    "typescript": "^4.7.4"
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx,yml,json,md}": [
+      "prettier --write"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "prettier": {
+    "arrowParens": "avoid"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "microbundle@0.15.1": "patches/microbundle@0.15.1.patch",
+      "@babel/plugin-transform-typescript@7.19.1": "patches/@babel__plugin-transform-typescript@7.19.1.patch"
+    }
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,40 +1,40 @@
 {
-	"name": "@preact/signals-core",
-	"version": "1.3.0",
-	"license": "MIT",
-	"description": "Manage state with style in every framework",
-	"keywords": [],
-	"authors": [
-		"The Preact Authors (https://github.com/preactjs/signals/contributors)"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/preactjs/signals"
-	},
-	"bugs": "https://github.com/preactjs/signals/issues",
-	"homepage": "https://preactjs.com",
-	"funding": {
-		"type": "opencollective",
-		"url": "https://opencollective.com/preact"
-	},
-	"amdName": "preactSignalsCore",
-	"main": "dist/signals-core.js",
-	"module": "dist/signals-core.module.js",
-	"unpkg": "dist/signals-core.min.js",
-	"types": "dist/signals-core.d.ts",
-	"source": "src/index.ts",
-	"sideEffects": false,
-	"exports": {
-		".": {
-			"types": "./dist/signals-core.d.ts",
-			"browser": "./dist/signals-core.module.js",
-			"umd": "./dist/signals-core.umd.js",
-			"import": "./dist/signals-core.mjs",
-			"require": "./dist/signals-core.js"
-		}
-	},
-	"mangle": "../../mangle.json",
-	"scripts": {
-		"prepublishOnly": "cp ../../README.md . && cd ../.. && pnpm build:core"
-	}
+  "name": "@preact/signals-core",
+  "version": "1.3.0",
+  "license": "MIT",
+  "description": "Manage state with style in every framework",
+  "keywords": [],
+  "authors": [
+    "The Preact Authors (https://github.com/preactjs/signals/contributors)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/preactjs/signals"
+  },
+  "bugs": "https://github.com/preactjs/signals/issues",
+  "homepage": "https://preactjs.com",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+  },
+  "amdName": "preactSignalsCore",
+  "main": "dist/signals-core.js",
+  "module": "dist/signals-core.module.js",
+  "unpkg": "dist/signals-core.min.js",
+  "types": "dist/signals-core.d.ts",
+  "source": "src/index.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/signals-core.d.ts",
+      "browser": "./dist/signals-core.module.js",
+      "umd": "./dist/signals-core.umd.js",
+      "import": "./dist/signals-core.mjs",
+      "require": "./dist/signals-core.js"
+    }
+  },
+  "mangle": "../../mangle.json",
+  "scripts": {
+    "prepublishOnly": "cp ../../README.md . && cd ../.. && pnpm build:core"
+  }
 }

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -23,7 +23,7 @@ describe("signal", () => {
 
 	it("should support JSON.Stringify()", () => {
 		const s = signal(123);
-		expect(JSON.stringify({ s })).equal(JSON.stringify({ s: 123}));
+		expect(JSON.stringify({ s })).equal(JSON.stringify({ s: 123 }));
 	});
 
 	it("should support .valueOf()", () => {

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -1,4 +1,3 @@
-
 # Signals
 
 Signals is a performant state management library with two primary goals:
@@ -15,15 +14,15 @@ npm install @preact/signals
 ```
 
 - [Guide / API](../../README.md#guide--api)
-	- [`signal(initialValue)`](../../README.md#signalinitialvalue)
-		- [`signal.peek()`](../../README.md#signalpeek)
-	- [`computed(fn)`](../../README.md#computedfn)
-	- [`effect(fn)`](../../README.md#effectfn)
-	- [`batch(fn)`](../../README.md#batchfn)
+  - [`signal(initialValue)`](../../README.md#signalinitialvalue)
+    - [`signal.peek()`](../../README.md#signalpeek)
+  - [`computed(fn)`](../../README.md#computedfn)
+  - [`effect(fn)`](../../README.md#effectfn)
+  - [`batch(fn)`](../../README.md#batchfn)
 - [Preact Integration](#preact-integration)
-	- [Hooks](#hooks)
-	- [Rendering optimizations](#rendering-optimizations)
-		- [Attribute optimization (experimental)](#attribute-optimization-experimental)
+  - [Hooks](#hooks)
+  - [Rendering optimizations](#rendering-optimizations)
+    - [Attribute optimization (experimental)](#attribute-optimization-experimental)
 - [License](#license)
 
 ## Preact Integration

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,50 +1,50 @@
 {
-	"name": "@preact/signals",
-	"version": "1.1.3",
-	"license": "MIT",
-	"description": "Manage state with style in Preact",
-	"keywords": [],
-	"authors": [
-		"The Preact Authors (https://github.com/preactjs/signals/contributors)"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/preactjs/signals",
-		"directory": "packages/preact"
-	},
-	"bugs": "https://github.com/preactjs/signals/issues",
-	"homepage": "https://preactjs.com",
-	"funding": {
-		"type": "opencollective",
-		"url": "https://opencollective.com/preact"
-	},
-	"amdName": "preactSignals",
-	"main": "dist/signals.js",
-	"module": "dist/signals.module.js",
-	"unpkg": "dist/signals.min.js",
-	"types": "dist/signals.d.ts",
-	"source": "src/index.ts",
-	"exports": {
-		".": {
-			"types": "./dist/signals.d.ts",
-			"browser": "./dist/signals.module.js",
-			"umd": "./dist/signals.umd.js",
-			"import": "./dist/signals.mjs",
-			"require": "./dist/signals.js"
-		}
-	},
-	"mangle": "../../mangle.json",
-	"scripts": {
-		"prepublishOnly": "cd ../.. && pnpm build:preact"
-	},
-	"dependencies": {
-		"@preact/signals-core": "workspace:^1.2.3"
-	},
-	"peerDependencies": {
-		"preact": "10.x"
-	},
-	"devDependencies": {
-		"preact": "10.9.0",
-		"preact-render-to-string": "^5.2.5"
-	}
+  "name": "@preact/signals",
+  "version": "1.1.3",
+  "license": "MIT",
+  "description": "Manage state with style in Preact",
+  "keywords": [],
+  "authors": [
+    "The Preact Authors (https://github.com/preactjs/signals/contributors)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/preactjs/signals",
+    "directory": "packages/preact"
+  },
+  "bugs": "https://github.com/preactjs/signals/issues",
+  "homepage": "https://preactjs.com",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+  },
+  "amdName": "preactSignals",
+  "main": "dist/signals.js",
+  "module": "dist/signals.module.js",
+  "unpkg": "dist/signals.min.js",
+  "types": "dist/signals.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/signals.d.ts",
+      "browser": "./dist/signals.module.js",
+      "umd": "./dist/signals.umd.js",
+      "import": "./dist/signals.mjs",
+      "require": "./dist/signals.js"
+    }
+  },
+  "mangle": "../../mangle.json",
+  "scripts": {
+    "prepublishOnly": "cd ../.. && pnpm build:preact"
+  },
+  "dependencies": {
+    "@preact/signals-core": "workspace:^1.2.3"
+  },
+  "peerDependencies": {
+    "preact": "10.x"
+  },
+  "devDependencies": {
+    "preact": "10.9.0",
+    "preact-render-to-string": "^5.2.5"
+  }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,55 +1,55 @@
 {
-	"name": "@preact/signals-react",
-	"version": "1.3.2",
-	"license": "MIT",
-	"description": "Manage state with style in React",
-	"keywords": [],
-	"authors": [
-		"The Preact Authors (https://github.com/preactjs/signals/contributors)"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/preactjs/signals",
-		"directory": "packages/react"
-	},
-	"bugs": "https://github.com/preactjs/signals/issues",
-	"homepage": "https://preactjs.com",
-	"funding": {
-		"type": "opencollective",
-		"url": "https://opencollective.com/preact"
-	},
-	"amdName": "reactSignals",
-	"main": "dist/signals.js",
-	"module": "dist/signals.module.js",
-	"unpkg": "dist/signals.min.js",
-	"types": "dist/signals.d.ts",
-	"source": "src/index.ts",
-	"exports": {
-		".": {
-			"types": "./dist/signals.d.ts",
-			"browser": "./dist/signals.module.js",
-			"umd": "./dist/signals.umd.js",
-			"import": "./dist/signals.mjs",
-			"require": "./dist/signals.js"
-		}
-	},
-	"mangle": "../../mangle.json",
-	"scripts": {
-		"prepublishOnly": "cd ../.. && pnpm build:react"
-	},
-	"dependencies": {
-		"@preact/signals-core": "workspace:^1.3.0",
-		"use-sync-external-store": "^1.2.0"
-	},
-	"peerDependencies": {
-		"react": "^16.14.0 || 17.x || 18.x"
-	},
-	"devDependencies": {
-		"@types/react": "^18.0.18",
-		"@types/react-dom": "^18.0.6",
-		"@types/use-sync-external-store": "^0.0.3",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
-		"react-router-dom": "^6.9.0"
-	}
+  "name": "@preact/signals-react",
+  "version": "1.3.2",
+  "license": "MIT",
+  "description": "Manage state with style in React",
+  "keywords": [],
+  "authors": [
+    "The Preact Authors (https://github.com/preactjs/signals/contributors)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/preactjs/signals",
+    "directory": "packages/react"
+  },
+  "bugs": "https://github.com/preactjs/signals/issues",
+  "homepage": "https://preactjs.com",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+  },
+  "amdName": "reactSignals",
+  "main": "dist/signals.js",
+  "module": "dist/signals.module.js",
+  "unpkg": "dist/signals.min.js",
+  "types": "dist/signals.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/signals.d.ts",
+      "browser": "./dist/signals.module.js",
+      "umd": "./dist/signals.umd.js",
+      "import": "./dist/signals.mjs",
+      "require": "./dist/signals.js"
+    }
+  },
+  "mangle": "../../mangle.json",
+  "scripts": {
+    "prepublishOnly": "cd ../.. && pnpm build:react"
+  },
+  "dependencies": {
+    "@preact/signals-core": "workspace:^1.3.0",
+    "use-sync-external-store": "^1.2.0"
+  },
+  "peerDependencies": {
+    "react": "^16.14.0 || 17.x || 18.x"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.18",
+    "@types/react-dom": "^18.0.6",
+    "@types/use-sync-external-store": "^0.0.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.9.0"
+  }
 }

--- a/scripts/node-13-exports.js
+++ b/scripts/node-13-exports.js
@@ -5,8 +5,9 @@ const pkgDir = path.join(__dirname, "..", "packages");
 const pkgs = fs.readdirSync(pkgDir);
 
 const copy = dir => {
-	let name = JSON.parse(fs.readFileSync(path.join(pkgDir, dir, "package.json")))
-		.name;
+	let name = JSON.parse(
+		fs.readFileSync(path.join(pkgDir, dir, "package.json"), "utf-8")
+	).name;
 	name = name.replace(/^(@[a-z_0-9]*)/, "");
 
 	// Copy .module.js --> .mjs for Node 13 compat.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,15 +11,9 @@
     "stripInternal": true,
     "noUnusedLocals": true,
     "paths": {
-      "@preact/signals-core": [
-        "./packages/core/src/index.ts"
-      ],
-      "@preact/signals": [
-        "./packages/preact/src/index.ts"
-      ],
-      "@preact/signals-react": [
-        "./packages/react/src/index.ts"
-      ]
+      "@preact/signals-core": ["./packages/core/src/index.ts"],
+      "@preact/signals": ["./packages/preact/src/index.ts"],
+      "@preact/signals-react": ["./packages/react/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
We had `useTabs: true` in our prettier config which overrode our `.editorconfig` to use spaces in `json` files. I've removed the `useTabs` in the package.json prettier config so `.editorconfig` is used instead. I've also reformatted all the code so it's consistent.