### PR TITLE
[TS] Narrow types for Show utility

### DIFF
--- a/packages/preact/utils/src/index.ts
+++ b/packages/preact/utils/src/index.ts
@@ -3,10 +3,12 @@ import { useSignal } from "@preact/signals";
 import { Fragment, createElement, JSX } from "preact";
 import { useMemo } from "preact/hooks";
 
+type Falsy = false | 0 | "" | null | undefined;
+
 interface ShowProps<T = boolean> {
 	when: Signal<T> | ReadonlySignal<T>;
 	fallback?: JSX.Element;
-	children: JSX.Element | ((value: T) => JSX.Element);
+	children: JSX.Element | ((value: Exclude<T, Falsy>) => JSX.Element);
 }
 
 export function Show<T = boolean>(props: ShowProps<T>): JSX.Element | null {


### PR DESCRIPTION
Here is part of my code:

```ts
<Show when={xScale}>
  {(xScale) => xScale.map(...)}
</Show>
```

`xScale` has the type of `ReadonlySignal<number[] | null>`

Within the `Show` component function, the `xScale` parameter is known to be truthy, since `Show` won't run the child unless the signal value is truthy.

Before this PR, I get the TS error `'xScale' is possibly 'null'.` from right before the `.map`.

After this PR, there are no errors, since the `xScale` parameter excludes falsy types from the original type, so its type is just `number[] | null`.

I do not use React but if you would like me to make the same change to the react utils package I would be happy to.

Thanks for signals! I have used preact for a long time but this is my first time using signals and it is so neat! I get a smile on my face every time a render is skipped because signals :smile: 