### PR TITLE
[react-transform] Add debug logging to inspect what components are transformed by plugin

### DIFF
--- a/.changeset/twenty-pillows-scream.md
+++ b/.changeset/twenty-pillows-scream.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": patch
+---
+
+Add debug logging to inspect what components are transformed by plugin

--- a/packages/react-transform/package.json
+++ b/packages/react-transform/package.json
@@ -48,6 +48,7 @@
     "@babel/helper-module-imports": "^7.22.5",
     "@babel/helper-plugin-utils": "^7.22.5",
     "@preact/signals-react": "workspace:^1.3.6",
+    "debug": "^4.3.4",
     "use-sync-external-store": "^1.2.0"
   },
   "peerDependencies": {
@@ -59,6 +60,7 @@
     "@types/babel__core": "^7.20.1",
     "@types/babel__helper-module-imports": "^7.18.0",
     "@types/babel__helper-plugin-utils": "^7.10.0",
+    "@types/debug": "^4.1.12",
     "@types/prettier": "^2.7.3",
     "@types/react": "^18.0.18",
     "@types/react-dom": "^18.0.6",

--- a/packages/react-transform/test/node/index.test.tsx
+++ b/packages/react-transform/test/node/index.test.tsx
@@ -19,7 +19,7 @@ import {
 // To help interactively debug a specific test case, add the test ids of the
 // test cases you want to debug to the `debugTestIds` array, e.g. (["258",
 // "259"]). Set to true to debug all tests.
-const DEBUG_TEST_IDS: string[] | true = true;
+const DEBUG_TEST_IDS: string[] | true = [];
 
 const format = (code: string) => prettier.format(code, { parser: "babel" });
 

--- a/packages/react/test/browser/updates.test.tsx
+++ b/packages/react/test/browser/updates.test.tsx
@@ -263,17 +263,16 @@ describe("@preact/signals-react updating", () => {
 		it("should update memo'ed component via signals", async () => {
 			const sig = signal("foo");
 
-			function Inner() {
+			function UseMemoTestInner() {
 				const value = sig.value;
 				return <p>{value}</p>;
 			}
 
-			function App() {
-				sig.value;
-				return useMemo(() => <Inner />, []);
+			function UseMemoTestApp() {
+				return useMemo(() => <UseMemoTestInner />, []);
 			}
 
-			await render(<App />);
+			await render(<UseMemoTestApp />);
 			expect(scratch.textContent).to.equal("foo");
 
 			await act(() => {
@@ -326,10 +325,10 @@ describe("@preact/signals-react updating", () => {
 		it("should consistently rerender in strict mode (with memo)", async () => {
 			const sig = signal(-1);
 
-			const Test = memo(() => <p>{sig.value}</p>);
+			const ReactMemoTest = memo(() => <p>{sig.value}</p>);
 			const App = () => (
 				<StrictMode>
-					<Test />
+					<ReactMemoTest />
 				</StrictMode>
 			);
 
@@ -347,7 +346,7 @@ describe("@preact/signals-react updating", () => {
 		it("should render static markup of a component", async () => {
 			const count = signal(0);
 
-			const Test = () => {
+			const StaticMarkupTest = () => {
 				return (
 					<pre>
 						{renderToStaticMarkup(<code>{count}</code>)}
@@ -356,7 +355,7 @@ describe("@preact/signals-react updating", () => {
 				);
 			};
 
-			await render(<Test />);
+			await render(<StaticMarkupTest />);
 			expect(scratch.textContent).to.equal("<code>0</code><code>0</code>");
 
 			for (let i = 0; i < 3; i++) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       '@preact/signals-react':
         specifier: workspace:^1.3.6
         version: link:../react
+      debug:
+        specifier: ^4.3.4
+        version: 4.3.4(supports-color@8.1.1)
       use-sync-external-store:
         specifier: ^1.2.0
         version: 1.2.0(react@18.2.0)
@@ -283,6 +286,9 @@ importers:
       '@types/babel__helper-plugin-utils':
         specifier: ^7.10.0
         version: 7.10.0
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/prettier':
         specifier: ^2.7.3
         version: 2.7.3
@@ -2385,6 +2391,12 @@ packages:
     resolution: {integrity: sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==}
     dev: true
 
+  /@types/debug@4.1.12:
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+    dependencies:
+      '@types/ms': 0.7.34
+    dev: true
+
   /@types/estree@0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
@@ -2409,6 +2421,10 @@ packages:
 
   /@types/mocha@9.1.1:
     resolution: {integrity: sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==}
+    dev: true
+
+  /@types/ms@0.7.34:
+    resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: true
 
   /@types/node@12.20.55:
@@ -3483,7 +3499,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
-    dev: true
 
   /decamelize-keys@1.1.0:
     resolution: {integrity: sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==}
@@ -4580,7 +4595,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -5692,7 +5706,6 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -7309,7 +7322,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}

--- a/test/browser/nodeGlobals.js
+++ b/test/browser/nodeGlobals.js
@@ -9,3 +9,5 @@ window.process = {
 };
 
 window.Buffer = Buffer;
+
+// localStorage.debug = "signals:react-transform:*";


### PR DESCRIPTION
To assist in deploying and debugging the react signals transform, add the ability to log what functions are transformed by the plugin. Also includes the option to log what functions look like Components but aren't transformed cuz they either don't appear to use Signals or don't contain JSX