### PR TITLE
build: update pnpm lockfile on changeset version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
+          version: pnpm run version
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "ci:build": "pnpm build && pnpm docs:build",
     "ci:test": "pnpm lint && pnpm test",
     "prepare": "husky install",
-    "format": "prettier --ignore-path .gitignore --write '**/*.{js,jsx,ts,tsx,yml,json,md}'"
+    "format": "prettier --ignore-path .gitignore --write '**/*.{js,jsx,ts,tsx,yml,json,md}'",
+    "version": "pnpm changeset version && pnpm i --lockfile-only"
   },
   "authors": [
     "The Preact Authors (https://github.com/preactjs/signals/contributors)"


### PR DESCRIPTION
This pull request modifies the changeset version bump script to also update the pnpm lockfile when needed. The solution is based on https://github.com/changesets/action/issues/203#issuecomment-1483000632.

This hopefully solves https://github.com/preactjs/signals/pull/528#issuecomment-1999126668, i.e. preact-signals-demo deployments failing when internal dependencies are bumped.