### PR TITLE
Changes void to unknown for callback definitions.

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -40,7 +40,7 @@ function hook<T extends OptionsTypes>(hookName: T, hookFn: HookFn<T>) {
 }
 
 let currentComponent: AugmentedComponent | undefined;
-let finishUpdate: (() => void) | undefined;
+let finishUpdate: (() => unknown) | undefined;
 
 function setCurrentUpdater(updater?: Effect) {
 	// end tracking for the current update:
@@ -49,7 +49,7 @@ function setCurrentUpdater(updater?: Effect) {
 	finishUpdate = updater && updater._start();
 }
 
-function createUpdater(update: () => void) {
+function createUpdater(update: () => unknown) {
 	let updater!: Effect;
 	effect(function (this: Effect) {
 		updater = this;
@@ -356,7 +356,7 @@ export function useComputed<T>(compute: () => T) {
 	return useMemo(() => computed<T>(() => $compute.current()), []);
 }
 
-export function useSignalEffect(cb: () => void | (() => void)) {
+export function useSignalEffect(cb: () => unknown | (() => unknown)) {
 	const callback = useRef(cb);
 	callback.current = cb;
 


### PR DESCRIPTION
A callback like `() => void` means that the caller must provide a function that is explicitly void returning.  This means one cannot pass a function as a callback that may have a return value that is ignored.  By changing the required return type to `unknown`, it allows the caller to provide either a void returning function, or a function that returns a value.

This is especially valuable when you have callback functions like `() => condition && doThing()`.  Such a function returns a boolean value, which makes it incompatible with `() => void` callback requirements.  You can work around this by wrapping the body with curly braces (to throw away the result of the expression), but it is better to be permissive in what is accepted instead.