### PR TITLE
Add watched and unwatched

### DIFF
--- a/.changeset/tough-rice-cover.md
+++ b/.changeset/tough-rice-cover.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-core": minor
+"@preact/signals": minor
+"@preact/signals-react": minor
+---
+
+Add an option to specify a watched/unwatched callback to a signal

--- a/README.md
+++ b/README.md
@@ -20,21 +20,16 @@ npm install @preact/signals-react
 npm install @preact/signals-core
 ```
 
-- [Guide / API](#guide--api)
-  - [`signal(initialValue)`](#signalinitialvalue)
-    - [`signal.peek()`](#signalpeek)
-  - [`computed(fn)`](#computedfn)
-  - [`effect(fn)`](#effectfn)
-  - [`batch(fn)`](#batchfn)
-  - [`untracked(fn)`](#untrackedfn)
-- [Preact Integration](./packages/preact/README.md#preact-integration)
-  - [Hooks](./packages/preact/README.md#hooks)
-  - [Rendering optimizations](./packages/preact/README.md#rendering-optimizations)
-    - [Attribute optimization (experimental)](./packages/preact/README.md#attribute-optimization-experimental)
-- [React Integration](./packages/react/README.md#react-integration)
-  - [Hooks](./packages/react/README.md#hooks)
-  - [Rendering optimizations](./packages/react/README.md#rendering-optimizations)
-- [License](#license)
+- [Signals](#signals)
+  - [Installation:](#installation)
+  - [Guide / API](#guide--api)
+    - [`signal(initialValue)`](#signalinitialvalue)
+      - [`signal.peek()`](#signalpeek)
+    - [`computed(fn)`](#computedfn)
+    - [`effect(fn)`](#effectfn)
+    - [`batch(fn)`](#batchfn)
+    - [`untracked(fn)`](#untrackedfn)
+  - [License](#license)
 
 ## Guide / API
 
@@ -57,6 +52,21 @@ counter.value = 1;
 ```
 
 Writing to a signal is done by setting its `.value` property. Changing a signal's value synchronously updates every [computed](#computedfn) and [effect](#effectfn) that depends on that signal, ensuring your app state is always consistent.
+
+You can also pass options to `signal()` and `computed()` to be notified when the signal gains its first subscriber and loses its last subscriber:
+
+```js
+const counter = signal(0, {
+	watched: function () {
+		console.log("Signal has its first subscriber");
+	},
+	unwatched: function () {
+		console.log("Signal lost its last subscriber");
+	},
+});
+```
+
+These callbacks are useful for managing resources or side effects that should only be active when the signal has subscribers. For example, you might use them to start/stop expensive background operations or subscribe/unsubscribe from external event sources.
 
 #### `signal.peek()`
 

