### PR TITLE
chore(hooks): removed usage of useMemo instead using useConst implemented with useRef

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -33,18 +33,14 @@ const HAS_PENDING_UPDATE = 1 << 0;
 const HAS_HOOK_STATE = 1 << 1;
 const HAS_COMPUTEDS = 1 << 2;
 
+const UNINITIALIZED = {};
 
 function useConst<T>(fn: () => T): T {
-	interface RefManagement {
-		value: T
-		status: 'uninitialized' | 'initialized'
+	const ref = useRef<typeof UNINITIALIZED | T>(UNINITIALIZED);
+	if (ref.current === UNINITIALIZED) {
+		ref.current = fn();
 	}
-	const ref = useRef<RefManagement>({status: 'uninitialized'} as any)
-	if (ref.current.status === 'uninitialized') {
-		ref.current = {status: 'initialized', value: fn()}
-	}
-
-	return ref.current.value
+	return ref.current;
 }
 
 

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -1,5 +1,5 @@
 import { options, Component, isValidElement } from "preact";
-import { useRef, useMemo, useEffect } from "preact/hooks";
+import { useRef, useEffect } from "preact/hooks";
 import {
 	signal,
 	computed,

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -5,7 +5,7 @@ import {
 	Signal,
 	ReadonlySignal,
 } from "@preact/signals-core";
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
 import { isAutoSignalTrackingInstalled } from "./auto";
 

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -360,17 +360,14 @@ Object.defineProperties(Signal.prototype, {
 	ref: { configurable: true, value: null },
 });
 
-function useConst<T>(fn: () => T): T {
-	interface RefManagement {
-		value: T
-		status: 'uninitialized' | 'initialized'
-	}
-	const ref = useRef<RefManagement>({status: 'uninitialized'} as any)
-	if (ref.current.status === 'uninitialized') {
-		ref.current = {status: 'initialized', value: fn()}
-	}
+const UNINITIALIZED = {};
 
-	return ref.current.value
+function useConst<T>(fn: () => T): T {
+	const ref = useRef<typeof UNINITIALIZED | T>(UNINITIALIZED);
+	if (ref.current === UNINITIALIZED) {
+		ref.current = fn();
+	}
+	return ref.current;
 }
 
 export function useSignals(usage?: EffectStoreUsage): EffectStore {


### PR DESCRIPTION
Proposing to prevent using hooks based on array dependency to simplify data lifecycle.

- It does not create multiple empty arrays for future GC collection
- Simple check  to create the instance

Maybe this change is small and not worthy. Considering the usage of several hooks around the application, it would reduce the GC time slices.