### PR TITLE
allow jsx alternatives

### DIFF
--- a/.changeset/pretty-chicken-fail.md
+++ b/.changeset/pretty-chicken-fail.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": patch
+---
+
+Adds `detectTransformedJSX` option which will trigger transformation when alternative methods (like `React.createElement`) are used to create elements

--- a/packages/react-transform/README.md
+++ b/packages/react-transform/README.md
@@ -131,6 +131,25 @@ module.exports = {
 };
 ```
 
+### `detectTransformedJSX`
+
+When enabled, alternative methods like `React.createElement` and `jsx-runtime` will also trigger transformation.
+This can be especially useful when npm depencendies are being transpiled as those generally don't contain JSX since they have alredy been transpiled to JavaScript.
+
+```js
+// babel.config.js
+module.exports = {
+	plugins: [
+		[
+			"@preact/signals-react-transform",
+			{
+				detectTransformedJSX: tue,
+			},
+		],
+	],
+};
+```
+
 ## Logging
 
 This plugin uses the [`debug`](https://www.npmjs.com/package/debug) package to log information about what it's doing. To enable logging, set the `DEBUG` environment variable to `signals:react-transform:*`.

--- a/packages/react-transform/test/node/index.test.tsx
+++ b/packages/react-transform/test/node/index.test.tsx
@@ -221,6 +221,32 @@ describe("React Signals Babel Transform", () => {
 			expectTransformed: true,
 			options: { mode: "auto" },
 		});
+
+		it("signal access in nested functions", () => {
+			const inputCode = `
+				function MyComponent(props) {
+					return props.listSignal.value.map(function iteration(x) {
+						return <div>{x}</div>;
+					});
+				};
+			`;
+
+			const expectedOutput = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent(props) {
+					var _effect = _useSignals(1);
+					try {
+						return props.listSignal.value.map(function iteration(x) {
+							return <div>{x}</div>;
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode, expectedOutput);
+		});
 	});
 
 	describe("auto mode doesn't transform", () => {
@@ -674,6 +700,299 @@ describe("React Signals Babel Transform", () => {
 			expect(signalsBinding).to.exist;
 			expect(signalsBinding.kind).to.equal("module");
 			expect(signalsBinding.referenced).to.be.true;
+		});
+	});
+
+	describe("detectTransformedJSX option", () => {
+		it("detects elements created using react/jsx-runtime import", () => {
+			const inputCode = `
+				import { jsx as _jsx } from "react/jsx-runtime";
+				function MyComponent() {
+					signal.value;
+					return _jsx("div", { children: "Hello World" });
+				};
+			`;
+
+			const expectedOutput = `
+				import { jsx as _jsx } from "react/jsx-runtime";
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+						signal.value;
+						return _jsx("div", {
+							children: "Hello World",
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode, expectedOutput, {
+				detectTransformedJSX: true,
+			});
+		});
+
+		it("detects elements created using react/jsx-runtime cjs require", () => {
+			const inputCode = `
+				const jsxRuntime = require("react/jsx-runtime");
+				function MyComponent() {
+					signal.value;
+					return jsxRuntime.jsx("div", { children: "Hello World" });
+				};
+			`;
+
+			const expectedOutput = `
+				var _useSignals = require("@preact/signals-react/runtime").useSignals
+				const jsxRuntime = require("react/jsx-runtime");
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+						signal.value;
+						return jsxRuntime.jsx("div", {
+							children: "Hello World",
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(
+				inputCode,
+				expectedOutput,
+				{
+					detectTransformedJSX: true,
+				},
+				undefined,
+				true
+			);
+		});
+
+		it("detects elements created using react/jsx-runtime cjs destuctured import", () => {
+			const inputCode = `
+				const { jsx } = require("react/jsx-runtime");
+				function MyComponent() {
+					signal.value;
+					return jsx("div", { children: "Hello World" });
+				};
+			`;
+
+			const expectedOutput = `
+				var _useSignals = require("@preact/signals-react/runtime").useSignals
+				const { jsx } = require("react/jsx-runtime");
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+						signal.value;
+						return jsx("div", {
+							children: "Hello World",
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(
+				inputCode,
+				expectedOutput,
+				{
+					detectTransformedJSX: true,
+				},
+				undefined,
+				true
+			);
+		});
+
+		it("does not detect jsx-runtime calls when detectJSXAlternatives is disabled", () => {
+			const inputCode = `
+				import { jsx as _jsx } from "react/jsx-runtime";
+				function MyComponent() {
+					signal.value;
+					return _jsx("div", { children: "Hello World" });
+				};
+			`;
+
+			// Should not transform because jsx-runtime detection is disabled - no useSignals import should be added
+			const expectedOutput = `
+				import { jsx as _jsx } from "react/jsx-runtime";
+				function MyComponent() {
+					signal.value;
+					return _jsx("div", {
+						children: "Hello World",
+					});
+				}
+			`;
+
+			runTest(inputCode, expectedOutput, {
+				detectTransformedJSX: false,
+			});
+		});
+
+		it("detects createElement calls created using react import", () => {
+			const inputCode = `
+				import { createElement } from "react";
+				function MyComponent() {
+					signal.value;
+					return createElement("div", { children: "Hello World" });
+				};
+			`;
+
+			const expectedOutput = `
+				import { createElement } from "react";
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+						signal.value;
+						return createElement("div", {
+							children: "Hello World",
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode, expectedOutput, {
+				detectTransformedJSX: true,
+			});
+		});
+
+		it("detects createElement calls created using react default import", () => {
+			const inputCode = `
+				import React from "react";
+				function MyComponent() {
+					signal.value;
+					return React.createElement("div", { children: "Hello World" });
+				};
+			`;
+
+			const expectedOutput = `
+				import React from "react";
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+						signal.value;
+						return React.createElement("div", {
+							children: "Hello World",
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode, expectedOutput, {
+				detectTransformedJSX: true,
+			});
+		});
+
+		it("detects createElement calls created using react cjs require", () => {
+			const inputCode = `
+				const React = require("react");
+				function MyComponent() {
+					signal.value;
+					return React.createElement("div", { children: "Hello World" });
+				};
+			`;
+
+			const expectedOutput = `
+				var _useSignals = require("@preact/signals-react/runtime").useSignals
+				const React = require("react");
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+						signal.value;
+						return React.createElement("div", {
+							children: "Hello World",
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(
+				inputCode,
+				expectedOutput,
+				{
+					detectTransformedJSX: true,
+				},
+				undefined,
+				true
+			);
+		});
+
+		it("detects createElement calls created using destructured react cjs require", () => {
+			const inputCode = `
+				const { createElement } = require("react");
+				function MyComponent() {
+					signal.value;
+					return createElement("div", { children: "Hello World" });
+				};
+			`;
+
+			const expectedOutput = `
+				var _useSignals = require("@preact/signals-react/runtime").useSignals
+				const { createElement } = require("react");
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+						signal.value;
+						return createElement("div", {
+							children: "Hello World",
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(
+				inputCode,
+				expectedOutput,
+				{
+					detectTransformedJSX: true,
+				},
+				undefined,
+				true
+			);
+		});
+
+		it("detects signal access in nested functions", () => {
+			const inputCode = `
+				import { jsx } from "react/jsx-runtime";
+				function MyComponent(props) {
+					return props.listSignal.value.map(function iteration(x) {
+						return jsx("div", { children: x });
+					});
+				};
+			`;
+
+			const expectedOutput = `
+				import { jsx } from "react/jsx-runtime";
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent(props) {
+					var _effect = _useSignals(1);
+					try {
+						return props.listSignal.value.map(function iteration(x) {
+							return jsx("div", {
+								children: x,
+							});
+						});
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode, expectedOutput, {
+				detectTransformedJSX: true,
+			});
 		});
 	});
 });


### PR DESCRIPTION
When we are dealing with transpiled JSX, be that because of a library or a component that is just written without JSX, the babel plugin will fail to notice these components and not inject `useSignals`. The absence of `useSignals` makes these components non-reactive to updates to the signals within the component.

This adds a new option to check for `jsx`/`createElement`, when components have them we treat it the same as we'd find JSX and register the component for reactivity.