### PR TITLE
refactor: use untracked to implement Signal.prototype.subscribe

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -288,16 +288,9 @@ Signal.prototype._unsubscribe = function (node) {
 };
 
 Signal.prototype.subscribe = function (fn) {
-	const signal = this;
-	return effect(function (this: Effect) {
-		const value = signal.value;
-		const flag = this._flags & TRACKING;
-		this._flags &= ~TRACKING;
-		try {
-			fn(value);
-		} finally {
-			this._flags |= flag;
-		}
+	return effect(() => {
+		const value = this.value;
+		untracked(() => fn(value));
 	});
 };
 
@@ -550,7 +543,7 @@ Computed.prototype._subscribe = function (node) {
 	if (this._targets === undefined) {
 		this._flags |= OUTDATED | TRACKING;
 
-		// A computed signal subscribes lazily to its dependencies when the it
+		// A computed signal subscribes lazily to its dependencies when it
 		// gets its first subscriber.
 		for (
 			let node = this._sources;
@@ -768,12 +761,4 @@ function effect(compute: () => unknown | EffectCleanup): () => void {
 	return effect._dispose.bind(effect);
 }
 
-export {
-	signal,
-	computed,
-	effect,
-	batch,
-	Signal,
-	ReadonlySignal,
-	untracked,
-};
+export { signal, computed, effect, batch, Signal, ReadonlySignal, untracked };


### PR DESCRIPTION
This pull request uses the `untracked()` function to simplify the implementation of the `Signal.prototype.subscribe` method. The functionality of the method stays the same.

Byte savings fall between 2 and 19 bytes, depending on the bundling output format:

```
Before this PR:
       1487 B: signals-core.js.gz
       1352 B: signals-core.js.br
       1513 B: signals-core.mjs.gz
       1378 B: signals-core.mjs.br
       1498 B: signals-core.module.js.gz
       1369 B: signals-core.module.js.br
       1561 B: signals-core.min.js.gz
       1421 B: signals-core.min.js.br

After this PR:
       1481 B: signals-core.js.gz
       1350 B: signals-core.js.br
       1494 B: signals-core.mjs.gz
       1363 B: signals-core.mjs.br
       1488 B: signals-core.module.js.gz
       1352 B: signals-core.module.js.br
       1557 B: signals-core.min.js.gz
       1414 B: signals-core.min.js.br
```

The downside is that `untracked` can't get tree-shaken as easily. Fortunately, based on a quick test that only imported `signal`+`computed`+`effect`, the amount of removed code is enough that the end result seems to save bytes also in cases where `untracked` would have been tree-shaken before.