### PR TITLE
Use afterNextFrame for hidden origins

### DIFF
--- a/.changeset/selfish-news-perform.md
+++ b/.changeset/selfish-news-perform.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Bail out of the animation frame with a setTimeout in case the origin page is hidden

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -388,10 +388,22 @@ export function useComputed<T>(compute: () => T) {
 	return useMemo(() => computed<T>(() => $compute.current()), []);
 }
 
+const HAS_RAF = typeof requestAnimationFrame == "function";
+function afterNextFrame(callback: () => void) {
+	let raf: number | undefined;
+
+	const done = () => {
+		clearTimeout(timeout);
+		if (HAS_RAF && raf != null) cancelAnimationFrame(raf);
+		setTimeout(callback);
+	};
+
+	const timeout = setTimeout(done, 100);
+	if (HAS_RAF) raf = requestAnimationFrame(done);
+}
+
 const deferEffects =
-	typeof requestAnimationFrame === "undefined"
-		? setTimeout
-		: requestAnimationFrame;
+	typeof requestAnimationFrame === "undefined" ? setTimeout : afterNextFrame;
 
 const deferDomUpdates = (cb: any) => {
 	queueMicrotask(() => {

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -394,8 +394,8 @@ function afterNextFrame(callback: () => void) {
 
 	const done = () => {
 		clearTimeout(timeout);
-		if (HAS_RAF && raf != null) cancelAnimationFrame(raf);
-		setTimeout(callback);
+		if (raf != null) cancelAnimationFrame(raf);
+		callback();
 	};
 
 	const timeout = setTimeout(done, 100);

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -388,18 +388,15 @@ export function useComputed<T>(compute: () => T) {
 	return useMemo(() => computed<T>(() => $compute.current()), []);
 }
 
-const HAS_RAF = typeof requestAnimationFrame == "function";
 function afterNextFrame(callback: () => void) {
-	let raf: number | undefined;
-
 	const done = () => {
 		clearTimeout(timeout);
-		if (raf != null) cancelAnimationFrame(raf);
+		cancelAnimationFrame(raf);
 		callback();
 	};
 
 	const timeout = setTimeout(done, 100);
-	if (HAS_RAF) raf = requestAnimationFrame(done);
+	const raf = requestAnimationFrame(done)
 }
 
 const deferEffects =

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -388,7 +388,7 @@ export function useComputed<T>(compute: () => T) {
 	return useMemo(() => computed<T>(() => $compute.current()), []);
 }
 
-function afterNextFrame(callback: () => void) {
+function safeRaf(callback: () => void) {
 	const done = () => {
 		clearTimeout(timeout);
 		cancelAnimationFrame(raf);
@@ -396,11 +396,11 @@ function afterNextFrame(callback: () => void) {
 	};
 
 	const timeout = setTimeout(done, 100);
-	const raf = requestAnimationFrame(done)
+	const raf = requestAnimationFrame(done);
 }
 
 const deferEffects =
-	typeof requestAnimationFrame === "undefined" ? setTimeout : afterNextFrame;
+	typeof requestAnimationFrame === "undefined" ? setTimeout : safeRaf;
 
 const deferDomUpdates = (cb: any) => {
 	queueMicrotask(() => {


### PR DESCRIPTION
When a page is hidden because the user is on a different tab but it received i.e. a webhook we still want effects to run. This PR ensures that by installing a 100ms timeout as animation frames don't run for non-visible pages.