### PR TITLE
chore: Bump Preact, TypeScript, and @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/babel__traverse": "^7.18.5",
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^18.6.5",
+    "@types/node": "^18.19.103",
     "@types/sinon": "^10.0.13",
     "@types/sinon-chai": "^3.2.8",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
@@ -89,7 +89,7 @@
     "shx": "^0.3.4",
     "sinon": "^14.0.0",
     "sinon-chai": "^3.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx,yml,json,md}": [

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -50,7 +50,7 @@
     "preact": ">= 10.25.0"
   },
   "devDependencies": {
-    "preact": "10.9.0",
+    "preact": "^10.26.6",
     "preact-render-to-string": "^5.2.5"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^9.1.1
         version: 9.1.1
       '@types/node':
-        specifier: ^18.6.5
-        version: 18.6.5
+        specifier: ^18.19.103
+        version: 18.19.103
       '@types/sinon':
         specifier: ^10.0.13
         version: 10.0.13
@@ -75,10 +75,10 @@ importers:
         version: 3.2.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.33.0
-        version: 5.33.0(@typescript-eslint/parser@5.33.0(eslint@8.21.0)(typescript@4.7.4))(eslint@8.21.0)(typescript@4.7.4)
+        version: 5.33.0(@typescript-eslint/parser@5.33.0(eslint@8.21.0)(typescript@4.9.5))(eslint@8.21.0)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^5.33.0
-        version: 5.33.0(eslint@8.21.0)(typescript@4.7.4)
+        version: 5.33.0(eslint@8.21.0)(typescript@4.9.5)
       babel-plugin-istanbul:
         specifier: ^6.1.1
         version: 6.1.1
@@ -158,8 +158,8 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0(chai@4.3.6)(sinon@14.0.0)
       typescript:
-        specifier: ^4.7.4
-        version: 4.7.4
+        specifier: ^4.9.5
+        version: 4.9.5
 
   docs:
     dependencies:
@@ -193,7 +193,7 @@ importers:
         version: 7.22.8
       '@preact/preset-vite':
         specifier: ^2.3.0
-        version: 2.3.0(@babel/core@7.22.8)(preact@10.9.0)(vite@3.2.7(@types/node@18.6.5)(terser@5.14.2))
+        version: 2.3.0(@babel/core@7.22.8)(preact@10.9.0)(vite@3.2.7(@types/node@18.19.103)(terser@5.14.2))
       '@types/react':
         specifier: ^18.0.18
         version: 18.0.18
@@ -211,7 +211,7 @@ importers:
         version: 0.2.9
       vite:
         specifier: ^3.2.7
-        version: 3.2.7(@types/node@18.6.5)(terser@5.14.2)
+        version: 3.2.7(@types/node@18.19.103)(terser@5.14.2)
 
   packages/core: {}
 
@@ -222,11 +222,11 @@ importers:
         version: link:../core
     devDependencies:
       preact:
-        specifier: 10.9.0
-        version: 10.9.0
+        specifier: ^10.26.6
+        version: 10.26.6
       preact-render-to-string:
         specifier: ^5.2.5
-        version: 5.2.6(preact@10.9.0)
+        version: 5.2.6(preact@10.26.6)
 
   packages/react:
     dependencies:
@@ -1385,8 +1385,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@18.6.5':
-    resolution: {integrity: sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==}
+  '@types/node@18.19.103':
+    resolution: {integrity: sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==}
 
   '@types/normalize-package-data@2.4.1':
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -3763,6 +3763,9 @@ packages:
     peerDependencies:
       preact: '>=10'
 
+  preact@10.26.6:
+    resolution: {integrity: sha512-5SRRBinwpwkaD+OqlBDeITlRgvd8I8QlxHJw9AxSdMNV6O+LodN9nUyYGpSF7sadHjs6RzeFShMexC6DbtWr9g==}
+
   preact@10.9.0:
     resolution: {integrity: sha512-jO6/OvCRL+OT8gst/+Q2ir7dMybZAX8ioP02Zmzh3BkQMHLyqZSujvxbUriXvHi8qmhcHKC2Gwbog6Kt+YTh+Q==}
 
@@ -4349,8 +4352,8 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  typescript@4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 
@@ -4359,6 +4362,9 @@ packages:
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -5809,18 +5815,18 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
-  '@preact/preset-vite@2.3.0(@babel/core@7.22.8)(preact@10.9.0)(vite@3.2.7(@types/node@18.6.5)(terser@5.14.2))':
+  '@preact/preset-vite@2.3.0(@babel/core@7.22.8)(preact@10.9.0)(vite@3.2.7(@types/node@18.19.103)(terser@5.14.2))':
     dependencies:
       '@babel/core': 7.22.8
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.22.8)
       '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.22.8)
