### PR TITLE
fix: add microbundle global for preact/hooks package

### DIFF
--- a/.changeset/little-vans-develop.md
+++ b/.changeset/little-vans-develop.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Fix error when using `useSignal` with UMD builds of `@preact/signals`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "prebuild": "rimraf packages/core/dist/ packages/preact/dist",
     "build": "pnpm build:core && pnpm build:preact && pnpm build:react-runtime && pnpm build:react && pnpm build:react-transform",
-    "_build": "microbundle --raw --globals @preact/signals-core=preactSignalsCore",
+    "_build": "microbundle --raw --globals @preact/signals-core=preactSignalsCore,preact/hooks=preactHooks",
     "build:core": "pnpm _build --cwd packages/core && pnpm postbuild:core",
     "build:preact": "pnpm _build --cwd packages/preact && pnpm postbuild:preact",
     "build:react": "pnpm _build --cwd packages/react && pnpm postbuild:react",


### PR DESCRIPTION
## Description

This fixes "useMemo undefined" error when using `useSignal` hook with UMD scripts.

The UMD builds of `preact/hooks` package will attach itself to the global `window.preactHooks` when using CDN, while `@preact/signals` is searching for `window.hooks` and cause this problem.

There is also some messages about this in microbundle's output log:

```
$ pnpm run build:preact

> pnpm _build --cwd packages/preact && pnpm postbuild:preact
> microbundle --raw --globals @preact/signals-core=preactSignalsCore "--cwd" "packages/preact"

No name was provided for external module 'preact/hooks' in output.globals – guessing 'hooks'
```

## Bug Reproduction

Here is a minimal reproduction page demonstrating the issue.

https://stackblitz.com/edit/preact-signals-cdn

```
Uncaught TypeError: Cannot read properties of undefined (reading 'useMemo')
    at useSignal (signals.min.js:1:2667)
    at g.App [as constructor] (use-signal-broken.html:36:29)
    at g.N [as render] (preact.min.js:1:8510)
    at j (preact.min.js:1:6180)
    at x (preact.min.js:1:2071)
    at j (preact.min.js:1:6394)
    at O (preact.min.js:1:8631)
    at use-signal-broken.html:50:7
```

## Expected Changes

The changes to the UMD build of `@preact/signals` package after applying this patch is as below:

```diff
--- signals-broken.min.js       2023-09-20 18:46:16
+++ signals-fixed.min.js        2023-09-20 18:46:14
@@ -11,7 +11,7 @@
                : i(
                                ((n || self).preactSignals = {}),
                                n.preact,
-                               n.hooks,
+                               n.preactHooks,
                                n.preactSignalsCore
                  );
 })(this, function (n, i, r, t) {
```
