### PR TITLE
docs: Split root ReadMe & core ReadMe, flesh out ToC in React & Preact ReadMes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,247 +7,37 @@ Signals is a performant state management library with two primary goals:
 
 Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solves and how it came to be.
 
-## Installation:
-
-```sh
-# Just the core library
-npm install @preact/signals-core
-# If you're using Preact
-npm install @preact/signals
-# If you're using React
-npm install @preact/signals-react
-# If you're using Svelte
-npm install @preact/signals-core
-```
-
-- [Signals](#signals)
-  - [Installation:](#installation)
-  - [Guide / API](#guide--api)
-    - [`signal(initialValue)`](#signalinitialvalue)
-      - [`signal.peek()`](#signalpeek)
-    - [`computed(fn)`](#computedfn)
-    - [`effect(fn)`](#effectfn)
-    - [`batch(fn)`](#batchfn)
-    - [`untracked(fn)`](#untrackedfn)
-  - [License](#license)
-
-## Guide / API
-
-The signals library exposes four functions which are the building blocks to model any business logic you can think of.
-
-### `signal(initialValue)`
-
-The `signal` function creates a new signal. A signal is a container for a value that can change over time. You can read a signal's value or subscribe to value updates by accessing its `.value` property.
-
-```js
-import { signal } from "@preact/signals-core";
-
-const counter = signal(0);
-
-// Read value from signal, logs: 0
-console.log(counter.value);
-
-// Write to a signal
-counter.value = 1;
-```
-
-Writing to a signal is done by setting its `.value` property. Changing a signal's value synchronously updates every [computed](#computedfn) and [effect](#effectfn) that depends on that signal, ensuring your app state is always consistent.
-
-You can also pass options to `signal()` and `computed()` to be notified when the signal gains its first subscriber and loses its last subscriber:
-
-```js
-const counter = signal(0, {
-	watched: function () {
-		console.log("Signal has its first subscriber");
-	},
-	unwatched: function () {
-		console.log("Signal lost its last subscriber");
-	},
-});
-```
-
-These callbacks are useful for managing resources or side effects that should only be active when the signal has subscribers. For example, you might use them to start/stop expensive background operations or subscribe/unsubscribe from external event sources.
-
-#### `signal.peek()`
-
-In the rare instance that you have an effect that should write to another signal based on the previous value, but you _don't_ want the effect to be subscribed to that signal, you can read a signals's previous value via `signal.peek()`.
-
-```js
-const counter = signal(0);
-const effectCount = signal(0);
-
-effect(() => {
-	console.log(counter.value);
-
-	// Whenever this effect is triggered, increase `effectCount`.
-	// But we don't want this signal to react to `effectCount`
-	effectCount.value = effectCount.peek() + 1;
-});
-```
-
-Note that you should only use `signal.peek()` if you really need it. Reading a signal's value via `signal.value` is the preferred way in most scenarios.
-
-### `computed(fn)`
-
-Data is often derived from other pieces of existing data. The `computed` function lets you combine the values of multiple signals into a new signal that can be reacted to, or even used by additional computeds. When the signals accessed from within a computed callback change, the computed callback is re-executed and its new return value becomes the computed signal's value.
-
-```js
-import { signal, computed } from "@preact/signals-core";
-
-const name = signal("Jane");
-const surname = signal("Doe");
-
-const fullName = computed(() => name.value + " " + surname.value);
-
-// Logs: "Jane Doe"
-console.log(fullName.value);
-
-// Updates flow through computed, but only if someone
-// subscribes to it. More on that later.
-name.value = "John";
-// Logs: "John Doe"
-console.log(fullName.value);
-```
-
-Any signal that is accessed inside the `computed`'s callback function will be automatically subscribed to and tracked as a dependency of the computed signal.
-
-### `effect(fn)`
-
-The `effect` function is the last piece that makes everything reactive. When you access a signal inside its callback function, that signal and every dependency of said signal will be activated and subscribed to. In that regard it is very similar to [`computed(fn)`](#computedfn). By default all updates are lazy, so nothing will update until you access a signal inside `effect`.
-
-```js
-import { signal, computed, effect } from "@preact/signals-core";
-
-const name = signal("Jane");
-const surname = signal("Doe");
-const fullName = computed(() => name.value + " " + surname.value);
-
-// Logs: "Jane Doe"
-effect(() => console.log(fullName.value));
-
-// Updating one of its dependencies will automatically trigger
-// the effect above, and will print "John Doe" to the console.
-name.value = "John";
-```
-
-You can destroy an effect and unsubscribe from all signals it was subscribed to, by calling the returned function.
-
-```js
-import { signal, computed, effect } from "@preact/signals-core";
-
-const name = signal("Jane");
-const surname = signal("Doe");
-const fullName = computed(() => name.value + " " + surname.value);
-
-// Logs: "Jane Doe"
-const dispose = effect(() => console.log(fullName.value));
-
-// Destroy effect and subscriptions
-dispose();
-
-// Update does nothing, because no one is subscribed anymore.
-// Even the computed `fullName` signal won't change, because it knows
-// that no one listens to it.
-surname.value = "Doe 2";
-```
-
-The effect callback may return a cleanup function. The cleanup function gets run once, either when the effect callback is next called _or_ when the effect gets disposed, whichever happens first.
-
-```js
-import { signal, effect } from "@preact/signals-core";
-
-const count = signal(0);
-
-const dispose = effect(() => {
-	const c = count.value;
-	return () => console.log(`cleanup ${c}`);
-});
-
-// Logs: cleanup 0
-count.value = 1;
-
-// Logs: cleanup 1
-dispose();
-```
-
-### `batch(fn)`
-
-The `batch` function allows you to combine multiple signal writes into one single update that is triggered at the end when the callback completes.
-
-```js
-import { signal, computed, effect, batch } from "@preact/signals-core";
-
-const name = signal("Jane");
-const surname = signal("Doe");
-const fullName = computed(() => name.value + " " + surname.value);
-
-// Logs: "Jane Doe"
-effect(() => console.log(fullName.value));
-
-// Combines both signal writes into one update. Once the callback
-// returns the `effect` will trigger and we'll log "Foo Bar"
-batch(() => {
-	name.value = "Foo";
-	surname.value = "Bar";
-});
-```
-
-When you access a signal that you wrote to earlier inside the callback, or access a computed signal that was invalidated by another signal, we'll only update the necessary dependencies to get the current value for the signal you read from. All other invalidated signals will update at the end of the callback function.
-
-```js
-import { signal, computed, effect, batch } from "@preact/signals-core";
-
-const counter = signal(0);
-const double = computed(() => counter.value * 2);
-const triple = computed(() => counter.value * 3);
-
-effect(() => console.log(double.value, triple.value));
-
-batch(() => {
-	counter.value = 1;
-	// Logs: 2, despite being inside batch, but `triple`
-	// will only update once the callback is complete
-	console.log(double.value);
-});
-// Now we reached the end of the batch and call the effect
-```
-
-Batches can be nested and updates will be flushed when the outermost batch call completes.
-
-```js
-import { signal, computed, effect, batch } from "@preact/signals-core";
-
-const counter = signal(0);
-effect(() => console.log(counter.value));
-
-batch(() => {
-	batch(() => {
-		// Signal is invalidated, but update is not flushed because
-		// we're still inside another batch
-		counter.value = 1;
-	});
-
-	// Still not updated...
-});
-// Now the callback completed and we'll trigger the effect.
-```
-
-### `untracked(fn)`
-
-In case when you're receiving a callback that can read some signals, but you don't want to subscribe to them, you can use `untracked` to prevent any subscriptions from happening.
-
-```js
-const counter = signal(0);
-const effectCount = signal(0);
-const fn = () => effectCount.value + 1;
-
-effect(() => {
-	console.log(counter.value);
-
-	// Whenever this effect is triggered, run `fn` that gives new value
-	effectCount.value = untracked(fn);
-});
-```
+- [Core API](./packages/core/README.md#guide--api)
+  - [`signal(initialValue)`](./packages/core/README.md#signalinitialvalue)
+    - [`signal.peek()`](./packages/core/README.md#signalpeek)
+  - [`computed(fn)`](./packages/core/README.md#computedfn)
+  - [`effect(fn)`](./packages/core/README.md#effectfn)
+  - [`batch(fn)`](./packages/core/README.md#batchfn)
+  - [`untracked(fn)`](./packages/core/README.md#untrackedfn)
+- [Preact Integration](./packages/preact/README.md#preact-integration)
+  - [Hooks](./packages/preact/README.md#hooks)
+  - [Rendering optimizations](./packages/preact/README.md#rendering-optimizations)
+    - [Attribute optimization (experimental)](./packages/preact/README.md#attribute-optimization-experimental)
+  - [Utility Components and Hooks](./packages/preact/README.md#utility-components-and-hooks)
+    - [Show Component](./packages/preact/README.md#show-component)
+    - [For Component](./packages/preact/README.md#for-component)
+    - [Additional Hooks](./packages/preact/README.md#additional-hooks)
+      - [`useLiveSignal`](./packages/preact/README.md#uselivesignal)
+      - [`useSignalRef`](./packages/preact/README.md#usesignalref)
+- [React Integration](./packages/react/README.md#react-integration)
+  - [Babel Transform](./packages/react/README.md#babel-transform)
+  - [`useSignals` hook](./packages/react/README.md#usesignals-hook)
+  - [Hooks](./packages/react/README.md#hooks)
+  - [Using signals with React's SSR APIs](./packages/react/README.md#using-signals-with-reacts-ssr-apis)
+  - [Rendering optimizations](./packages/react/README.md#rendering-optimizations)
+  - [Utility Components and Hooks](./packages/react/README.md#utility-components-and-hooks)
+    - [Show Component](./packages/react/README.md#show-component)
+    - [For Component](./packages/react/README.md#for-component)
+    - [Additional Hooks](./packages/react/README.md#additional-hooks)
+      - [`useLiveSignal`](./packages/react/README.md#uselivesignal)
+      - [`useSignalRef`](./packages/react/README.md#usesignalref)
+  - [Limitations](./packages/react/README.md#limitations)
+- [License](#license)
 
 ## License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,246 @@
+# Signals
+
+Signals is a performant state management library with two primary goals:
+
+1. Make it as easy as possible to write business logic for small up to complex apps. No matter how complex your logic is, your app updates should stay fast without you needing to think about it. Signals automatically optimize state updates behind the scenes to trigger the fewest updates necessary. They are lazy by default and automatically skip signals that no one listens to.
+2. Integrate into frameworks as if they were native built-in primitives. You don't need any selectors, wrapper functions, or anything else. Signals can be accessed directly and your component will automatically re-render when the signal's value changes.
+
+Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solves and how it came to be.
+
+- [Installation](#installation)
+- [Guide / API](#guide--api)
+  - [`signal(initialValue)`](#signalinitialvalue)
+    - [`signal.peek()`](#signalpeek)
+  - [`computed(fn)`](#computedfn)
+  - [`effect(fn)`](#effectfn)
+  - [`batch(fn)`](#batchfn)
+  - [`untracked(fn)`](#untrackedfn)
+- [License](#license)
+
+## Installation:
+
+```sh
+npm install @preact/signals-core
+```
+
+## Guide / API
+
+The signals library exposes five functions which are the building blocks to model any business logic you can think of.
+
+### `signal(initialValue)`
+
+The `signal` function creates a new signal. A signal is a container for a value that can change over time. You can read a signal's value or subscribe to value updates by accessing its `.value` property.
+
+```js
+import { signal } from "@preact/signals-core";
+
+const counter = signal(0);
+
+// Read value from signal, logs: 0
+console.log(counter.value);
+
+// Write to a signal
+counter.value = 1;
+```
+
+Writing to a signal is done by setting its `.value` property. Changing a signal's value synchronously updates every [computed](#computedfn) and [effect](#effectfn) that depends on that signal, ensuring your app state is always consistent.
+
+You can also pass options to `signal()` and `computed()` to be notified when the signal gains its first subscriber and loses its last subscriber:
+
+```js
+const counter = signal(0, {
+	watched: function () {
+		console.log("Signal has its first subscriber");
+	},
+	unwatched: function () {
+		console.log("Signal lost its last subscriber");
+	},
+});
+```
+
+These callbacks are useful for managing resources or side effects that should only be active when the signal has subscribers. For example, you might use them to start/stop expensive background operations or subscribe/unsubscribe from external event sources.
+
+#### `signal.peek()`
+
+In the rare instance that you have an effect that should write to another signal based on the previous value, but you _don't_ want the effect to be subscribed to that signal, you can read a signals's previous value via `signal.peek()`.
+
+```js
+const counter = signal(0);
+const effectCount = signal(0);
+
+effect(() => {
+	console.log(counter.value);
+
+	// Whenever this effect is triggered, increase `effectCount`.
+	// But we don't want this signal to react to `effectCount`
+	effectCount.value = effectCount.peek() + 1;
+});
+```
+
+Note that you should only use `signal.peek()` if you really need it. Reading a signal's value via `signal.value` is the preferred way in most scenarios.
+
+### `computed(fn)`
+
+Data is often derived from other pieces of existing data. The `computed` function lets you combine the values of multiple signals into a new signal that can be reacted to, or even used by additional computeds. When the signals accessed from within a computed callback change, the computed callback is re-executed and its new return value becomes the computed signal's value.
+
+```js
+import { signal, computed } from "@preact/signals-core";
+
+const name = signal("Jane");
+const surname = signal("Doe");
+
+const fullName = computed(() => name.value + " " + surname.value);
+
+// Logs: "Jane Doe"
+console.log(fullName.value);
+
+// Updates flow through computed, but only if someone
+// subscribes to it. More on that later.
+name.value = "John";
+// Logs: "John Doe"
+console.log(fullName.value);
+```
+
+Any signal that is accessed inside the `computed`'s callback function will be automatically subscribed to and tracked as a dependency of the computed signal.
+
+### `effect(fn)`
+
+The `effect` function is the last piece that makes everything reactive. When you access a signal inside its callback function, that signal and every dependency of said signal will be activated and subscribed to. In that regard it is very similar to [`computed(fn)`](#computedfn). By default all updates are lazy, so nothing will update until you access a signal inside `effect`.
+
+```js
+import { signal, computed, effect } from "@preact/signals-core";
+
+const name = signal("Jane");
+const surname = signal("Doe");
+const fullName = computed(() => name.value + " " + surname.value);
+
+// Logs: "Jane Doe"
+effect(() => console.log(fullName.value));
+
+// Updating one of its dependencies will automatically trigger
+// the effect above, and will print "John Doe" to the console.
+name.value = "John";
+```
+
+You can destroy an effect and unsubscribe from all signals it was subscribed to, by calling the returned function.
+
+```js
+import { signal, computed, effect } from "@preact/signals-core";
+
+const name = signal("Jane");
+const surname = signal("Doe");
+const fullName = computed(() => name.value + " " + surname.value);
+
+// Logs: "Jane Doe"
+const dispose = effect(() => console.log(fullName.value));
+
+// Destroy effect and subscriptions
+dispose();
+
+// Update does nothing, because no one is subscribed anymore.
+// Even the computed `fullName` signal won't change, because it knows
+// that no one listens to it.
+surname.value = "Doe 2";
+```
+
+The effect callback may return a cleanup function. The cleanup function gets run once, either when the effect callback is next called _or_ when the effect gets disposed, whichever happens first.
+
+```js
+import { signal, effect } from "@preact/signals-core";
+
+const count = signal(0);
+
+const dispose = effect(() => {
+	const c = count.value;
+	return () => console.log(`cleanup ${c}`);
+});
+
+// Logs: cleanup 0
+count.value = 1;
+
+// Logs: cleanup 1
+dispose();
+```
+
+### `batch(fn)`
+
+The `batch` function allows you to combine multiple signal writes into one single update that is triggered at the end when the callback completes.
+
+```js
+import { signal, computed, effect, batch } from "@preact/signals-core";
+
+const name = signal("Jane");
+const surname = signal("Doe");
+const fullName = computed(() => name.value + " " + surname.value);
+
+// Logs: "Jane Doe"
+effect(() => console.log(fullName.value));
+
+// Combines both signal writes into one update. Once the callback
+// returns the `effect` will trigger and we'll log "Foo Bar"
+batch(() => {
+	name.value = "Foo";
+	surname.value = "Bar";
+});
+```
+
+When you access a signal that you wrote to earlier inside the callback, or access a computed signal that was invalidated by another signal, we'll only update the necessary dependencies to get the current value for the signal you read from. All other invalidated signals will update at the end of the callback function.
+
+```js
+import { signal, computed, effect, batch } from "@preact/signals-core";
+
+const counter = signal(0);
+const double = computed(() => counter.value * 2);
+const triple = computed(() => counter.value * 3);
+
+effect(() => console.log(double.value, triple.value));
+
+batch(() => {
+	counter.value = 1;
+	// Logs: 2, despite being inside batch, but `triple`
+	// will only update once the callback is complete
+	console.log(double.value);
+});
+// Now we reached the end of the batch and call the effect
+```
+
+Batches can be nested and updates will be flushed when the outermost batch call completes.
+
+```js
+import { signal, computed, effect, batch } from "@preact/signals-core";
+
+const counter = signal(0);
+effect(() => console.log(counter.value));
+
+batch(() => {
+	batch(() => {
+		// Signal is invalidated, but update is not flushed because
+		// we're still inside another batch
+		counter.value = 1;
+	});
+
+	// Still not updated...
+});
+// Now the callback completed and we'll trigger the effect.
+```
+
+### `untracked(fn)`
+
+In case when you're receiving a callback that can read some signals, but you don't want to subscribe to them, you can use `untracked` to prevent any subscriptions from happening.
+
+```js
+const counter = signal(0);
+const effectCount = signal(0);
+const fn = () => effectCount.value + 1;
+
+effect(() => {
+	console.log(counter.value);
+
+	// Whenever this effect is triggered, run `fn` that gives new value
+	effectCount.value = untracked(fn);
+});
+```
+
+## License
+
+`MIT`, see the [LICENSE](../../LICENSE) file.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
   },
   "mangle": "../../mangle.json",
   "scripts": {
-    "prepublishOnly": "cp ../../README.md . && cd ../.. && pnpm build:core"
+    "prepublishOnly": "cd ../.. && pnpm build:core"
   },
   "files": [
     "src",

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -28,8 +28,8 @@ npm install @preact/signals
   - [Show Component](#show-component)
   - [For Component](#for-component)
   - [Additional Hooks](#additional-hooks)
-  - [`useLiveSignal`](#uselivesignal)
-  - [`useSignalRef`](#usesignalref)
+    - [`useLiveSignal`](#uselivesignal)
+    - [`useSignalRef`](#usesignalref)
 - [License](#license)
 
 ## Preact Integration

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -24,6 +24,12 @@ npm install @preact/signals
   - [Hooks](#hooks)
   - [Rendering optimizations](#rendering-optimizations)
     - [Attribute optimization (experimental)](#attribute-optimization-experimental)
+- [Utility Components and Hooks](#utility-components-and-hooks)
+  - [Show Component](#show-component)
+  - [For Component](#for-component)
+  - [Additional Hooks](#additional-hooks)
+  - [`useLiveSignal`](#uselivesignal)
+  - [`useSignalRef`](#usesignalref)
 - [License](#license)
 
 ## Preact Integration

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -7,29 +7,23 @@ Signals is a performant state management library with two primary goals:
 
 Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solves and how it came to be.
 
-## Installation:
-
-```sh
-npm install @preact/signals
-```
-
-- [Guide / API](../../README.md#guide--api)
-  - [`signal(initialValue)`](../../README.md#signalinitialvalue)
-    - [`signal.peek()`](../../README.md#signalpeek)
-  - [`computed(fn)`](../../README.md#computedfn)
-  - [`effect(fn)`](../../README.md#effectfn)
-  - [`batch(fn)`](../../README.md#batchfn)
-  - [`untracked(fn)`](../../README.md#untrackedfn)
+- [Core API](../core/README.md#guide--api)
+  - [`signal(initialValue)`](../core/README.md#signalinitialvalue)
+    - [`signal.peek()`](../core/README.md#signalpeek)
+  - [`computed(fn)`](../core/README.md#computedfn)
+  - [`effect(fn)`](../core/README.md#effectfn)
+  - [`batch(fn)`](../core/README.md#batchfn)
+  - [`untracked(fn)`](../core/README.md#untrackedfn)
 - [Preact Integration](#preact-integration)
   - [Hooks](#hooks)
   - [Rendering optimizations](#rendering-optimizations)
     - [Attribute optimization (experimental)](#attribute-optimization-experimental)
-- [Utility Components and Hooks](#utility-components-and-hooks)
-  - [Show Component](#show-component)
-  - [For Component](#for-component)
-  - [Additional Hooks](#additional-hooks)
-    - [`useLiveSignal`](#uselivesignal)
-    - [`useSignalRef`](#usesignalref)
+  - [Utility Components and Hooks](#utility-components-and-hooks)
+    - [Show Component](#show-component)
+    - [For Component](#for-component)
+    - [Additional Hooks](#additional-hooks)
+      - [`useLiveSignal`](#uselivesignal)
+      - [`useSignalRef`](#usesignalref)
 - [License](#license)
 
 ## Preact Integration
@@ -117,11 +111,11 @@ function Person() {
 
 This way we'll bypass checking the virtual-dom and update the DOM property directly.
 
-## Utility Components and Hooks
+### Utility Components and Hooks
 
 The `@preact/signals/utils` package provides additional utility components and hooks to make working with signals even easier.
 
-### Show Component
+#### Show Component
 
 The `Show` component provides a declarative way to conditionally render content based on a signal's value.
 
@@ -145,7 +139,7 @@ function App() {
 }
 ```
 
-### For Component
+#### For Component
 
 The `For` component helps you render lists from signal arrays with automatic caching of rendered items.
 
@@ -164,9 +158,9 @@ function App() {
 }
 ```
 
-### Additional Hooks
+#### Additional Hooks
 
-#### useLiveSignal
+##### useLiveSignal
 
 The `useLiveSignal` hook allows you to create a local signal that stays synchronized with an external signal.
 
@@ -182,7 +176,7 @@ function Component() {
 }
 ```
 
-#### useSignalRef
+##### useSignalRef
 
 The `useSignalRef` hook creates a signal that behaves like a React ref with a `.current` property.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,28 +7,26 @@ Signals is a performant state management library with two primary goals:
 
 Read the [announcement post](https://preactjs.com/blog/introducing-signals/) to learn more about which problems signals solves and how it came to be.
 
-## Installation:
-
-```sh
-npm install @preact/signals-react
-```
-
-- [Guide / API](../../README.md#guide--api)
-  - [`signal(initialValue)`](../../README.md#signalinitialvalue)
-    - [`signal.peek()`](../../README.md#signalpeek)
-  - [`computed(fn)`](../../README.md#computedfn)
-  - [`effect(fn)`](../../README.md#effectfn)
-  - [`batch(fn)`](../../README.md#batchfn)
-  - [`untracked(fn)`](../../README.md#untrackedfn)
+- [Core API](../core/README.md#guide--api)
+  - [`signal(initialValue)`](../core/README.md#signalinitialvalue)
+    - [`signal.peek()`](../core/README.md#signalpeek)
+  - [`computed(fn)`](../core/README.md#computedfn)
+  - [`effect(fn)`](../core/README.md#effectfn)
+  - [`batch(fn)`](../core/README.md#batchfn)
+  - [`untracked(fn)`](../core/README.md#untrackedfn)
 - [React Integration](#react-integration)
+  - [Babel Transform](#babel-transform)
+  - [`useSignals` hook](#usesignals-hook)
   - [Hooks](#hooks)
-- [Utility Components and Hooks](#utility-components-and-hooks)
-  - [Show Component](#show-component)
-  - [For Component](#for-component)
-  - [Additional Hooks](#additional-hooks)
-    - [`useLiveSignal`](#uselivesignal)
-    - [`useSignalRef`](#usesignalref)
-- [Limitations](#limitations)
+  - [Using signals with React's SSR APIs](#using-signals-with-reacts-ssr-apis)
+  - [Rendering optimizations](#rendering-optimizations)
+  - [Utility Components and Hooks](#utility-components-and-hooks)
+    - [Show Component](#show-component)
+    - [For Component](#for-component)
+    - [Additional Hooks](#additional-hooks)
+      - [`useLiveSignal`](#uselivesignal)
+      - [`useSignalRef`](#usesignalref)
+  - [Limitations](#limitations)
 - [License](#license)
 
 ## React Integration
@@ -139,11 +137,11 @@ To opt into this optimization, simply pass the signal directly instead of access
 > **Note**
 > The content is wrapped in a React Fragment due to React 18's newer, more strict children types.
 
-## Utility Components and Hooks
+### Utility Components and Hooks
 
 The `@preact/signals-react/utils` package provides additional utility components and hooks to make working with signals even easier.
 
-### Show Component
+#### Show Component
 
 The `Show` component provides a declarative way to conditionally render content based on a signal's value.
 
@@ -167,7 +165,7 @@ function App() {
 }
 ```
 
-### For Component
+#### For Component
 
 The `For` component helps you render lists from signal arrays with automatic caching of rendered items.
 
@@ -186,9 +184,9 @@ function App() {
 }
 ```
 
-### Additional Hooks
+#### Additional Hooks
 
-#### useLiveSignal
+##### useLiveSignal
 
 The `useLiveSignal` hook allows you to create a local signal that stays synchronized with an external signal.
 
@@ -204,7 +202,7 @@ function Component() {
 }
 ```
 
-#### useSignalRef
+##### useSignalRef
 
 The `useSignalRef` hook creates a signal that behaves like a React ref with a `.current` property.
 
@@ -217,7 +215,7 @@ function Component() {
 }
 ```
 
-## Limitations
+### Limitations
 
 This version of React integration does not support passing signals as DOM attributes. Support for this may be added at a later date.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -22,6 +22,13 @@ npm install @preact/signals-react
   - [`untracked(fn)`](../../README.md#untrackedfn)
 - [React Integration](#react-integration)
   - [Hooks](#hooks)
+- [Utility Components and Hooks](#utility-components-and-hooks)
+  - [Show Component](#show-component)
+  - [For Component](#for-component)
+  - [Additional Hooks](#additional-hooks)
+  - [`useLiveSignal`](#uselivesignal)
+  - [`useSignalRef`](#usesignalref)
+- [Limitations](#limitations)
 - [License](#license)
 
 ## React Integration

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -26,8 +26,8 @@ npm install @preact/signals-react
   - [Show Component](#show-component)
   - [For Component](#for-component)
   - [Additional Hooks](#additional-hooks)
-  - [`useLiveSignal`](#uselivesignal)
-  - [`useSignalRef`](#usesignalref)
+    - [`useLiveSignal`](#uselivesignal)
+    - [`useSignalRef`](#usesignalref)
 - [Limitations](#limitations)
 - [License](#license)
 


### PR DESCRIPTION
Does a couple things, all related to the our ReadMes:

- Firstly, adds all headings to the "Table of Contents" for each ReadMe
  - The new signal utils were missing from that in both the React & Preact integrations. The React integration was also missing a few others as well.
- Creates a new ReadMe for core, splitting it away from the repo root
  - Previously the ReadMe in the repo root was copied into the core lib prior to publish, but I suppose that created an odd situation in which the Core package had links to the React & Preact integrations (up until https://github.com/preactjs/signals/pull/634/commits/7f729c4ec1a961ed58b6c9d1f98bb75a5a6b2513, that is). Whilst very helpful to have in the repo root here on GitHub, it did make less sense to be in the published documentation for `@preact/signals-core`.
  - As such, I've split them up. The ReadMe in the repo root now acts as just a bit Table of Contents with the ReadMe in core containing all of the core info. This does bury content a bit more, but equally, we've had a lot of problems stemming from folks reading the root ReadMe and not the specific integration notes for React.