### PR TITLE
Raf aligned dom updates

### DIFF
--- a/.changeset/ninety-beans-compare.md
+++ b/.changeset/ninety-beans-compare.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": minor
+---
+
+Defer all DOM updates by an animation frame as well

--- a/.changeset/ninety-beans-compare.md
+++ b/.changeset/ninety-beans-compare.md
@@ -3,14 +3,14 @@
 ---
 
 Defer all DOM updates by an animation frame, this should make it so
-that any used to be synchronous DOM update will be delayed by an
+that any previously synchronous DOM update will be instead delayed by an
 animation frame. This allows Preact to first perform its own render
 cycle and then our direct DOM updates to occur. These will now
 be performed in a batched way which is more performant as the browser
 is prepared to handle these during the animation frame.
 
-This does have one way to how Preact based signals are tested, when
-we perform a signal update we have to wrap it in `act`, in a way
-this was always the case as a signal update that resulted in
-a Preact state update would require it to be wrapped in `act` but
+This does impact how Preact based signals are tested, when
+you perform a signal update, you'll need to wrap it in `act`. In a way
+this was always the case, as a signal update that resulted in
+a Preact state update would require it to be wrapped in `act`, but
 now this is the norm.

--- a/.changeset/ninety-beans-compare.md
+++ b/.changeset/ninety-beans-compare.md
@@ -1,5 +1,5 @@
 ---
-"@preact/signals": minor
+"@preact/signals": major
 ---
 
 Defer all DOM updates by an animation frame, this should make it so

--- a/.changeset/ninety-beans-compare.md
+++ b/.changeset/ninety-beans-compare.md
@@ -2,4 +2,15 @@
 "@preact/signals": minor
 ---
 
