### PR TITLE
feat(react-transform): Suppport require syntax in our babel transform

### DIFF
--- a/.changeset/wet-radios-clap.md
+++ b/.changeset/wet-radios-clap.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": minor
+---
+
+Support `require()` syntax in the Babel transform

--- a/packages/react-transform/src/index.ts
+++ b/packages/react-transform/src/index.ts
@@ -457,6 +457,8 @@ function createImportLazily(
 
 			return reference;
 		} else {
+			// This code originates from
+			// https://github.com/XantreDev/preact-signals/blob/%40preact-signals/safe-react%400.6.1/packages/react/src/babel.ts#L390-L400
 			let reference = get(pass, `requires/${importName}`);
 			if (reference) {
 				reference = types.cloneNode(reference);


### PR DESCRIPTION
Noticed we threw an error for non-ESM modules, so added support for that as we are exporting a CJS build of our react-bindings either way.

CC @andrewiggins not sure if you opted out here for a reason

Fixes https://github.com/preactjs/signals/issues/575