### PR TITLE
Revert raf aligned effects for react

### DIFF
--- a/.changeset/empty-chefs-repeat.md
+++ b/.changeset/empty-chefs-repeat.md
@@ -1,6 +1,5 @@
 ---
 "@preact/signals": minor
-"@preact/signals-react": minor
 ---
 
 Align signal effects with animation-frames for better performance

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -4,7 +4,6 @@ import {
 	effect,
 	Signal,
 	ReadonlySignal,
-	batch,
 } from "@preact/signals-core";
 import { useRef, useMemo, useEffect, useLayoutEffect } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
@@ -39,7 +38,6 @@ const symDispose: unique symbol =
 interface Effect {
 	_sources: object | undefined;
 	_start(): () => void;
-	_notify: () => void;
 	_callback(): void;
 	_dispose(): void;
 }
@@ -284,9 +282,6 @@ function createEmptyEffectStore(): EffectStore {
 	return {
 		_usage: UNMANAGED,
 		effect: {
-			_notify() {
-				return noop;
-			},
 			_sources: undefined,
 			_callback() {},
 			_start() {
@@ -386,39 +381,12 @@ export function useComputed<T>(compute: () => T): ReadonlySignal<T> {
 	return useMemo(() => computed<T>(() => $compute.current()), Empty);
 }
 
-let oldNotify: (this: Effect) => void,
-	queue: Array<Effect> = [],
-	isFlushing = false;
-
-function flush() {
-	batch(() => {
-		let flushing = [...queue];
-		isFlushing = false;
-		queue.length = 0;
-		for (let i = 0; i < flushing.length; i++) {
-			oldNotify.call(flushing[i]);
-		}
-	});
-}
-
-function notify(this: Effect) {
-	queue.push(this);
-	if (!isFlushing) {
-		isFlushing = true;
-		(typeof requestAnimationFrame === "undefined"
-			? setTimeout
-			: requestAnimationFrame)(flush);
-	}
-}
-
 export function useSignalEffect(cb: () => void | (() => void)) {
 	const callback = useRef(cb);
 	callback.current = cb;
 
 	useEffect(() => {
 		return effect(function (this: Effect) {
-			if (!oldNotify) oldNotify = this._notify;
-			this._notify = notify;
 			return callback.current();
 		});
 	}, Empty);


### PR DESCRIPTION
As we have no good way to align this with i.e. `act` for testing purposes, ... I reckon it's better we just revert this for react.