### PR TITLE
fix(react-transform): fix doc typo

### DIFF
--- a/packages/react-transform/README.md
+++ b/packages/react-transform/README.md
@@ -143,7 +143,7 @@ module.exports = {
 		[
 			"@preact/signals-react-transform",
 			{
-				detectTransformedJSX: tue,
+				detectTransformedJSX: true,
 			},
 		],
 	],


### PR DESCRIPTION
This change is a minor typo fix for documentation for `react-transform`.