### PR TITLE
Tweak package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "prebuild": "rimraf packages/core/dist/ packages/preact/dist",
     "build": "pnpm build:core && pnpm build:preact && pnpm build:react-runtime && pnpm build:react-auto && pnpm build:react && pnpm build:react-transform",
-    "_build": "microbundle --raw --globals @preact/signals-core=preactSignalsCore,preact/hooks=preactHooks,@preact/signals-react/runtime=reactSignalsRuntime",
+    "_build": "microbundle --format esm,cjs --raw --globals @preact/signals-core=preactSignalsCore,preact/hooks=preactHooks,@preact/signals-react/runtime=reactSignalsRuntime",
     "build:core": "pnpm _build --cwd packages/core && pnpm postbuild:core",
     "build:preact": "pnpm _build --cwd packages/preact && pnpm postbuild:preact",
     "build:react": "pnpm _build --cwd packages/react --external \"react,@preact/signals-react/runtime,@preact/signals-core\" && pnpm postbuild:react",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   },
   "amdName": "preactSignalsCore",
   "main": "dist/signals-core.js",
-  "module": "dist/signals-core.module.js",
+  "module": "dist/signals-core.mjs",
   "unpkg": "dist/signals-core.min.js",
   "types": "dist/signals-core.d.ts",
   "source": "src/index.ts",
@@ -27,7 +27,7 @@
   "exports": {
     ".": {
       "types": "./dist/signals-core.d.ts",
-      "browser": "./dist/signals-core.module.js",
+      "module": "./dist/signals-core.mjs",
       "import": "./dist/signals-core.mjs",
       "require": "./dist/signals-core.js"
     }

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -20,14 +20,14 @@
   },
   "amdName": "preactSignals",
   "main": "dist/signals.js",
-  "module": "dist/signals.module.js",
+  "module": "dist/signals.mjs",
   "unpkg": "dist/signals.min.js",
   "types": "dist/signals.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
       "types": "./dist/signals.d.ts",
-      "browser": "./dist/signals.module.js",
+      "module": "./dist/signals.mjs",
       "import": "./dist/signals.mjs",
       "require": "./dist/signals.js"
     }

--- a/packages/react-transform/package.json
+++ b/packages/react-transform/package.json
@@ -23,12 +23,13 @@
     "url": "https://opencollective.com/preact"
   },
   "main": "dist/signals-transform.js",
-  "module": "dist/signals-transform.module.js",
+  "module": "dist/signals-transform.mjs",
   "types": "dist/signals-transform.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
       "types": "./dist/signals-transform.d.ts",
+      "module": "./dist/signals-transform.mjs",
       "import": "./dist/signals-transform.mjs",
       "require": "./dist/signals-transform.js"
     }

--- a/packages/react/auto/package.json
+++ b/packages/react/auto/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "amdName": "reactSignalsAuto",
   "main": "dist/auto.js",
-  "module": "dist/auto.module.js",
+  "module": "dist/auto.mjs",
   "unpkg": "dist/auto.min.js",
   "types": "dist/index.d.ts",
   "mangle": "../../../mangle.json",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "browser": "./dist/auto.module.js",
+      "module": "./dist/auto.mjs",
       "import": "./dist/auto.mjs",
       "require": "./dist/auto.js"
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,20 +27,20 @@
   "exports": {
     ".": {
       "types": "./dist/signals.d.ts",
-      "browser": "./dist/signals.module.js",
+      "module": "./dist/signals.mjs",
       "import": "./dist/signals.mjs",
       "require": "./dist/signals.js"
     },
     "./runtime": {
       "types": "./runtime/dist/index.d.ts",
-      "browser": "./runtime/dist/runtime.module.js",
+      "module": "./runtime/dist/runtime.mjs",
       "import": "./runtime/dist/runtime.mjs",
       "require": "./runtime/dist/runtime.js"
     },
     "./runtime/package.json": "./runtime/package.json",
     "./auto": {
       "types": "./auto/dist/index.d.ts",
-      "browser": "./auto/dist/auto.module.js",
+      "module": "./auto/dist/auto.mjs",
       "import": "./auto/dist/auto.mjs",
       "require": "./auto/dist/auto.js"
     },

--- a/packages/react/runtime/package.json
+++ b/packages/react/runtime/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "amdName": "reactSignalsRuntime",
   "main": "dist/runtime.js",
-  "module": "dist/runtime.module.js",
+  "module": "dist/runtime.mjs",
   "unpkg": "dist/runtime.min.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
@@ -12,7 +12,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "browser": "./dist/runtime.module.js",
+      "module": "./dist/runtime.mjs",
       "import": "./dist/runtime.mjs",
       "require": "./dist/runtime.js"
     }


### PR DESCRIPTION
Fix usage in Jest, drop *.module.js for just .mjs (files were nearly identical), don't include `"browser"` export map key, do include `"module"` export map key (to avoid dual package hazard).