### PR TITLE
Fix internal property names

### DIFF
--- a/.changeset/plenty-rabbits-tickle.md
+++ b/.changeset/plenty-rabbits-tickle.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+Fix internal property names

--- a/packages/react/runtime/package.json
+++ b/packages/react/runtime/package.json
@@ -8,6 +8,7 @@
   "unpkg": "dist/runtime.min.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
+  "mangle": "../../../mangle.json",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
I forgot to include the mangle.json pointer in the new package.json so some property names weren't being properly mangled. 

Note: no tests fail because currently `@preact/signals-react` bundles the runtime package inside of it's bundled output and those properties are mangled - it doesn't import from `/runtime`. I left that as is for now since the `/runtime` package is intended to be an internal detail that will likely change in the future. I discovered this while working on the babel transform which does import from `/runtime` directly.