### PR TITLE
Modify comments explaining why dependency versions are checked before and after refresh

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -433,12 +433,16 @@ function needsToRecompute(target: Computed | Effect): boolean {
 		node !== undefined;
 		node = node._nextSource
 	) {
-		// If there's a new version of the dependency before or after refreshing,
-		// or the dependency has something blocking it from refreshing at all (e.g. a
-		// dependency cycle), then we need to recompute.
 		if (
+			// If the dependency has definitely been updated since its version number
+			// was observed, then we need to recompute. This first check is not strictly
+			// necessary for correctness, but allows us to skip the refresh call if the
+			// dependency has already been updated.
 			node._source._version !== node._version ||
+			// Refresh the dependency. If there's something blocking the refresh (e.g. a
+			// dependency cycle), then we need to recompute.
 			!node._source._refresh() ||
+			// If the dependency got a new version after the refresh, then we need to recompute.
 			node._source._version !== node._version
 		) {
 			return true;


### PR DESCRIPTION
There have been some questions (e.g. #671) why the internal `needsToRecompute` function in the core checks dependency versions before _and_ after refreshing the dependency. This pull request tries to address this by modifying the surrounding code comments to make the reasoning a bit more explicit.

The first check is not strictly necessary for the functionality, because an incremented version number will stay incremented, but it allows skipping the `_refresh()` call in cases where the dependency has already definitely been updated.

Big thanks to @nishan-singh for pointing out the ambiguousness of the code.