### PR TITLE
refactor: Remove non-functional `package.json#exports.umd`

### DIFF
--- a/.changeset/chilled-cheetahs-grin.md
+++ b/.changeset/chilled-cheetahs-grin.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-core": patch
+"@preact/signals": patch
+"@preact/signals-react": patch
+---
+
+Removes package.json#exports.umd, which had invalid paths if they were ever to be consumed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,6 @@
     ".": {
       "types": "./dist/signals-core.d.ts",
       "browser": "./dist/signals-core.module.js",
-      "umd": "./dist/signals-core.umd.js",
       "import": "./dist/signals-core.mjs",
       "require": "./dist/signals-core.js"
     }

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -28,7 +28,6 @@
     ".": {
       "types": "./dist/signals.d.ts",
       "browser": "./dist/signals.module.js",
-      "umd": "./dist/signals.umd.js",
       "import": "./dist/signals.mjs",
       "require": "./dist/signals.js"
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,6 @@
     ".": {
       "types": "./dist/signals.d.ts",
       "browser": "./dist/signals.module.js",
-      "umd": "./dist/signals.umd.js",
       "import": "./dist/signals.mjs",
       "require": "./dist/signals.js"
     }

--- a/packages/react/runtime/package.json
+++ b/packages/react/runtime/package.json
@@ -12,7 +12,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/runtime.module.js",
-      "umd": "./dist/runtime.min.js",
       "import": "./dist/runtime.mjs",
       "require": "./dist/runtime.js"
     }


### PR DESCRIPTION
In all three of the packages, `package.json#exports.umd` has been referencing the incorrect path for the UMD bundles since release (should've been `x.min.js`).

However, seeing as how I can't see a single complaint relating to this, and I'm not aware of any tools that actually consume it (would love to know if there are tools that do), I elected to remove the entries. Saves us from making a breaking change in the future if we were to alter that entry in any way.