### PR TITLE
feat(core): add unique identifier for signals

### DIFF
--- a/.changeset/wild-spies-glow.md
+++ b/.changeset/wild-spies-glow.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": minor
+---
+
+Add unique identifier to every `Signal`, this will be present on the `type` property of a Signal coming from either `signal()` or `computed()`

--- a/mangle.json
+++ b/mangle.json
@@ -5,7 +5,11 @@
   },
   "minify": {
     "mangle": {
-      "reserved": ["useSignal", "useComputed", "useSignalEffect"],
+      "reserved": [
+        "useSignal",
+        "useComputed",
+        "useSignalEffect"
+      ],
       "keep_classnames": true,
       "properties": {
         "regex": "^_[^_]",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,8 @@ function mutationDetected(): never {
 	throw new Error("Computed cannot have side-effects");
 }
 
+const identifier = Symbol.for('preact-signals')
+
 // Flags for Computed and Effect.
 const RUNNING = 1 << 0;
 const NOTIFIED = 1 << 1;
@@ -242,6 +244,8 @@ declare class Signal<T = any> {
 
 	peek(): T;
 
+	type: typeof identifier;
+
 	get value(): T;
 	set value(value: T);
 }
@@ -254,6 +258,8 @@ function Signal(this: Signal, value?: unknown) {
 	this._node = undefined;
 	this._targets = undefined;
 }
+
+Signal.prototype.type = identifier
 
 Signal.prototype._refresh = function () {
 	return true;

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -164,6 +164,16 @@ describe("signal", () => {
 			expect(spy).not.to.be.called;
 		});
 	});
+
+	it("signals should be identified with a symbol", () => {
+		const a = signal(0);
+		expect(a.type).to.equal(Symbol.for('preact-signals'))
+	})
+
+	it("should be identified with a symbol", () => {
+		const a = computed(() => {});
+		expect(a.type).to.equal(Symbol.for('preact-signals'))
+	})
 });
 
 describe("effect()", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2021.WeakRef"],
+    "lib": ["ES2021.WeakRef", "ES2015.Symbol"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
fixes #402

This allows for multiple versions of signals to be in a bundle and still be properly identified as signals.