-      '@prefresh/vite': 2.2.8(preact@10.9.0)(vite@3.2.7(@types/node@18.6.5)(terser@5.14.2))
+      '@prefresh/vite': 2.2.8(preact@10.9.0)(vite@3.2.7(@types/node@18.19.103)(terser@5.14.2))
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.22.8)
       debug: 4.3.4(supports-color@8.1.1)
       kolorist: 1.5.1
       resolve: 1.22.1
-      vite: 3.2.7(@types/node@18.6.5)(terser@5.14.2)
+      vite: 3.2.7(@types/node@18.19.103)(terser@5.14.2)
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -5833,7 +5839,7 @@ snapshots:
 
   '@prefresh/utils@1.1.3': {}
 
-  '@prefresh/vite@2.2.8(preact@10.9.0)(vite@3.2.7(@types/node@18.6.5)(terser@5.14.2))':
+  '@prefresh/vite@2.2.8(preact@10.9.0)(vite@3.2.7(@types/node@18.19.103)(terser@5.14.2))':
     dependencies:
       '@babel/core': 7.22.8
       '@prefresh/babel-plugin': 0.4.3
@@ -5841,7 +5847,7 @@ snapshots:
       '@prefresh/utils': 1.1.3
       '@rollup/pluginutils': 4.2.1
       preact: 10.9.0
-      vite: 3.2.7(@types/node@18.6.5)(terser@5.14.2)
+      vite: 3.2.7(@types/node@18.19.103)(terser@5.14.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5980,7 +5986,9 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@18.6.5': {}
+  '@types/node@18.19.103':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/normalize-package-data@2.4.1': {}
 
@@ -6002,7 +6010,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 18.6.5
+      '@types/node': 18.19.103
 
   '@types/scheduler@0.16.2': {}
 
@@ -6021,33 +6029,33 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@5.33.0(@typescript-eslint/parser@5.33.0(eslint@8.21.0)(typescript@4.7.4))(eslint@8.21.0)(typescript@4.7.4)':
+  '@typescript-eslint/eslint-plugin@5.33.0(@typescript-eslint/parser@5.33.0(eslint@8.21.0)(typescript@4.9.5))(eslint@8.21.0)(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/parser': 5.33.0(eslint@8.21.0)(typescript@4.7.4)
+      '@typescript-eslint/parser': 5.33.0(eslint@8.21.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.33.0
-      '@typescript-eslint/type-utils': 5.33.0(eslint@8.21.0)(typescript@4.7.4)
-      '@typescript-eslint/utils': 5.33.0(eslint@8.21.0)(typescript@4.7.4)
+      '@typescript-eslint/type-utils': 5.33.0(eslint@8.21.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.33.0(eslint@8.21.0)(typescript@4.9.5)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.21.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@4.7.4)
+      tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.33.0(eslint@8.21.0)(typescript@4.7.4)':
+  '@typescript-eslint/parser@5.33.0(eslint@8.21.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.33.0
       '@typescript-eslint/types': 5.33.0
-      '@typescript-eslint/typescript-estree': 5.33.0(typescript@4.7.4)
+      '@typescript-eslint/typescript-estree': 5.33.0(typescript@4.9.5)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.21.0
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -6056,20 +6064,20 @@ snapshots:
       '@typescript-eslint/types': 5.33.0
       '@typescript-eslint/visitor-keys': 5.33.0
 
-  '@typescript-eslint/type-utils@5.33.0(eslint@8.21.0)(typescript@4.7.4)':
+  '@typescript-eslint/type-utils@5.33.0(eslint@8.21.0)(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/utils': 5.33.0(eslint@8.21.0)(typescript@4.7.4)
+      '@typescript-eslint/utils': 5.33.0(eslint@8.21.0)(typescript@4.9.5)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.21.0
-      tsutils: 3.21.0(typescript@4.7.4)
+      tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@5.33.0': {}
 
-  '@typescript-eslint/typescript-estree@5.33.0(typescript@4.7.4)':
+  '@typescript-eslint/typescript-estree@5.33.0(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 5.33.0
       '@typescript-eslint/visitor-keys': 5.33.0
@@ -6077,18 +6085,18 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@4.7.4)
+      tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.33.0(eslint@8.21.0)(typescript@4.7.4)':
+  '@typescript-eslint/utils@5.33.0(eslint@8.21.0)(typescript@4.9.5)':
     dependencies:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.33.0
       '@typescript-eslint/types': 5.33.0
-      '@typescript-eslint/typescript-estree': 5.33.0(typescript@4.7.4)
+      '@typescript-eslint/typescript-estree': 5.33.0(typescript@4.9.5)
       eslint: 8.21.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.21.0)
