### PR TITLE
refactor: implement signals-core with untranspiled classes

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -144,6 +144,7 @@ function createEsbuildPlugin() {
 						{
 							jsxPragma: "createElement",
 							jsxPragmaFrag: "Fragment",
+							allowDeclareFields: true,
 						},
 					];
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "prebuild": "rimraf packages/core/dist/ packages/preact/dist",
     "build": "pnpm build:core && pnpm build:preact && pnpm build:react-runtime && pnpm build:react-auto && pnpm build:react && pnpm build:react-transform",
     "_build": "microbundle --raw --globals @preact/signals-core=preactSignalsCore,preact/hooks=preactHooks,@preact/signals-react/runtime=reactSignalsRuntime",
-    "build:core": "pnpm _build --cwd packages/core && pnpm postbuild:core",
+    "build:core": "pnpm -F @preact/signals-core build && pnpm postbuild:core",
     "build:preact": "pnpm _build --cwd packages/preact && pnpm postbuild:preact",
     "build:react": "pnpm _build --cwd packages/react --external \"react,@preact/signals-react/runtime,@preact/signals-core\" && pnpm postbuild:react",
     "build:react-auto": "pnpm _build --cwd packages/react/auto && pnpm postbuild:react-auto",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,20 @@
     }
   },
   "mangle": "../../mangle.json",
+  "babel": {
+    "presets": [
+      [
+        "@babel/preset-env",
+        {
+          "exclude": [
+            "transform-classes"
+          ]
+        }
+      ]
+    ]
+  },
   "scripts": {
+    "build": "microbundle --raw",
     "prepublishOnly": "cp ../../README.md . && cd ../.. && pnpm build:core"
   },
   "files": [

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -125,6 +125,11 @@ Object.defineProperties(Signal.prototype, {
 	__b: { configurable: true, value: 1 },
 });
 
+// Due to the prototype hierarchy of native classes, having Signal.prototype.constructor
+// been set to undefined gets masked for Computed.prototype. We need to explicitly set
+// Computed.prototype.constructor to undefined as well.
+computed(() => 0).constructor.prototype.constructor = undefined;
+
 /** Inject low-level property/attribute bindings for Signals into Preact's diff */
 hook(OptionsTypes.DIFF, (old, vnode) => {
 	if (typeof vnode.type === "string") {


### PR DESCRIPTION
This pull request converts the signals-core package to use ES6 classes instead of ES5-style prototypes. It effectively reverts the changes introduced in #160.

Notes:
 * The classes are not transpiled to ES5: The transpilation is disabled by excluding the transform-classes Babel transform when transpiling the core.
 * Some class property definitions use TypeScript's `declare` keyword. This avoids a redundant property assignment getting added to the class's constructor. There is a comment included that describes this reasoning.
 * Computed's prototype chain changes from `Computed` -> `Signal` to `Computed` -> `Intermediate` -> `Signal`. The Preact binding needed to be modified to take this into account: setting `Signal.prototype.constructor` to `undefined` gets masked and `Computed.prototype.constructor` is not `undefined` anymore. Which led to [this cursed piece of code](https://github.com/preactjs/signals/pull/520/files#diff-4591ce43e1392f08bc0ff48bbb0365d81a7565d97afa329834d8f3011b7928edR128-R132) by Yours Truly.

The sizes of the build artifacts before and after this change are listed below. In general the number of bytes saved falls around 40-60 bytes, depending on the output format.

```
Before:
       1487 B: signals-core.js.gz
       1352 B: signals-core.js.br
       1513 B: signals-core.mjs.gz
       1378 B: signals-core.mjs.br
       1498 B: signals-core.module.js.gz
       1369 B: signals-core.module.js.br
       1561 B: signals-core.min.js.gz
       1421 B: signals-core.min.js.br

After:
       1429 B: signals-core.js.gz
       1300 B: signals-core.js.br
       1449 B: signals-core.mjs.gz
       1328 B: signals-core.mjs.br
       1438 B: signals-core.module.js.gz
       1316 B: signals-core.module.js.br
       1513 B: signals-core.min.js.gz
       1379 B: signals-core.min.js.br
```