### PR TITLE
Fix array signals when used as jsx

### DIFF
--- a/.changeset/cuddly-geese-matter.md
+++ b/.changeset/cuddly-geese-matter.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Fix array signals when used as jsx

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -106,8 +106,11 @@ function SignalValue(this: AugmentedComponent, { data }: { data: Signal }) {
 			return s === 0 ? 0 : s === true ? "" : s || "";
 		});
 
-		const isText = computed(() => !isValidElement(wrappedSignal.value));
-
+		const isText = computed(
+			() =>
+				!Array.isArray(wrappedSignal.value) &&
+				!isValidElement(wrappedSignal.value)
+		);
 		// Update text nodes directly without rerendering when the new value
 		// is also text.
 		const dispose = effect(function (this: Effect) {

--- a/packages/preact/test/index.test.tsx
+++ b/packages/preact/test/index.test.tsx
@@ -940,4 +940,26 @@ describe("@preact/signals", () => {
 
 		expect(renderSpy).to.be.calledTwice;
 	});
+
+	it("Array based signals should maintain reactivity", () => {
+		const count = signal([1, 2, 3].map(i => <div>{i}</div>));
+
+		function App() {
+			return <div>{count}</div>;
+		}
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(scratch.innerHTML).to.equal(
+			"<div><div>1</div><div>2</div><div>3</div></div>"
+		);
+
+		act(() => {
+			count.value = [4, 5, 6].map(i => <div>{i}</div>);
+		});
+		expect(scratch.innerHTML).to.equal(
+			"<div><div>4</div><div>5</div><div>6</div></div>"
+		);
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/preactjs/signals/issues/665

We forgot that an Array can't be optimised rendered, this is considered not a valid element but also isn't text. We used to catch this with `nodeType` checks https://github.com/preactjs/signals/blob/%40preact/signals%401.3.2/packages/preact/src/index.ts#L97