### PR TITLE
Fix: always reset the evaluation context upon entering an untracked block

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,19 +99,12 @@ function batch<T>(callback: () => T): T {
 // Currently evaluated computed or effect.
 let evalContext: Computed | Effect | undefined = undefined;
 
-let untrackedDepth = 0;
-
 function untracked<T>(callback: () => T): T {
-	if (untrackedDepth > 0) {
-		return callback();
-	}
 	const prevContext = evalContext;
 	evalContext = undefined;
-	untrackedDepth++;
 	try {
 		return callback();
 	} finally {
-		untrackedDepth--;
 		evalContext = prevContext;
 	}
 }

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -1946,3 +1946,16 @@ describe("batch/transaction", () => {
 		expect(callCount).to.equal(1);
 	});
 });
+
+describe("untracked", () => {
+	it("should block tracking even when run inside effect run inside untracked", () => {
+		const s = signal(1);
+		const spy = sinon.spy(() => s.value);
+
+		untracked(() => effect(() => untracked(spy)));
+		expect(spy).to.be.calledOnce;
+
+		s.value = 2;
+		expect(spy).to.be.calledOnce;
+	});
+});

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -659,36 +659,6 @@ describe("effect()", () => {
 		expect(spy).not.to.be.called;
 	});
 
-	it("should not run if readed signals in a untracked", () => {
-		const a = signal(1);
-		const b = signal(2);
-		const spy = sinon.spy(() => a.value + b.value);
-		effect(() => untracked(spy));
-		a.value = 10;
-		b.value = 20;
-
-		expect(spy).to.be.calledOnce;
-	});
-
-	it("should not throw on assignment in untracked", () => {
-		const a = signal(1);
-		const aChangedTime = signal(0);
-
-		const dispose = effect(() => {
-			a.value;
-			untracked(() => {
-				aChangedTime.value = aChangedTime.value + 1;
-			});
-		});
-
-		expect(() => (a.value = 2)).not.to.throw();
-		expect(aChangedTime.value).to.equal(2);
-		a.value = 3;
-		expect(aChangedTime.value).to.equal(3);
-
-		dispose();
-	});
-
 	it("should not rerun parent effect if a nested child effect's signal's value changes", () => {
 		const parentSignal = signal(0);
 		const childSignal = signal(0);
@@ -993,22 +963,6 @@ describe("computed()", () => {
 		a.value = 1;
 		expect(() => c.value).to.throw();
 		expect(spy).to.be.calledTwice;
-	});
-
-	it("should not recompute if readed signals in a untracked", () => {
-		const a = signal(1);
-		const b = signal(2);
-		const spy = sinon.spy(() => a.value + b.value);
-		const c = computed(() => untracked(spy));
-
-		expect(spy).to.not.be.called;
-		expect(c.value).to.equal(3);
-		a.value = 10;
-		c.value;
-		b.value = 20;
-		c.value;
-		expect(spy).to.be.calledOnce;
-		expect(c.value).to.equal(3);
 	});
 
 	it("should store thrown non-errors and recompute only after a dependency changes", () => {
@@ -1948,6 +1902,18 @@ describe("batch/transaction", () => {
 });
 
 describe("untracked", () => {
+	it("should block tracking inside effects", () => {
+		const a = signal(1);
+		const b = signal(2);
+		const spy = sinon.spy(() => a.value + b.value);
+		effect(() => untracked(spy));
+		expect(spy).to.be.calledOnce;
+
+		a.value = 10;
+		b.value = 20;
+		expect(spy).to.be.calledOnce;
+	});
+
 	it("should block tracking even when run inside effect run inside untracked", () => {
 		const s = signal(1);
 		const spy = sinon.spy(() => s.value);
@@ -1957,5 +1923,40 @@ describe("untracked", () => {
 
 		s.value = 2;
 		expect(spy).to.be.calledOnce;
+	});
+
+	it("should not cause signal assignments throw", () => {
+		const a = signal(1);
+		const aChangedTime = signal(0);
+
+		const dispose = effect(() => {
+			a.value;
+			untracked(() => {
+				aChangedTime.value = aChangedTime.value + 1;
+			});
+		});
+
+		expect(() => (a.value = 2)).not.to.throw();
+		expect(aChangedTime.value).to.equal(2);
+		a.value = 3;
+		expect(aChangedTime.value).to.equal(3);
+
+		dispose();
+	});
+
+	it("should block tracking inside computed signals", () => {
+		const a = signal(1);
+		const b = signal(2);
+		const spy = sinon.spy(() => a.value + b.value);
+		const c = computed(() => untracked(spy));
+
+		expect(spy).to.not.be.called;
+		expect(c.value).to.equal(3);
+		a.value = 10;
+		c.value;
+		b.value = 20;
+		c.value;
+		expect(spy).to.be.calledOnce;
+		expect(c.value).to.equal(3);
 	});
 });


### PR DESCRIPTION
This pull request fixes an issue with multiple levels of mixed `effect` and `untracked` calls:

```ts
import { signal, effect, untracked } from "@preact/signals-core";

const s = signal(0);

untracked(() => {
  effect(() => {
    untracked(() => {
      console.log(s.value); // <-- s.value gets tracked while inside untracked(...)
    });
  });
});
// 0 gets printed to the console

s.value = 1;
// 1 gets printed to the console
```

The expected behavior is that the effect should not run when `s.value` is set to `1`, because `s.value` was only used inside `untracked`. Therefore the effect should not become dependent on `s.value`.

The root cause is that only the outermost level of nested `untracked()` calls sets the evaluation context to undefined (which disables tracking). The fix is to unconditionally set the evaluation context to undefined inside every `untracked` call. The `untrackedDepth` counter then becomes unused.

The first commit of this pull request adds a test for the issue. The second commit applies the fix and removes the `untrackedDepth` counter.

The last commit does some minor refactoring: it just moves all tests related to `untracked` into their own section in the test file and modifies the test names accordingly. The last commit can be dropped if it feels superfluous.