@@ -6721,7 +6729,7 @@ snapshots:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.12
-      '@types/node': 18.6.5
+      '@types/node': 18.19.103
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -7582,7 +7590,7 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 18.6.5
+      '@types/node': 18.19.103
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
@@ -7910,13 +7918,13 @@ snapshots:
       rollup-plugin-bundle-size: 1.0.3
       rollup-plugin-postcss: 4.0.2(postcss@8.4.31)
       rollup-plugin-terser: 7.0.2(rollup@2.77.2)
-      rollup-plugin-typescript2: 0.32.1(rollup@2.77.2)(typescript@4.7.4)
+      rollup-plugin-typescript2: 0.32.1(rollup@2.77.2)(typescript@4.9.5)
       rollup-plugin-visualizer: 5.7.1(rollup@2.77.2)
       sade: 1.8.1
       terser: 5.14.2
       tiny-glob: 0.2.9
       tslib: 2.4.0
-      typescript: 4.7.4
+      typescript: 4.9.5
     transitivePeerDependencies:
       - '@types/babel__core'
       - supports-color
@@ -8416,10 +8424,12 @@ snapshots:
       preact: 10.9.0
       pretty-format: 3.8.0
 
-  preact-render-to-string@5.2.6(preact@10.9.0):
+  preact-render-to-string@5.2.6(preact@10.26.6):
     dependencies:
-      preact: 10.9.0
+      preact: 10.26.6
       pretty-format: 3.8.0
+
+  preact@10.26.6: {}
 
   preact@10.9.0: {}
 
@@ -8634,7 +8644,7 @@ snapshots:
       serialize-javascript: 4.0.0
       terser: 5.14.2
 
-  rollup-plugin-typescript2@0.32.1(rollup@2.77.2)(typescript@4.7.4):
+  rollup-plugin-typescript2@0.32.1(rollup@2.77.2)(typescript@4.9.5):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       find-cache-dir: 3.3.2
@@ -8642,7 +8652,7 @@ snapshots:
       resolve: 1.22.1
       rollup: 2.77.2
       tslib: 2.4.0
-      typescript: 4.7.4
+      typescript: 4.9.5
 
   rollup-plugin-visualizer@5.7.1(rollup@2.77.2):
     dependencies:
@@ -8994,10 +9004,10 @@ snapshots:
 
   tslib@2.4.0: {}
 
-  tsutils@3.21.0(typescript@4.7.4):
+  tsutils@3.21.0(typescript@4.9.5):
     dependencies:
       tslib: 1.14.1
-      typescript: 4.7.4
+      typescript: 4.9.5
 
   tty-table@4.1.6:
     dependencies:
@@ -9030,7 +9040,7 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typescript@4.7.4: {}
+  typescript@4.9.5: {}
 
   ua-parser-js@0.7.37: {}
 
@@ -9040,6 +9050,8 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  undici-types@5.26.5: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -9103,14 +9115,14 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@3.2.7(@types/node@18.6.5)(terser@5.14.2):
+  vite@3.2.7(@types/node@18.19.103)(terser@5.14.2):
     dependencies:
       esbuild: 0.15.18
       postcss: 8.4.31
       resolve: 1.22.1
       rollup: 2.79.1
     optionalDependencies:
-      '@types/node': 18.6.5
+      '@types/node': 18.19.103
       fsevents: 2.3.3
       terser: 5.14.2
 


### PR DESCRIPTION
Re: #679

Preact added a wrapper type for `PictureInPictureEvent` at some point which means bumping TS to 4.9 to get access to the lib type. Bumping TS then causes a conflict w/ `@types/node`'s redeclaration of `AbortSignal` so we bump it as well.

Still need to figure out the Context provider issue, dunno what's up there.