### PR TITLE
Import runtime package to prevent src import

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -13,7 +13,7 @@ import {
 	useComputed,
 	useSignalEffect,
 	installAutoSignalTracking,
-} from "../runtime/src/index"; // TODO: This duplicates runtime code between main and sub runtime packages
+} from "../runtime"; // TODO: This duplicates runtime code between main and sub runtime packages
 
 export {
 	signal,


### PR DESCRIPTION
Using less specific import let's typescript resolve to a d.ts file instead of the .ts file.

Fixes #450 