### PR TITLE
Fix text update recomputing in @preact/signals 1.3.x

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -90,6 +90,13 @@ function SignalValue(this: AugmentedComponent, { data }: { data: Signal }) {
 		}
 
 		this._updater!._callback = () => {
+			// When overriding Effect._callback, source versions are only updated between _start() and end(), not when the callback is executed.
+			// To fix this, whenever _callback is executed we update the Effect's source versions to their latest values.
+			// Note that we don't do this for the re-rendering Component updater, because that eventually calls _start().
+			for (let source = this._updater!._sources; source !== undefined; source = source._nextSource) {
+				source._version = source._source._version;
+			}
+
 			if (isValidElement(s.peek()) || this.base?.nodeType !== 3) {
 				this._updateFlags |= HAS_PENDING_UPDATE;
 				this.setState({});


### PR DESCRIPTION
We could have just checked the value against a local variable, but that would leave the computeds re-running unnecessarily.

Note that this would be patch - `@preact/signals@1.3.1`, as main is already at least a minor version ahead (or major).