### PR TITLE
chore: add changesets for recent pull requests

### DIFF
--- a/.changeset/cool-pianos-fly.md
+++ b/.changeset/cool-pianos-fly.md
@@ -1,0 +1,10 @@
+---
+"@preact/signals-core": patch
+"@preact/signals": patch
+"@preact/signals-react": patch
+"@preact/signals-react-transform": patch
+---
+
+Publish packages with provenance statements
+
+pr: #535

--- a/.changeset/neat-carrots-drop.md
+++ b/.changeset/neat-carrots-drop.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-core": patch
+---
+
+Document effect cleanups
+
+pr: #529

--- a/.changeset/perfect-onions-remember.md
+++ b/.changeset/perfect-onions-remember.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-core": patch
+---
+
+Always reset the evaluation context upon entering an untracked block
+
+pr: #512

--- a/.changeset/rare-colts-smash.md
+++ b/.changeset/rare-colts-smash.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-core": patch
+---
+
+Add JSDocs for exported core module members
+
+pr: #531


### PR DESCRIPTION
This pull request adds changesets for #512, #529, #531 and #535. The changesets use the "pr: #N" syntax introduced in https://github.com/changesets/changesets/pull/535 for signaling which pull requests they're related to.

All the changesets apply only to the core, _except_ the changeset for #535 ("Publish packages with provenance statements") which introduces a patch bump for all of the packages.