### PR TITLE
Lower required babel version required as a peer dependency

### DIFF
--- a/.changeset/forty-points-marry.md
+++ b/.changeset/forty-points-marry.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": patch
+---
+
+Lower required babel version required as a peer dependency

--- a/packages/react-transform/package.json
+++ b/packages/react-transform/package.json
@@ -44,7 +44,7 @@
     "use-sync-external-store": "^1.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.22.8",
+    "@babel/core": "^7.0.0",
     "react": "^16.14.0 || 17.x || 18.x"
   },
   "devDependencies": {


### PR DESCRIPTION
To make it easier to use this library in existing projects with various babel versions