### PR TITLE
Use function expression name if it has one

### DIFF
--- a/.changeset/stupid-badgers-float.md
+++ b/.changeset/stupid-badgers-float.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": minor
+---
+
+Use function expression name to determine if it is a Component and should be transformed.

--- a/packages/react-transform/src/index.ts
+++ b/packages/react-transform/src/index.ts
@@ -84,7 +84,11 @@ function getObjectPropertyKey(
  * name), return that. Else return null.
  */
 function getFunctionNodeName(path: NodePath<FunctionLike>): string | null {
-	if (path.node.type === "FunctionDeclaration" && path.node.id) {
+	if (
+		(path.node.type === "FunctionDeclaration" ||
+			path.node.type === "FunctionExpression") &&
+		path.node.id
+	) {
 		return path.node.id.name;
 	} else if (path.node.type === "ObjectMethod") {
 		return getObjectPropertyKey(path.node);


### PR DESCRIPTION
Component's like
```js
var render = function App() { ... }
```
will now by transformed by the babel plugin since the function expression has a valid Component name.

Before it would not be transformed because the variable name was not valid because the variable name begins with a lowercase letter.