### PR TITLE
refactor: inline cycle errors & use a shared .peek() implementation for signals and computeds

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,10 @@
-function cycleDetected(): never {
-	throw new Error("Cycle detected");
-}
 function mutationDetected(): never {
 	throw new Error("Computed cannot have side-effects");
 }
 
-const identifier = Symbol.for("preact-signals");
+// An named symbol/brand for detecting Signal instances even when they weren't
+// created using the same signals library version.
+const BRAND_SYMBOL = Symbol.for("preact-signals");
 
 // Flags for Computed and Effect.
 const RUNNING = 1 << 0;
@@ -237,7 +236,7 @@ declare class Signal<T = any> {
 
 	peek(): T;
 
-	brand: typeof identifier;
+	brand: typeof BRAND_SYMBOL;
 
 	get value(): T;
 	set value(value: T);
@@ -252,7 +251,7 @@ function Signal(this: Signal, value?: unknown) {
 	this._targets = undefined;
 }
 
-Signal.prototype.brand = identifier;
+Signal.prototype.brand = BRAND_SYMBOL;
 
 Signal.prototype._refresh = function () {
 	return true;
@@ -325,7 +324,7 @@ Object.defineProperty(Signal.prototype, "value", {
 
 		if (value !== this._value) {
 			if (batchIteration > 100) {
-				cycleDetected();
+				throw new Error("Cycle detected");
 			}
 
 			this._value = value;
@@ -593,7 +592,7 @@ Computed.prototype._notify = function () {
 
 Computed.prototype.peek = function () {
 	if (!this._refresh()) {
-		cycleDetected();
+		throw new Error("Cycle detected");
 	}
 	if (this._flags & HAS_ERROR) {
 		throw this._value;
@@ -604,7 +603,7 @@ Computed.prototype.peek = function () {
 Object.defineProperty(Computed.prototype, "value", {
 	get() {
 		if (this._flags & RUNNING) {
-			cycleDetected();
+			throw new Error("Cycle detected");
 		}
 		const node = addDependency(this);
 		this._refresh();
@@ -719,7 +718,7 @@ Effect.prototype._callback = function () {
 
 Effect.prototype._start = function () {
 	if (this._flags & RUNNING) {
-		cycleDetected();
+		throw new Error("Cycle detected");
 	}
 	this._flags |= RUNNING;
 	this._flags &= ~DISPOSED;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -306,7 +306,13 @@ Signal.prototype.toJSON = function () {
 };
 
 Signal.prototype.peek = function () {
-	return this._value;
+	const prevContext = evalContext;
+	evalContext = undefined;
+	try {
+		return this.value;
+	} finally {
+		evalContext = prevContext;
+	}
 };
 
 Object.defineProperty(Signal.prototype, "value", {
@@ -588,16 +594,6 @@ Computed.prototype._notify = function () {
 			node._target._notify();
 		}
 	}
-};
-
-Computed.prototype.peek = function () {
-	if (!this._refresh()) {
-		throw new Error("Cycle detected");
-	}
-	if (this._flags & HAS_ERROR) {
-		throw this._value;
-	}
-	return this._value;
 };
 
 Object.defineProperty(Computed.prototype, "value", {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -1175,6 +1175,21 @@ describe("computed()", () => {
 			expect(c.peek()).equal(1);
 		});
 
+		it("should throw when evaluation throws", () => {
+			const c = computed(() => {
+				throw Error("test");
+			});
+			expect(() => c.peek()).to.throw("test");
+		});
+
+		it("should throw when previous evaluation threw and dependencies haven't changed", () => {
+			const c = computed(() => {
+				throw Error("test");
+			});
+			expect(() => c.value).to.throw("test");
+			expect(() => c.peek()).to.throw("test");
+		});
+
 		it("should refresh value if stale", () => {
 			const a = signal(1);
 			const b = computed(() => a.value);


### PR DESCRIPTION
This pull request 
 * Inline the `cycleDetected` function. The downside is that the error message is now repeated in multiple places of the codebase. The next change helps with this by removing one of these repeats.
 * Reimplement `Signal.prototype.peek` that works for both Signal and Computed instances, so that the specialized `Computed.prototype.peek` implementation can be removed. This also removes one place where `cycleDetected` was used.

A couple of new tests are included to test that computeds' `peek()` still throws errors when the computed function fails.

In aggregate these changes save between 10 and 29 bytes, depending on the output format:

```
Before:
       1481 B: signals-core.js.gz
       1350 B: signals-core.js.br
       1494 B: signals-core.mjs.gz
       1363 B: signals-core.mjs.br
       1488 B: signals-core.module.js.gz
       1352 B: signals-core.module.js.br
       1557 B: signals-core.min.js.gz
       1414 B: signals-core.min.js.br

After:
       1454 B: signals-core.js.gz
       1324 B: signals-core.js.br
       1474 B: signals-core.mjs.gz
       1356 B: signals-core.mjs.br
       1468 B: signals-core.module.js.gz
       1337 B: signals-core.module.js.br
       1528 B: signals-core.min.js.gz
       1401 B: signals-core.min.js.br
```