### PR TITLE
docs: add React fragment note

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,6 +66,36 @@ function Counter() {
 }
 ```
 
+### Rendering optimizations
+
+The React adapter ships with several optimizations it can apply out of the box to skip virtual-dom rendering entirely. If you pass a signal directly into JSX, it will bind directly to the DOM `Text` node that is created and update that whenever the signal changes.
+
+```js
+import { signal } from "@preact/signals-react";
+
+const count = signal(0);
+
+// Unoptimized: Will trigger the surrounding
+// component to re-render
+function Counter() {
+	return <p>Value: {count.value}</p>;
+}
+
+// Optimized: Will update the text node directly
+function Counter() {
+	return (
+		<p>
+			<>Value: {count}</>
+		</p>
+	);
+}
+```
+
+To opt into this optimization, simply pass the signal directly instead of accessing the `.value` property.
+
+> **Note**
+> The content is wrapped in a React Fragment due to React 18's newer, more strict children types.
+
 ## License
 
 `MIT`, see the [LICENSE](../../LICENSE) file.


### PR DESCRIPTION
There is missing documentation regarding the TypeScript error in React when the signal object is used directly in JSX.  This requires wrapping the object in a React Fragment (see https://github.com/preactjs/signals/issues/323).

This PR adds a note about the React Fragment requirement.  The Preact 'Render Optimization' content was copied with changes to code example and added note.  This updated code sample was tested and working the correctly with React.

https://codesandbox.io/s/preact-signals-in-react-test-mzfv8x\?file\=/src/LogCount.tsx