### PR TITLE
fix: Ensure that text effects get disposed

### DIFF
--- a/.changeset/unlucky-impalas-grow.md
+++ b/.changeset/unlucky-impalas-grow.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Ensure that text effects get disposed

--- a/mangle.json
+++ b/mangle.json
@@ -19,6 +19,7 @@
       }
     },
     "compress": {
+      "pure_getters": false,
       "conditionals": false,
       "loops": false,
       "sequences": false


### PR DESCRIPTION
This pull request fixes a case in the Preact bindings where effects created for optimized text updates didn't get disposed. This in turn could cause intermediate computeds to never get garbage collected as long as their dependencies didn't get garbage collected.

There's a new test for this scenario. The test passes after applying this PR.

There is also an additional modification to mangle.json: The `pure_effects` option is now set to `false`, because `.value` accesses for signals are not pure. This caused the minifier to remove and reorder important `.value` accesses in a way that internal effects weren't always depending on them properly, causing the production tests to fail.