--- a/mangle.json
+++ b/mangle.json
@@ -29,6 +29,8 @@
     "cname": 6,
     "props": {
       "core: Node": "",
+      "$_watched": "W",
+      "$_unwatched": "Z",
       "$_source": "S",
       "$_prevSource": "p",
       "$_nextSource": "n",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -628,8 +628,9 @@ Computed.prototype._subscribe = function (node) {
 
 Computed.prototype._unsubscribe = function (node) {
 	// Only run the unsubscribe step if the computed signal has any subscribers.
-	Signal.prototype._unsubscribe.call(this, node);
 	if (this._targets !== undefined) {
+		Signal.prototype._unsubscribe.call(this, node);
+
 		// Computed signal unsubscribes from its dependencies when it loses its last subscriber.
 		// This makes it possible for unreferences subgraphs of computed signals to get garbage collected.
 		if (this._targets === undefined) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -308,8 +308,10 @@ Signal.prototype._subscribe = function (node) {
 
 		if (targets !== undefined) {
 			targets._prevTarget = node;
-		} else if (this._watched !== undefined) {
-			this._watched();
+		} else {
+			untracked(() => {
+				this._watched?.call(this);
+			});
 		}
 	}
 };
@@ -331,8 +333,10 @@ Signal.prototype._unsubscribe = function (node) {
 
 		if (node === this._targets) {
 			this._targets = next;
-			if (next === undefined && this._unwatched !== undefined) {
-				this._unwatched();
+			if (next === undefined) {
+				untracked(() => {
+					this._unwatched?.call(this);
+				});
 			}
 		}
 	}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -301,15 +301,16 @@ Signal.prototype._refresh = function () {
 };
 
 Signal.prototype._subscribe = function (node) {
-	if (this._watched != null && this._targets === undefined) {
-		this._watched();
-	}
-	if (this._targets !== node && node._prevTarget === undefined) {
-		node._nextTarget = this._targets;
-		if (this._targets !== undefined) {
-			this._targets._prevTarget = node;
-		}
+	const targets = this._targets;
+	if (targets !== node && node._prevTarget === undefined) {
+		node._nextTarget = targets;
 		this._targets = node;
+
+		if (targets !== undefined) {
+			targets._prevTarget = node;
+		} else if (this._watched !== undefined) {
+			this._watched();
+		}
 	}
 };
 
@@ -330,10 +331,9 @@ Signal.prototype._unsubscribe = function (node) {
 
 		if (node === this._targets) {
 			this._targets = next;
-		}
-
-		if (this._unwatched != null && this._targets === undefined) {
-			this._unwatched();
+			if (next === undefined && this._unwatched !== undefined) {
+				this._unwatched();
+			}
 		}
 	}
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -272,7 +272,7 @@ declare class Signal<T = any> {
 	set value(value: T);
 }
 
-interface SignalOptions<T = any> {
+export interface SignalOptions<T = any> {
 	watched: (this: Signal<T>) => void;
 	unwatched: (this: Signal<T>) => void;
 }

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -182,7 +182,7 @@ describe("signal", () => {
 		});
 	});
 
-	describe.only(".(un)watched()", () => {
+	describe(".(un)watched()", () => {
 		it("should call watched when first subscription occurs", () => {
 			const watched = sinon.spy();
 			const unwatched = sinon.spy();

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -196,6 +196,29 @@ describe("signal", () => {
 			unsubscribe2();
 			expect(unwatched).to.be.calledOnce;
 		});
+
+		it("should allow updating the signal from watched", async () => {
+			const calls: number[] = [];
+			const watched = sinon.spy(() => {
+				setTimeout(() => {
+					s.value = 2;
+				});
+			});
+			const unwatched = sinon.spy();
+			const s = signal(1, { watched, unwatched });
+			expect(watched).to.not.be.called;
+			const unsubscribe = s.subscribe(() => {
+				calls.push(s.value);
+			});
+			expect(watched).to.be.calledOnce;
+			const unsubscribe2 = s.subscribe(() => {});
+			expect(watched).to.be.calledOnce;
+			await new Promise(resolve => setTimeout(resolve));
+			unsubscribe();
+			unsubscribe2();
+			expect(unwatched).to.be.calledOnce;
+			expect(calls).to.deep.equal([1, 2]);
+		});
 	});
 
 	it("signals should be identified with a symbol", () => {

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -1080,6 +1080,37 @@ describe("computed()", () => {
 		expect(spy).not.to.be.called;
 	});
 
+	describe(".(un)watched()", () => {
+		it("should call watched when first subscription occurs", () => {
+			const watched = sinon.spy();
+			const unwatched = sinon.spy();
+			const s = computed(() => 1, { watched, unwatched });
+			expect(watched).to.not.be.called;
+			const unsubscribe = s.subscribe(() => {});
+			expect(watched).to.be.calledOnce;
+			const unsubscribe2 = s.subscribe(() => {});
+			expect(watched).to.be.calledOnce;
+			unsubscribe();
+			unsubscribe2();
+			expect(unwatched).to.be.calledOnce;
+		});
+
+		it("should call watched when first subscription occurs w/ nested signal", () => {
+			const watched = sinon.spy();
+			const unwatched = sinon.spy();
+			const s = signal(1, { watched, unwatched });
+			const c = computed(() => s.value + 1, { watched, unwatched });
+			expect(watched).to.not.be.called;
+			const unsubscribe = c.subscribe(() => {});
+			expect(watched).to.be.calledTwice;
+			const unsubscribe2 = s.subscribe(() => {});
+			expect(watched).to.be.calledTwice;
+			unsubscribe2();
+			unsubscribe();
+			expect(unwatched).to.be.calledTwice;
+		});
+	});
+
 	it("should consider undefined value separate from uninitialized value", () => {
 		const a = signal(0);
 		const spy = sinon.spy(() => undefined);

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -182,6 +182,22 @@ describe("signal", () => {
 		});
 	});
 
+	describe.only(".(un)watched()", () => {
+		it("should call watched when first subscription occurs", () => {
+			const watched = sinon.spy();
+			const unwatched = sinon.spy();
+			const s = signal(1, { watched, unwatched });
+			expect(watched).to.not.be.called;
+			const unsubscribe = s.subscribe(() => {});
+			expect(watched).to.be.calledOnce;
+			const unsubscribe2 = s.subscribe(() => {});
+			expect(watched).to.be.calledOnce;
+			unsubscribe();
+			unsubscribe2();
+			expect(unwatched).to.be.calledOnce;
+		});
+	});
+
 	it("signals should be identified with a symbol", () => {
 		const a = signal(0);
 		expect(a.brand).to.equal(Symbol.for("preact-signals"));

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -8,6 +8,7 @@ import {
 	Signal,
 	type ReadonlySignal,
 	untracked,
+	SignalOptions,
 } from "@preact/signals-core";
 import {
 	VNode,
@@ -382,10 +383,13 @@ Component.prototype.shouldComponentUpdate = function (
 	return false;
 };
 
-export function useSignal<T>(value: T): Signal<T>;
+export function useSignal<T>(value: T, options?: SignalOptions<T>): Signal<T>;
 export function useSignal<T = undefined>(): Signal<T | undefined>;
-export function useSignal<T>(value?: T) {
-	return useMemo(() => signal<T | undefined>(value), []);
+export function useSignal<T>(value?: T, options?: SignalOptions<T>) {
+	return useMemo(
+		() => signal<T | undefined>(value, options as SignalOptions),
+		[]
+	);
 }
 
 export function useComputed<T>(compute: () => T) {

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -392,11 +392,11 @@ export function useSignal<T>(value?: T, options?: SignalOptions<T>) {
 	);
 }
 
-export function useComputed<T>(compute: () => T) {
+export function useComputed<T>(compute: () => T, options?: SignalOptions<T>) {
 	const $compute = useRef(compute);
 	$compute.current = compute;
 	(currentComponent as AugmentedComponent)._updateFlags |= HAS_COMPUTEDS;
-	return useMemo(() => computed<T>(() => $compute.current()), []);
+	return useMemo(() => computed<T>(() => $compute.current(), options), []);
 }
 
 function safeRaf(callback: () => void) {

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -4,6 +4,7 @@ import {
 	effect,
 	Signal,
 	ReadonlySignal,
+	SignalOptions,
 } from "@preact/signals-core";
 import {
 	useRef,
@@ -384,10 +385,13 @@ export function useSignals(usage?: EffectStoreUsage): EffectStore {
 	return _useSignalsImplementation(usage);
 }
 
-export function useSignal<T>(value: T): Signal<T>;
+export function useSignal<T>(value: T, options?: SignalOptions<T>): Signal<T>;
 export function useSignal<T = undefined>(): Signal<T | undefined>;
-export function useSignal<T>(value?: T) {
-	return useMemo(() => signal<T | undefined>(value), Empty);
+export function useSignal<T>(value?: T, options?: SignalOptions<T>) {
+	return useMemo(
+		() => signal<T | undefined>(value, options as SignalOptions),
+		Empty
+	);
 }
 
 export function useComputed<T>(compute: () => T): ReadonlySignal<T> {

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -394,10 +394,13 @@ export function useSignal<T>(value?: T, options?: SignalOptions<T>) {
 	);
 }
 
-export function useComputed<T>(compute: () => T): ReadonlySignal<T> {
+export function useComputed<T>(
+	compute: () => T,
+	options?: SignalOptions<T>
+): ReadonlySignal<T> {
 	const $compute = useRef(compute);
 	$compute.current = compute;
-	return useMemo(() => computed<T>(() => $compute.current()), Empty);
+	return useMemo(() => computed<T>(() => $compute.current(), options), Empty);
 }
 
 export function useSignalEffect(cb: () => void | (() => void)) {


### PR DESCRIPTION
Resolves https://github.com/preactjs/signals/issues/351
Resolves https://github.com/preactjs/signals/issues/428

This adds a second argument to `signal` which are the `options`, currently this adds two properties, watched and unwatched. These will most likely serve third party libraries a lot more than first party consumers.

- watched will trigger when the first subscriber subscribes to a signal
- unwatched will trigger when the last subscriber unsubscribes from a signal

The second parameter can in the future be used for other RFC's in our pipeline like the equality function. The addition of this parameter is in line with the TC39 proposal for browser-native signals https://github.com/tc39/proposal-signals

I opted not to add this to `computed` for the time being as the signal itself is the atom while computed is more of a derived value. Not sure if a utility like this would be useful there. In the TC39 proposal they also add this to computed, so might as well for parity.

Note that calling the `watcher` on the `subscribe` is slightly distinct from how we normally treat signals, i.e. we calculate the `computed` when its value is accessed for the first time.