### PR TITLE
Loosen up types for (un)watched

### DIFF
--- a/.changeset/breezy-cherries-type.md
+++ b/.changeset/breezy-cherries-type.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Loosen up types for `watched` and `unwatched`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -273,8 +273,8 @@ declare class Signal<T = any> {
 }
 
 export interface SignalOptions<T = any> {
-	watched: (this: Signal<T>) => void;
-	unwatched: (this: Signal<T>) => void;
+	watched?: (this: Signal<T>) => void;
+	unwatched?: (this: Signal<T>) => void;
 }
 
 /** @internal */


### PR DESCRIPTION
It should still be optional even when providing an object