### PR TITLE
support destructured signal access

### DIFF
--- a/.changeset/sixty-snails-raise.md
+++ b/.changeset/sixty-snails-raise.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": patch
+---
+
+Destructured access to signal values should be registered as usage, before this change Babel would skip a component that would access `.value` on a signal through destructuring

--- a/packages/react-transform/src/index.ts
+++ b/packages/react-transform/src/index.ts
@@ -361,6 +361,19 @@ function isJSXAlternativeCall(
 	return false;
 }
 
+function hasValuePropertyInPattern(pattern: BabelTypes.ObjectPattern): boolean {
+	for (const property of pattern.properties) {
+		if (BabelTypes.isObjectProperty(property)) {
+			const key = property.key;
+
+			if (BabelTypes.isIdentifier(key, { name: "value" })) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 const tryCatchTemplate = template.statements`var STORE_IDENTIFIER = HOOK_IDENTIFIER(HOOK_USAGE);
 try {
 	BODY
@@ -710,6 +723,12 @@ export default function signalsTransform(
 
 			MemberExpression(path) {
 				if (isValueMemberExpression(path)) {
+					setOnFunctionScope(path, maybeUsesSignal, true, this.filename);
+				}
+			},
+
+			ObjectPattern(path) {
+				if (hasValuePropertyInPattern(path.node)) {
 					setOnFunctionScope(path, maybeUsesSignal, true, this.filename);
 				}
 			},

--- a/packages/react-transform/test/node/index.test.tsx
+++ b/packages/react-transform/test/node/index.test.tsx
@@ -222,6 +222,101 @@ describe("React Signals Babel Transform", () => {
 			options: { mode: "auto" },
 		});
 
+		it("detects destructuring patterns with value property", () => {
+			const inputCode = `
+				function MyComponent(props) {
+					const { value: signalValue } = props.signal;
+					return <div>{signalValue}</div>;
+				}
+			`;
+
+			const expectedOutput = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent(props) {
+					var _effect = _useSignals(1);
+					try {
+						const { value: signalValue } = props.signal;
+						return <div>{signalValue}</div>;
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode, expectedOutput);
+		});
+
+		it("detects nested destructuring patterns with value property", () => {
+			// Test case 1: Simple nested destructuring
+			const inputCode1 = `
+				function MyComponent(props) {
+					const { signal: { value } } = props;
+					return <div>{value}</div>;
+				}
+			`;
+
+			const expectedOutput1 = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent(props) {
+					var _effect = _useSignals(1);
+					try {
+						const { signal: { value } } = props;
+						return <div>{value}</div>;
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode1, expectedOutput1);
+
+			// Test case 2: Deeply nested destructuring
+			const inputCode2 = `
+				function MyComponent(props) {
+					const { data: { signal: { value: signalValue } } } = props;
+					return <div>{signalValue}</div>;
+				}
+			`;
+
+			const expectedOutput2 = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent(props) {
+					var _effect = _useSignals(1);
+					try {
+						const { data: { signal: { value: signalValue } } } = props;
+						return <div>{signalValue}</div>;
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode2, expectedOutput2);
+
+			// Test case 3: Multiple value properties at different levels
+			const inputCode3 = `
+				function MyComponent(props) {
+					const { value: outerValue, signal: { value: innerValue } } = props;
+					return <div>{outerValue} {innerValue}</div>;
+				}
+			`;
+
+			const expectedOutput3 = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent(props) {
+					var _effect = _useSignals(1);
+					try {
+						const { value: outerValue, signal: { value: innerValue } } = props;
+						return <div>{outerValue} {innerValue}</div>;
+					} finally {
+						_effect.f();
+					}
+				}
+			`;
+
+			runTest(inputCode3, expectedOutput3);
+		});
+
 		it("signal access in nested functions", () => {
 			const inputCode = `
 				function MyComponent(props) {


### PR DESCRIPTION
Enable the Babel plugin to register accessing `.value` during destructuring as signals usage. This will end up correctly registering components like the following

```jsx
const X = (props) => {
  const { x: { value: mySignalValue } } = props
}
```

The result is that X will correctly have `useSignals` and react to changing to the x-signal.