### PR TITLE
Test change to run karma tests with latest chrome

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,8 @@ var coverage = String(process.env.COVERAGE) === "true",
 const babel = require("@babel/core");
 const fs = require("fs").promises;
 
+// test
+
 var localLaunchers = {
 	ChromeNoSandboxHeadless: {
 		base: "Chrome",


### PR DESCRIPTION
Investigating test failures explained in https://github.com/preactjs/signals/issues/546

Will need approval to let tests run against CI.

I noticed the [last time the test suite ran](https://github.com/preactjs/signals/actions/runs/8347769508/job/22848155169), Chrome Headless 122.0.6261.128 (Linux x86_64) was used and the failures were on Chrome 123.
