### PR TITLE
Remove duplicate node version check and add type as Node | undefined for head

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -412,8 +412,7 @@ function needsToRecompute(target: Computed | Effect): boolean {
 		// dependency cycle), then we need to recompute.
 		if (
 			node._source._version !== node._version ||
-			!node._source._refresh() ||
-			node._source._version !== node._version
+			!node._source._refresh()
 		) {
 			return true;
 		}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -456,7 +456,7 @@ function prepareSources(target: Computed | Effect) {
 
 function cleanupSources(target: Computed | Effect) {
 	let node = target._sources;
-	let head = undefined;
+	let head: Node | undefined = undefined;
 
 	/**
 	 * At this point 'target._sources' points to the tail of the doubly-linked list.


### PR DESCRIPTION
I removed duplicated node source version check in `needToRecompute` func and make the head's type `Node | undefined` in `cleanUpSources` func.