### PR TITLE
In tests, skip Babel on node_modules when not down leveling

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,8 @@
       "microbundle@0.15.1": "patches/microbundle@0.15.1.patch",
       "@babel/plugin-transform-typescript@7.19.1": "patches/@babel__plugin-transform-typescript@7.19.1.patch"
     }
+  },
+  "volta": {
+    "node": "18.18.0"
   }
 }


### PR DESCRIPTION
Local tests run a lot faster now since we aren't running babel on all of React DOM