### PR TITLE
Register newly inserted import statement as a declaration in Babel scope

### DIFF
--- a/.changeset/cyan-swans-serve.md
+++ b/.changeset/cyan-swans-serve.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-react-transform": minor
+---
+
+Remove support for transforming CJS files
+
+Removing support for transforming CommonJS files since we have no tests for it currently

--- a/.changeset/lucky-radios-deny.md
+++ b/.changeset/lucky-radios-deny.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": patch
+---
+
+Register newly inserted import statement as a scope declaration in Babel's scope tracking

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/standalone": "^7.22.6",
     "@changesets/changelog-github": "^0.4.6",
     "@changesets/cli": "^2.24.2",
+    "@types/babel__traverse": "^7.18.5",
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.6.5",

--- a/packages/react-transform/src/index.ts
+++ b/packages/react-transform/src/index.ts
@@ -279,6 +279,29 @@ function createImportLazily(
 		});
 		set(pass, `imports/${importName}`, reference);
 
+		/** Helper function to determine if an import declaration's specifier matches the given importName  */
+		const matchesImportName = (
+			s: BabelTypes.ImportDeclaration["specifiers"][0]
+		) => {
+			if (s.type !== "ImportSpecifier") return false;
+			return (
+				(s.imported.type === "Identifier" && s.imported.name === importName) ||
+				(s.imported.type === "StringLiteral" &&
+					s.imported.value === importName)
+			);
+		};
+
+		for (let statement of path.get("body")) {
+			if (
+				statement.isImportDeclaration() &&
+				statement.node.source.value === source &&
+				statement.node.specifiers.some(matchesImportName)
+			) {
+				path.scope.registerDeclaration(statement);
+				break;
+			}
+		}
+
 		return reference;
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.24.2
         version: 2.24.2
+      '@types/babel__traverse':
+        specifier: ^7.18.5
+        version: 7.18.5
       '@types/chai':
         specifier: ^4.3.3
         version: 4.3.3


### PR DESCRIPTION
When inserting a new import statement, we need to register it with Babel's scope tracking so future usages of the import are properly tracked to this declaration.

I've also removed CJS support currently since we don't have any tests for it and I'm uncertain if the maintenance burden if worth it. Open to suggestions.