### PR TITLE
Added `untracked` function

### DIFF
--- a/.changeset/dirty-geese-learn.md
+++ b/.changeset/dirty-geese-learn.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": minor
+---
+
+Added `untracked` api, to more flexible control over dependency tracking. More info in README.md

--- a/.changeset/dirty-geese-learn.md
+++ b/.changeset/dirty-geese-learn.md
@@ -2,4 +2,4 @@
 "@preact/signals-core": minor
 ---
 
-Added `untracked` api, to more flexible control over dependency tracking. More info in README.md
+Add `untracked` function, this allows more granular control within `effect`/`computed` around what should affect re-runs.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npm install @preact/signals-core
   - [`computed(fn)`](#computedfn)
   - [`effect(fn)`](#effectfn)
   - [`batch(fn)`](#batchfn)
+  - [`untracked(fn)`](#untrackedfn)
 - [Preact Integration](./packages/preact/README.md#preact-integration)
   - [Hooks](./packages/preact/README.md#hooks)
   - [Rendering optimizations](./packages/preact/README.md#rendering-optimizations)
@@ -70,6 +71,25 @@ effect(() => {
 	// Whenever this effect is triggered, increase `effectCount`.
 	// But we don't want this signal to react to `effectCount`
 	effectCount.value = effectCount.peek() + 1;
+});
+```
+
+Note that you should only use `signal.peek()` if you really need it. Reading a signal's value via `signal.value` is the preferred way in most scenarios.
+
+### `untracked(fn)`
+
+In case when you're receiving a callback that can read some signals, but you don't want to subscribe to them, you can use `untracked` to prevent any subscriptions from happening.
+
+```js
+const counter = signal(0);
+const effectCount = signal(0);
+const fn = () => effectCount.value + 1;
+
+effect(() => {
+	console.log(counter.value);
+
+	// Whenever this effect is triggered, run `fn` that gives new value
+	effectCount.value = untracked(fn);
 });
 ```
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,21 @@ function batch<T>(callback: () => T): T {
 // Currently evaluated computed or effect.
 let evalContext: Computed | Effect | undefined = undefined;
 
+let untrackDepth = 0;
+function untrack<T>(callback: () => T): T {
+	if (untrackDepth > 0) {
+		return callback();
+	}
+	const prevContext = evalContext;
+	untrackDepth++;
+	try {
+		return callback();
+	} finally {
+		untrackDepth--;
+		evalContext = prevContext;
+	}
+}
+
 // Effects collected into a batch.
 let batchedEffect: Effect | undefined = undefined;
 let batchDepth = 0;
@@ -752,4 +767,4 @@ function effect(compute: () => unknown | EffectCleanup): () => void {
 	return effect._dispose.bind(effect);
 }
 
-export { signal, computed, effect, batch, Signal, type ReadonlySignal };
+export { signal, computed, effect, batch, Signal, type ReadonlySignal, untrack };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,17 +97,19 @@ function batch<T>(callback: () => T): T {
 // Currently evaluated computed or effect.
 let evalContext: Computed | Effect | undefined = undefined;
 
-let untrackDepth = 0;
-function untrack<T>(callback: () => T): T {
-	if (untrackDepth > 0) {
+
+let untrackedDepth = 0;
+
+function untracked<T>(callback: () => T): T {
+	if (untrackedDepth > 0) {
 		return callback();
 	}
 	const prevContext = evalContext;
-	untrackDepth++;
+	untrackedDepth++;
 	try {
 		return callback();
 	} finally {
-		untrackDepth--;
+		untrackedDepth--;
 		evalContext = prevContext;
 	}
 }
@@ -767,4 +769,4 @@ function effect(compute: () => unknown | EffectCleanup): () => void {
 	return effect._dispose.bind(effect);
 }
 
-export { signal, computed, effect, batch, Signal, type ReadonlySignal, untrack };
+export { signal, computed, effect, batch, Signal, type ReadonlySignal, untracked };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,7 +97,6 @@ function batch<T>(callback: () => T): T {
 // Currently evaluated computed or effect.
 let evalContext: Computed | Effect | undefined = undefined;
 
-
 let untrackedDepth = 0;
 
 function untracked<T>(callback: () => T): T {
@@ -105,6 +104,7 @@ function untracked<T>(callback: () => T): T {
 		return callback();
 	}
 	const prevContext = evalContext;
+	evalContext = undefined;
 	untrackedDepth++;
 	try {
 		return callback();
@@ -769,4 +769,12 @@ function effect(compute: () => unknown | EffectCleanup): () => void {
 	return effect._dispose.bind(effect);
 }
 
-export { signal, computed, effect, batch, Signal, type ReadonlySignal, untracked };
+export {
+	signal,
+	computed,
+	effect,
+	batch,
+	Signal,
+	type ReadonlySignal,
+	untracked,
+};

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -679,22 +679,6 @@ describe("effect()", () => {
 		dispose();
 	});
 
-	it("should not throw on recursive assignment in untracked", () => {
-		const a = signal(1);
-
-		const dispose = effect(() => {
-			a.value;
-			untracked(() => {
-				a.value = 2;
-			});
-		});
-
-		expect(() => (a.value = 3)).not.to.throw();
-		expect(a.value).to.equal(2);
-
-		dispose();
-	});
-
 	it("should not rerun parent effect if a nested child effect's signal's value changes", () => {
 		const parentSignal = signal(0);
 		const childSignal = signal(0);

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -1,4 +1,4 @@
-import { signal, computed, effect, batch, Signal } from "@preact/signals-core";
+import { signal, computed, effect, batch, Signal, untracked } from "@preact/signals-core";
 
 describe("signal", () => {
 	it("should return value", () => {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -642,6 +642,17 @@ describe("effect()", () => {
 		expect(spy).not.to.be.called;
 	});
 
+	it("should not run if readed signals in a untracked", () => {
+		const a = signal(1);
+		const b = signal(2);
+		const spy = sinon.spy(() => a.value + b.value);
+		effect(() => untracked(spy));
+		a.value = 10;
+		b.value = 20;
+
+		expect(spy).to.be.calledOnce;
+	});
+
 	it("should not rerun parent effect if a nested child effect's signal's value changes", () => {
 		const parentSignal = signal(0);
 		const childSignal = signal(0);
@@ -946,6 +957,22 @@ describe("computed()", () => {
 		a.value = 1;
 		expect(() => c.value).to.throw();
 		expect(spy).to.be.calledTwice;
+	});
+
+	it("should not recompute if readed signals in a untracked", () => {
+		const a = signal(1);
+		const b = signal(2);
+		const spy = sinon.spy(() => a.value + b.value);
+		const c = computed(() => untracked(spy));
+
+		expect(spy).to.not.be.called;
+		expect(c.value).to.equal(3);
+		a.value = 10;
+		c.value;
+		b.value = 20;
+		c.value;
+		expect(spy).to.be.calledOnce;
+		expect(c.value).to.equal(3);
 	});
 
 	it("should store thrown non-errors and recompute only after a dependency changes", () => {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -1,4 +1,11 @@
-import { signal, computed, effect, batch, Signal, untracked } from "@preact/signals-core";
+import {
+	signal,
+	computed,
+	effect,
+	batch,
+	Signal,
+	untracked,
+} from "@preact/signals-core";
 
 describe("signal", () => {
 	it("should return value", () => {
@@ -651,6 +658,41 @@ describe("effect()", () => {
 		b.value = 20;
 
 		expect(spy).to.be.calledOnce;
+	});
+
+	it("should not throw on assignment in untracked", () => {
+		const a = signal(1);
+		const aChangedTime = signal(0);
+
+		const dispose = effect(() => {
+			a.value;
+			untracked(() => {
+				aChangedTime.value = aChangedTime.value + 1;
+			});
+		});
+
+		expect(() => (a.value = 2)).not.to.throw();
+		expect(aChangedTime.value).to.equal(2);
+		a.value = 3;
+		expect(aChangedTime.value).to.equal(3);
+
+		dispose();
+	});
+
+	it("should not throw on recursive assignment in untracked", () => {
+		const a = signal(1);
+
+		const dispose = effect(() => {
+			a.value;
+			untracked(() => {
+				a.value = 2;
+			});
+		});
+
+		expect(() => (a.value = 3)).not.to.throw();
+		expect(a.value).to.equal(2);
+
+		dispose();
 	});
 
 	it("should not rerun parent effect if a nested child effect's signal's value changes", () => {

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -19,6 +19,7 @@ npm install @preact/signals
   - [`computed(fn)`](../../README.md#computedfn)
   - [`effect(fn)`](../../README.md#effectfn)
   - [`batch(fn)`](../../README.md#batchfn)
+  - [`untracked(fn)`](../../README.md#untrackedfn)
 - [Preact Integration](#preact-integration)
   - [Hooks](#hooks)
   - [Rendering optimizations](#rendering-optimizations)

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -7,6 +7,7 @@ import {
 	effect,
 	Signal,
 	type ReadonlySignal,
+	untracked,
 } from "@preact/signals-core";
 import {
 	VNode,
@@ -18,7 +19,15 @@ import {
 	AugmentedElement as Element,
 } from "./internal";
 
-export { signal, computed, batch, effect, Signal, type ReadonlySignal };
+export {
+	signal,
+	computed,
+	batch,
+	effect,
+	Signal,
+	type ReadonlySignal,
+	untracked,
+};
 
 const HAS_PENDING_UPDATE = 1 << 0;
 const HAS_HOOK_STATE = 1 << 1;

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,6 +19,7 @@ npm install @preact/signals-react
   - [`computed(fn)`](../../README.md#computedfn)
   - [`effect(fn)`](../../README.md#effectfn)
   - [`batch(fn)`](../../README.md#batchfn)
+  - [`untracked(fn)`](../../README.md#untrackedfn)
 - [React Integration](#react-integration)
   - [Hooks](#hooks)
 - [License](#license)

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,7 @@ import {
 	effect,
 	Signal,
 	type ReadonlySignal,
+	untracked,
 } from "@preact/signals-core";
 import type { ReactElement } from "react";
 import { useSignal, useComputed, useSignalEffect } from "../runtime";
@@ -20,6 +21,7 @@ export {
 	useSignal,
 	useComputed,
 	useSignalEffect,
+	untracked,
 };
 
 declare module "@preact/signals-core" {


### PR DESCRIPTION
Resolves https://github.com/preactjs/signals/issues/378

As mentioned in the proposal this allows us to write effects that essentially aren't re-executed by the signals that get accessed in the function body of `untracked`.

Allowing functionality like

```js
function reaction(sender, listener) {
  effect(() => {
    const value = sender();
    untracked(() => {
      listener(value);
    });
  }
}
```