### PR TITLE
Fix out-of-order effect error when suspending in React Native

### DIFF
--- a/.changeset/gorgeous-moose-hope.md
+++ b/.changeset/gorgeous-moose-hope.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+Fix out-of-order effect error when suspending in React Native

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -1333,6 +1333,7 @@ describe("computed()", () => {
 
 			(gc as () => void)();
 			await new Promise(resolve => setTimeout(resolve, 0));
+			(gc as () => void)();
 			expect(ref.deref()).to.be.undefined;
 		});
 
@@ -1352,6 +1353,7 @@ describe("computed()", () => {
 			dispose();
 			(gc as () => void)();
 			await new Promise(resolve => setTimeout(resolve, 0));
+			(gc as () => void)();
 			expect(ref.deref()).to.be.undefined;
 		});
 	});

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -5,7 +5,7 @@ import {
 	Signal,
 	ReadonlySignal,
 } from "@preact/signals-core";
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect, useLayoutEffect } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
 import { isAutoSignalTrackingInstalled } from "./auto";
 
@@ -268,8 +268,9 @@ function createEffectStore(_usage: EffectStoreUsage): EffectStore {
 			}
 		},
 		f() {
-			endEffect?.();
+			const end = endEffect;
 			endEffect = undefined;
+			end?.();
 		},
 		[symDispose]() {
 			this.f();
@@ -307,11 +308,12 @@ const _queueMicroTask = Promise.prototype.then.bind(Promise.resolve());
 let finalCleanup: Promise<void> | undefined;
 export function ensureFinalCleanup() {
 	if (!finalCleanup) {
-		finalCleanup = _queueMicroTask(() => {
-			finalCleanup = undefined;
-			currentStore?.f();
-		});
+		finalCleanup = _queueMicroTask(cleanupTrailingStore);
 	}
+}
+function cleanupTrailingStore() {
+	finalCleanup = undefined;
+	currentStore?.f();
 }
 
 /**
@@ -331,6 +333,8 @@ export function _useSignalsImplementation(
 	const store = storeRef.current;
 	useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
 	store._start();
+	// note: _usage is a constant here, so conditional is okay
+	if (_usage === UNMANAGED) useLayoutEffect(cleanupTrailingStore);
 
 	return store;
 }

--- a/packages/react/runtime/test/browser/suspense.test.tsx
+++ b/packages/react/runtime/test/browser/suspense.test.tsx
@@ -1,3 +1,6 @@
+// @ts-expect-error
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 import { createElement, lazy, useLayoutEffect, Suspense } from "react";
 import { signal } from "@preact/signals-core";
 import {
@@ -110,11 +113,11 @@ describe("Suspense", () => {
 		await render(<Parent />);
 		expect(scratch.innerHTML).to.equal("<span>loading...</span>");
 
-		act(() => {
+		await act(async () => {
 			signal1.value++;
 			signal2.value++;
 		});
-		act(() => {
+		await act(async () => {
 			signal1.value--;
 			signal2.value--;
 		});
@@ -135,7 +138,7 @@ describe("Suspense", () => {
 			`<p>0</p><div data-foo="0"><span>lazy</span></div>`
 		);
 
-		act(() => {
+		await act(async () => {
 			signal1.value++;
 			signal2.value++;
 		});

--- a/packages/react/runtime/test/browser/suspense.test.tsx
+++ b/packages/react/runtime/test/browser/suspense.test.tsx
@@ -13,7 +13,7 @@ import {
 	getConsoleErrorSpy,
 } from "../../../test/shared/utils";
 
-describe.only("Suspense", () => {
+describe("Suspense", () => {
 	let scratch: HTMLDivElement;
 	let root: Root;
 

--- a/packages/react/runtime/test/browser/suspense.test.tsx
+++ b/packages/react/runtime/test/browser/suspense.test.tsx
@@ -1,0 +1,146 @@
+import { createElement, lazy, useLayoutEffect, Suspense } from "react";
+import { signal } from "@preact/signals-core";
+import {
+	useComputed,
+	useSignalEffect,
+	useSignals,
+} from "@preact/signals-react/runtime";
+import {
+	Root,
+	createRoot,
+	act,
+	checkHangingAct,
+	getConsoleErrorSpy,
+} from "../../../test/shared/utils";
+
+describe.only("Suspense", () => {
+	let scratch: HTMLDivElement;
+	let root: Root;
+
+	async function render(element: Parameters<Root["render"]>[0]) {
+		await act(() => root.render(element));
+	}
+
+	beforeEach(async () => {
+		scratch = document.createElement("div");
+		document.body.appendChild(scratch);
+		root = await createRoot(scratch);
+		getConsoleErrorSpy().resetHistory();
+	});
+
+	afterEach(async () => {
+		await act(() => root.unmount());
+		scratch.remove();
+
+		// TODO: Consider re-enabling, though updates during finalCleanup are not
+		// wrapped in act().
+		//
+		// checkConsoleErrorLogs();
+		checkHangingAct();
+	});
+
+	it("should handle suspending and unsuspending", async () => {
+		const signal1 = signal(0);
+		const signal2 = signal(0);
+		function Child() {
+			useEverything();
+			return <p>{signal1.value}</p>;
+		}
+
+		function Middle({ children }: React.PropsWithChildren) {
+			useEverything();
+			const value = signal1.value;
+			useLayoutEffect(() => {
+				signal1.value++;
+				signal1.value--;
+			}, []);
+			if (!middlePromResolved) throw middleProm;
+			return <div data-foo={value}>{children}</div>;
+		}
+
+		function LazyComponent() {
+			useEverything();
+			return <span>lazy</span>;
+		}
+
+		let resolveMiddleProm!: () => void;
+		let middlePromResolved = false;
+		const middleProm = new Promise(resolve => {
+			resolveMiddleProm = () => {
+				middlePromResolved = true;
+				resolve(undefined);
+			};
+		});
+		let unsuspend!: () => void;
+		let prom = new Promise<{ default: React.ComponentType }>(resolve => {
+			unsuspend = () => resolve({ default: LazyComponent });
+		});
+		const SuspendingComponent = lazy(() => prom);
+
+		function useEverything() {
+			useSignals();
+			signal1.value;
+			signal2.value;
+			const comp = useComputed(() => ({
+				s1: signal1.value,
+				s2: signal2.value,
+			}));
+			comp.value;
+			useSignalEffect(() => {
+				signal1.value;
+				signal2.value;
+			});
+			useSignals();
+			signal1.value;
+			signal2.value;
+		}
+
+		function Parent() {
+			useEverything();
+			return (
+				<Suspense fallback={<span>loading...</span>}>
+					<Child />
+					<Middle>
+						<SuspendingComponent />
+					</Middle>
+				</Suspense>
+			);
+		}
+
+		await render(<Parent />);
+		expect(scratch.innerHTML).to.equal("<span>loading...</span>");
+
+		act(() => {
+			signal1.value++;
+			signal2.value++;
+		});
+		act(() => {
+			signal1.value--;
+			signal2.value--;
+		});
+
+		await act(async () => {
+			resolveMiddleProm();
+			await middleProm;
+		});
+
+		expect(scratch.innerHTML).to.equal("<span>loading...</span>");
+
+		await act(async () => {
+			unsuspend();
+			await prom;
+		});
+
+		expect(scratch.innerHTML).to.equal(
+			`<p>0</p><div data-foo="0"><span>lazy</span></div>`
+		);
+
+		act(() => {
+			signal1.value++;
+			signal2.value++;
+		});
+		expect(scratch.innerHTML).to.equal(
+			`<p>1</p><div data-foo="1"><span>lazy</span></div>`
+		);
+	});
+});

--- a/packages/react/test/shared/utils.ts
+++ b/packages/react/test/shared/utils.ts
@@ -68,10 +68,22 @@ export function checkHangingAct() {
 	}
 }
 
+function realActShim(cb: any) {
+	const ret = realAct(cb);
+	if (String(ret.then).includes("it is not a Promise.")) {
+		return {
+			then(r: any) {
+				r();
+			},
+		};
+	}
+	return ret;
+}
+
 export const act =
 	process.env.NODE_ENV === "production"
 		? (prodActShim as typeof realAct)
-		: realAct;
+		: (realActShim as typeof realAct);
 
 /**
  * `console.log` supports formatting strings with `%s` for string substitutions.


### PR DESCRIPTION
I have not managed to reproduce this in tests, since it only seems to happen in React Native, and I believe only with Hermes. In this environment, layout effects are flushed after a microtask (or synchronously?), and rendering can be triggered synchronously from them (via setState/useSyncExternalStore/etc). This means the "close current tracking context" operation we schedule after a Promise tick doesn't happen before the next render begins, which can cause an unmanaged useSignals() call to be left "open".

I've added a `useLayoutEffect()` to unmanaged `useSignals()` to address this, which just works by closing any open tracking context when React finishes the current render (as defined by the time at which React begins to execute effects).

As part of this, I also had to tweak `store.f()` to ignore repeated calls, as doing so could also trigger the "Out-of-order effect" exception (`endEffect()` does not guard against this internally as its only possible to trigger when reaching into the guts of signals-core as we do in the integration libraries).