### PR TITLE
Removes backward-incompatible type export.

### DIFF
--- a/.changeset/metal-snakes-hide.md
+++ b/.changeset/metal-snakes-hide.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Removes backward-incompatible type export from signals core.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -781,6 +781,6 @@ export {
 	effect,
 	batch,
 	Signal,
-	type ReadonlySignal,
+	ReadonlySignal,
 	untracked,
 };


### PR DESCRIPTION
This syntax (export { type Foo }) insta-breaks the build for any project using versions of TS earlier than v4.5. Verified locally that this change fixes the build for earlier versions while not breaking it for later versions.

I believe the only scenario in which this change could impact tree-shaking is if someone is only importing the `ReadonlySignal` type in a project that doesn't otherwise use signals, which seems unlikely.