-Defer all DOM updates by an animation frame as well
+Defer all DOM updates by an animation frame, this should make it so
+that any used to be synchronous DOM update will be delayed by an
+animation frame. This allows Preact to first perform its own render
+cycle and then our direct DOM updates to occur. These will now
+be performed in a batched way which is more performant as the browser
+is prepared to handle these during the animation frame.
+
+This does have one way to how Preact based signals are tested, when
+we perform a signal update we have to wrap it in `act`, in a way
+this was always the case as a signal update that resulted in
+a Preact state update would require it to be wrapped in `act` but
+now this is the norm.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -381,7 +381,7 @@ function flushEffects() {
 
 function notifyEffects(this: Effect) {
 	if (effectsQueue.push(this) === 1) {
-		defer(flushEffects);
+		(options.debounceRendering || defer)(flushEffects);
 	}
 }
 
@@ -394,7 +394,7 @@ function flushComputeds() {
 
 function notifyComputeds(this: Effect) {
 	if (computedsQueue.push(this) === 1) {
-		defer(flushComputeds);
+		(options.debounceRendering || defer)(flushComputeds);
 	}
 }
 

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -381,7 +381,7 @@ function flushEffects() {
 
 function notifyEffects(this: Effect) {
 	if (effectsQueue.push(this) === 1) {
-		(options.debounceRendering || defer)(flushEffects);
+		(options.requestAnimationFrame || defer)(flushEffects);
 	}
 }
 
@@ -394,7 +394,7 @@ function flushComputeds() {
 
 function notifyComputeds(this: Effect) {
 	if (computedsQueue.push(this) === 1) {
-		(options.debounceRendering || defer)(flushComputeds);
+		(options.requestAnimationFrame || defer)(flushComputeds);
 	}
 }
 

--- a/packages/preact/test/index.test.tsx
+++ b/packages/preact/test/index.test.tsx
@@ -23,7 +23,7 @@ const afterFrame = () => {
 	});
 };
 
-describe("@preact/signals", () => {
+describe.only("@preact/signals", () => {
 	let scratch: HTMLDivElement;
 	let rerender: () => void;
 
@@ -70,8 +70,9 @@ describe("@preact/signals", () => {
 			const text = scratch.firstChild!.firstChild!;
 			expect(text).to.have.property("data", "test");
 
-			sig.value = "changed";
-			await afterFrame();
+			act(() => {
+				sig.value = "changed";
+			});
 
 			// should not remount/replace SignalValue
 			expect(scratch.firstChild!.firstChild!).to.equal(text);
@@ -92,8 +93,9 @@ describe("@preact/signals", () => {
 			const text = scratch.firstChild!.firstChild!;
 			expect(text).to.have.property("data", "test");
 
-			sig.value = "changed";
-			await afterFrame();
+			act(() => {
+				sig.value = "changed";
+			});
 
 			// should not remount/replace SignalValue
 			expect(scratch.firstChild!.firstChild!).to.equal(text);
@@ -111,18 +113,22 @@ describe("@preact/signals", () => {
 				spy();
 				return <span>{x}</span>;
 			}
-			render(<App x={sig} />, scratch);
+
+			act(() => {
+				render(<App x={sig} />, scratch);
+			});
 			spy.resetHistory();
 
 			const text = scratch.firstChild!.firstChild!;
 			expect(text).to.have.property("data", "test");
 
 			const sig2 = signal("different");
-			render(<App x={sig2} />, scratch);
+			act(() => {
+				render(<App x={sig2} />, scratch);
+			});
 			expect(spy).to.have.been.called;
 			spy.resetHistory();
 
-			await afterFrame();
 			// should not remount/replace SignalValue
 			expect(scratch.firstChild!.firstChild!).to.equal(text);
 			// should update the text in-place
@@ -131,15 +137,18 @@ describe("@preact/signals", () => {
 			await sleep();
 			expect(spy).not.to.have.been.called;
 
-			sig.value = "changed old signal";
+			act(() => {
+				sig.value = "changed old signal";
+			});
 
 			await sleep();
 			expect(spy).not.to.have.been.called;
 			// the text should _not_ have changed:
 			expect(text).to.have.property("data", "different");
 
-			sig2.value = "changed";
-			await afterFrame();
+			act(() => {
+				sig2.value = "changed";
+			});
 
 			expect(scratch.firstChild!.firstChild!).to.equal(text);
 			expect(text).to.have.property("data", "changed");
@@ -181,9 +190,9 @@ describe("@preact/signals", () => {
 			expect(text).to.be.an.instanceOf(HTMLSpanElement);
 			expect(text).to.have.property("firstChild").that.is.an.instanceOf(Text);
 
-			sig.value = <div>a</div>;
-			await afterFrame();
-			rerender();
+			act(() => {
+				sig.value = <div>a</div>;
+			});
 			expect(spy).not.to.have.been.calledOnce;
 			scratch.firstChild!.firstChild!.textContent!.should.equal("a");
 		});
@@ -201,26 +210,30 @@ describe("@preact/signals", () => {
 			expect(text.textContent).to.equal("test");
 			expect(text).to.be.an.instanceOf(HTMLSpanElement);
 			expect(text).to.have.property("firstChild").that.is.an.instanceOf(Text);
-			sig.value = "a";
-			await afterFrame();
-			rerender();
+
+			act(() => {
+				sig.value = "a";
+			});
 			text = scratch.firstChild!.firstChild!;
 			expect(text.nodeType).to.equal(Node.TEXT_NODE);
 			expect(text.textContent).to.equal("a");
 
-			sig.value = "b";
-			await afterFrame();
+			act(() => {
+				sig.value = "b";
+			});
 			expect(text.textContent).to.equal("b");
 
-			sig.value = <div>c</div>;
-			await afterFrame();
-			rerender();
+			act(() => {
+				sig.value = <div>c</div>;
+			});
 			await sleep();
 			text = scratch.firstChild!.firstChild!;
 
 			expect(text).to.be.an.instanceOf(HTMLDivElement);
 			expect(text.textContent).to.equal("c");
-			sig.value = <span>d</span>;
+			act(() => {
+				sig.value = <span>d</span>;
+			});
 			await afterFrame();
 			rerender();
 			await sleep();
@@ -475,8 +488,9 @@ describe("@preact/signals", () => {
 
 			expect(scratch.firstChild).to.have.property("checked", true);
 
-			s.value = false;
-			await afterFrame();
+			act(() => {
+				s.value = false;
+			});
 
 			expect(scratch.firstChild).to.have.property("checked", false);
 		});
@@ -494,8 +508,9 @@ describe("@preact/signals", () => {
 
 			expect(scratch.firstChild).to.have.property("value", "initial");
 
-			s.value = "updated";
-			await afterFrame();
+			act(() => {
+				s.value = "updated";
+			});
 
 			expect(scratch.firstChild).to.have.property("value", "updated");
 
@@ -503,8 +518,9 @@ describe("@preact/signals", () => {
 			await sleep();
 			expect(spy).not.to.have.been.called;
 
-			s.value = "second update";
-			await afterFrame();
+			act(() => {
+				s.value = "second update";
+			});
 
 			expect(scratch.firstChild).to.have.property("value", "second update");
 
@@ -532,8 +548,9 @@ describe("@preact/signals", () => {
 			await sleep();
 			expect(spy).not.to.have.been.called;
 
-			style.value = "left: 20px;";
-			await afterFrame();
+			act(() => {
+				style.value = "left: 20px;";
+			});
 
 			expect(div.style).to.have.property("left", "20px");
 
@@ -701,12 +718,9 @@ describe("@preact/signals", () => {
 
 			act(() => {
 				sig.value = "bar";
-				rerender();
 			});
 
 			expect(scratch.textContent).to.equal("bar");
-			await afterFrame();
-			await afterFrame();
 
 			expect(spy).to.have.been.calledOnceWith(
 				"bar",
@@ -751,12 +765,10 @@ describe("@preact/signals", () => {
 			);
 			spy.resetHistory();
 
-			act(async () => {
+			act(() => {
 				sig.value = "bar";
-				rerender();
 			});
 
-			await afterFrame();
 			expect(scratch.textContent).to.equal("bar");
 
 			const child = scratch.firstElementChild;
@@ -783,8 +795,6 @@ describe("@preact/signals", () => {
 				render(<App />, scratch);
 			});
 
-			await afterFrame();
-
 			const child = scratch.firstElementChild;
 
 			expect(cleanup).not.to.have.been.called;
@@ -794,8 +804,6 @@ describe("@preact/signals", () => {
 			act(() => {
 				render(null, scratch);
 			});
-
-			await afterFrame();
 
 			expect(spy).not.to.have.been.called;
 			expect(cleanup).to.have.been.calledOnceWith("foo", child);

--- a/packages/preact/test/index.test.tsx
+++ b/packages/preact/test/index.test.tsx
@@ -13,17 +13,8 @@ import { useContext, useRef, useState } from "preact/hooks";
 import { setupRerender, act } from "preact/test-utils";
 
 const sleep = (ms?: number) => new Promise(r => setTimeout(r, ms));
-const defer =
-	typeof requestAnimationFrame === "undefined"
-		? setTimeout
-		: requestAnimationFrame;
-const afterFrame = () => {
-	return new Promise(res => {
-		defer(res);
-	});
-};
 
-describe.only("@preact/signals", () => {
+describe("@preact/signals", () => {
 	let scratch: HTMLDivElement;
 	let rerender: () => void;
 
@@ -234,7 +225,6 @@ describe.only("@preact/signals", () => {
 			act(() => {
 				sig.value = <span>d</span>;
 			});
-			await afterFrame();
 			rerender();
 			await sleep();
 
@@ -707,7 +697,6 @@ describe.only("@preact/signals", () => {
 			});
 			expect(scratch.textContent).to.equal("foo");
 			// expect(spy).not.to.have.been.called;
-			await afterFrame();
 			expect(spy).to.have.been.calledOnceWith(
 				"foo",
 				scratch.firstElementChild,
@@ -756,7 +745,6 @@ describe.only("@preact/signals", () => {
 				render(<App />, scratch);
 			});
 
-			await afterFrame();
 			expect(cleanup).not.to.have.been.called;
 			expect(spy).to.have.been.calledOnceWith(
 				"foo",

--- a/packages/react/test/shared/updates.tsx
+++ b/packages/react/test/shared/updates.tsx
@@ -161,6 +161,7 @@ export function updateSignalsTests(usingTransform = false) {
 			await act(() => {
 				sig.value = "bar";
 			});
+			await afterFrame();
 			expect(scratch.textContent).to.equal("bar");
 		});
 
@@ -282,6 +283,7 @@ export function updateSignalsTests(usingTransform = false) {
 			await act(() => {
 				sig.value = "bar";
 			});
+			await afterFrame();
 			expect(scratch.textContent).to.equal("bar");
 		});
 
@@ -302,6 +304,7 @@ export function updateSignalsTests(usingTransform = false) {
 			await act(() => {
 				sig.value = "bar";
 			});
+			await afterFrame();
 			expect(scratch.textContent).to.equal("bar");
 		});
 
@@ -322,6 +325,7 @@ export function updateSignalsTests(usingTransform = false) {
 				await act(async () => {
 					sig.value = i;
 				});
+				await afterFrame();
 				expect(scratch.textContent).to.equal("" + i);
 			}
 		});
@@ -343,6 +347,7 @@ export function updateSignalsTests(usingTransform = false) {
 				await act(async () => {
 					sig.value = i;
 				});
+				await afterFrame();
 				expect(scratch.textContent).to.equal("" + i);
 			}
 		});
@@ -411,6 +416,7 @@ export function updateSignalsTests(usingTransform = false) {
 				await act(async () => {
 					count.value += 1;
 				});
+				await afterFrame();
 				expect(scratch.innerHTML).to.equal(
 					`<pre><code>-2</code><code>${count.value * 2}</code></pre>`
 				);
@@ -617,6 +623,7 @@ export function updateSignalsTests(usingTransform = false) {
 			await act(() => {
 				scratch.querySelector("button")!.click();
 			});
+			await afterFrame();
 
 			expect(url.textContent).to.equal("https://domain.com/test?a=2");
 			expect(URLModelProvider).to.be.calledOnce;

--- a/packages/react/test/shared/updates.tsx
+++ b/packages/react/test/shared/updates.tsx
@@ -161,7 +161,6 @@ export function updateSignalsTests(usingTransform = false) {
 			await act(() => {
 				sig.value = "bar";
 			});
-			await afterFrame();
 			expect(scratch.textContent).to.equal("bar");
 		});
 
@@ -283,7 +282,6 @@ export function updateSignalsTests(usingTransform = false) {
 			await act(() => {
 				sig.value = "bar";
 			});
-			await afterFrame();
 			expect(scratch.textContent).to.equal("bar");
 		});
 
@@ -304,7 +302,6 @@ export function updateSignalsTests(usingTransform = false) {
 			await act(() => {
 				sig.value = "bar";
 			});
-			await afterFrame();
 			expect(scratch.textContent).to.equal("bar");
 		});
 
@@ -325,7 +322,6 @@ export function updateSignalsTests(usingTransform = false) {
 				await act(async () => {
 					sig.value = i;
 				});
-				await afterFrame();
 				expect(scratch.textContent).to.equal("" + i);
 			}
 		});
@@ -347,7 +343,6 @@ export function updateSignalsTests(usingTransform = false) {
 				await act(async () => {
 					sig.value = i;
 				});
-				await afterFrame();
 				expect(scratch.textContent).to.equal("" + i);
 			}
 		});
@@ -416,7 +411,6 @@ export function updateSignalsTests(usingTransform = false) {
 				await act(async () => {
 					count.value += 1;
 				});
-				await afterFrame();
 				expect(scratch.innerHTML).to.equal(
 					`<pre><code>-2</code><code>${count.value * 2}</code></pre>`
 				);
@@ -623,7 +617,6 @@ export function updateSignalsTests(usingTransform = false) {
 			await act(() => {
 				scratch.querySelector("button")!.click();
 			});
-			await afterFrame();
 
 			expect(url.textContent).to.equal("https://domain.com/test?a=2");
 			expect(URLModelProvider).to.be.calledOnce;


### PR DESCRIPTION
This also converts our synchronous DOM updates to be animation-frame aligned, this will make them execute in parallel and when the browser is prepared for it.

Let's draw out the ideal scenario we want to create:

- effects that end up in a setState get executed synchronously so these updates are immediately added in the render queue
- signal-effects are deferred by an animation-frame
- TextNodeUpdates are deferred by an animation-frame
- AttributeNodeUpdates are deferred by an animation-frame

Now we can be sure that Preact updates take presedence over our normal DOM updates.

One thing I am unsure of is the following https://github.com/preactjs/signals/blob/main/packages/preact/src/index.ts#L92-L100 whether we can reliably make this also deferred as currently it's synchronous, we could just defer the `s.data = s.peek()` part? From the tests it looks to work as we expect with RAF though 😅 

Fixes https://github.com/preactjs/signals/issues/315
Proof: https://codesandbox.io/p/sandbox/epic-wilbur-hhln8l

This could be considered a breaking change though 😅 

Another thing to consider here would be the testing story, we could tie it into `options.debounceRendering` but that might lead to some odd behavior in terms of rendering. To align with how the user would see this behave it would need to execute Preact updates and then update the nodes directly.

In the latest version of this branch the above is fixed by leveraging `options.requestAnimationFrame` which now means that any signal update needs to be wrapped in `act`. In a way this was always the case as a signal update that resulted in a Preact state update would require it to be wrapped in `act` but now this is the norm.

Doing this investigation made me think about how we do `useSignalEffect` in React and maybe we should leverage the `scheduler` package rather than injecting an arbitrary animation frame as React would better work with its own scheduler.