### PR TITLE
Change delay to double microtask for prop updates

### DIFF
--- a/.changeset/tidy-rivers-fly.md
+++ b/.changeset/tidy-rivers-fly.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Change timing to a double microtask so we are behind the Preact render queue but can't delay as much as a user-input coming in.


### PR DESCRIPTION
This changes the delay for property updates to be a double micro-task, we got a report that in examples like

```jsx
const App = () => {
  const text = useSignal('')
  const style = useSignal('')

  const callback = (input) => {
    text.value = input.currentTarget.value
    if (text.value >= 5) { style.value = 'display:none;'}
  }

  return <input style={style} onInput={callback} value={text} />
}
```

In the above case the user would be able to type 6 characters while we have actually already made the input dissapear.