### PR TITLE
fix(react-signals-transform): Support nested functions accessing signals

### DIFF
--- a/.changeset/tame-bobcats-invent.md
+++ b/.changeset/tame-bobcats-invent.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": patch
+---
+
+Support nested scopes like a component accessing an array of signals

--- a/packages/react-transform/src/index.ts
+++ b/packages/react-transform/src/index.ts
@@ -63,7 +63,6 @@ function getComponentFunctionDeclaration(
 		const parent = functionScope.path.parent;
 		let functionName = getFunctionName(functionScope.path as any);
 		if (functionName === DefaultExportSymbol) {
-			// TODO
 			functionName = filename || null;
 		}
 		if (isComponentFunction(functionScope.path as any, functionName)) {

--- a/packages/react-transform/test/node/index.test.tsx
+++ b/packages/react-transform/test/node/index.test.tsx
@@ -553,6 +553,26 @@ describe("React Signals Babel Transform", () => {
 				experimental: { noTryFinally: true },
 			});
 		});
+
+		it("recursively propogates `.value` reads to parent component", () => {
+			const inputCode = `
+				function MyComponent() {
+					return <div>{new Array(20).fill(null).map(() => signal.value)}</div>;
+				}
+			`;
+
+			const expectedOutput = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent() {
+					_useSignals();
+					return <div>{new Array(20).fill(null).map(() => signal.value)}</div>;
+				}
+			`;
+
+			runTest(inputCode, expectedOutput, {
+				experimental: { noTryFinally: true },
+			});
+		});
 	});
 
 	describe("importSource option", () => {


### PR DESCRIPTION
This was a bit more complex than initially anticipated due to how we have chosen to transform, I wanted to make as little change as possible so here goes...

- This adds a check to our `memberExpression` that zooms out towards the component definition
- If along the way we encounter any hooks like `useEffect`/... we bail
- When we reach the highest scope we signal this as a component in need of signals

Fixes https://github.com/preactjs/signals/issues/552
Supersedes https://github.com/preactjs/signals/pull/553