### PR TITLE
Allow setting a signal value inside a computed

### DIFF
--- a/.changeset/dull-pumas-carry.md
+++ b/.changeset/dull-pumas-carry.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": minor
+---
+
+Allow setting a signal value inside a computed

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,3 @@
-function mutationDetected(): never {
-	throw new Error("Computed cannot have side-effects");
-}
-
 // An named symbol/brand for detecting Signal instances even when they weren't
 // created using the same signals library version.
 const BRAND_SYMBOL = Symbol.for("preact-signals");
@@ -331,10 +327,6 @@ Object.defineProperty(Signal.prototype, "value", {
 		return this._value;
 	},
 	set(this: Signal, value) {
-		if (evalContext instanceof Computed) {
-			mutationDetected();
-		}
-
 		if (value !== this._value) {
 			if (batchIteration > 100) {
 				throw new Error("Cycle detected");

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -596,7 +596,7 @@ describe("effect()", () => {
 		expect(fn).to.throw(/Cycle detected/);
 	});
 
-	it("should throw if a computed tries to set a signal's value", () => {
+	it("should throw on indirect cycles", () => {
 		const a = signal(0);
 		let i = 0;
 
@@ -615,7 +615,7 @@ describe("effect()", () => {
 				c.value;
 			});
 
-		expect(fn).to.throw(/Computed cannot have side-effects/);
+		expect(fn).to.throw(/Cycle detected/);
 	});
 
 	it("should allow disposing the effect multiple times", () => {
@@ -925,13 +925,16 @@ describe("computed()", () => {
 		expect(spy).to.be.calledOnce;
 	});
 
-	it("should disallow setting signal's value", () => {
-		const v = 123;
-		const a: Signal = signal(v);
-		const c: Signal = computed(() => a.value++);
-
-		expect(() => c.value).to.throw(/Computed cannot have side-effects/);
-		expect(a.value).to.equal(v);
+	it("should recompute if a dependency changes during computation after becoming a dependency", () => {
+		const a = signal(0);
+		const spy = sinon.spy(() => {
+			a.value++;
+		});
+		const c = computed(spy);
+		c.value;
+		expect(spy).to.be.calledOnce;
+		c.value;
+		expect(spy).to.be.calledTwice;
 	});
 
 	it("should detect simple dependency cycles", () => {


### PR DESCRIPTION
This pull request allows setting a `signal`'s value inside a `computed`. Previously the following code was not allowed and raised an error with the message "Computed cannot have side-effects":

```ts
const s = signal(0);

const c = computed(() => {
  s.value = 1;
});

c.value; // Error: Computed cannot have side-effects
```

This suggested change is based on Slack discussions (TL;DR: there may be legitimate use-cases that the side-effect limitation blocks / the "regular" cycle detection might be enough for preventing runaway modification loops) and submitted here for further evaluation. /cc @developit @marvinhagemeister 

This change saves some bytes from the output bundles:

```
Before this change:
       1481 B: signals-core.js.gz
       1350 B: signals-core.js.br
       1494 B: signals-core.mjs.gz
       1363 B: signals-core.mjs.br
       1488 B: signals-core.module.js.gz
       1352 B: signals-core.module.js.br
       1557 B: signals-core.min.js.gz
       1414 B: signals-core.min.js.br

After this change:
       1439 B: signals-core.js.gz
       1312 B: signals-core.js.br
       1452 B: signals-core.mjs.gz
       1325 B: signals-core.mjs.br
       1448 B: signals-core.module.js.gz
       1315 B: signals-core.module.js.br
       1518 B: signals-core.min.js.gz
       1381 B: signals-core.min.js.br
```