### PR TITLE
Ensure that a state settled hook cant interfere with a signal update

### DIFF
--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -47,6 +47,7 @@ export const enum OptionsTypes {
 	RENDER = "__r",
 	CATCH_ERROR = "__e",
 	UNMOUNT = "unmount",
+	AFTER_RENDER = "__d",
 }
 
 export interface OptionsType {
@@ -54,6 +55,7 @@ export interface OptionsType {
 	[OptionsTypes.DIFF](vnode: VNode): void;
 	[OptionsTypes.DIFFED](vnode: VNode): void;
 	[OptionsTypes.RENDER](vnode: VNode): void;
+	[OptionsTypes.AFTER_RENDER](vnode: VNode): void;
 	[OptionsTypes.CATCH_ERROR](error: any, vnode: VNode, oldVNode: VNode): void;
 	[OptionsTypes.UNMOUNT](vnode: VNode): void;
 }


### PR DESCRIPTION
We should set `component.__f` in Preact again to make sure we hit the branch, this ensures that the new state settling logic as seen in https://github.com/preactjs/preact/pull/4760 can cooperate with signals.

The issue is when we dispatch 3 updates

- SetHookState(new)
- SetSignalState(new)
- SetHookState(old)

This would result in `_afterRender` setting SKIP_CHILDREN for the hook but the signal wants to rightfully update.