### PR TITLE
refactor: inline Signal.prototype.subscribe implementation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -290,7 +290,14 @@ Signal.prototype._unsubscribe = function (node) {
 Signal.prototype.subscribe = function (fn) {
 	return effect(() => {
 		const value = this.value;
-		untracked(() => fn(value));
+
+		const prevContext = evalContext;
+		evalContext = undefined;
+		try {
+			fn(value);
+		} finally {
+			evalContext = prevContext;
+		}
 	});
 };
 

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -118,6 +118,16 @@ describe("signal", () => {
 			expect(spy).to.be.calledWith(1);
 		});
 
+		it("should run the callback when the signal value changes", () => {
+			const spy = sinon.spy();
+			const a = signal(1);
+
+			a.subscribe(spy);
+
+			a.value = 2;
+			expect(spy).to.be.calledWith(2);
+		});
+
 		it("should unsubscribe from a signal", () => {
 			const spy = sinon.spy();
 			const a = signal(1);


### PR DESCRIPTION
This pull request is a continuation for #523, where the `Signal.prototype.subscribe` method was implemented using the `untracked()` function, saving some bytes. 

Inlining the `untracked()` call saves bytes for most output formats and solves the tree-shaking downside mentioned in #523.

```
Before:
       1481 B: signals-core.js.gz
       1350 B: signals-core.js.br
       1494 B: signals-core.mjs.gz
       1363 B: signals-core.mjs.br
       1488 B: signals-core.module.js.gz
       1352 B: signals-core.module.js.br
       1557 B: signals-core.min.js.gz
       1414 B: signals-core.min.js.br

After:
       1474 B: signals-core.js.gz
       1333 B: signals-core.js.br
       1497 B: signals-core.mjs.gz
       1364 B: signals-core.mjs.br
       1486 B: signals-core.module.js.gz
       1353 B: signals-core.module.js.br
       1550 B: signals-core.min.js.gz
       1412 B: signals-core.min.js.br
```

A new test case is included for checking that the subscription callback will run when the signal's original value changes after the subscription has been created.