### PR TITLE
feat: add `jsxBind` function to @preact/signals

### DIFF
--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -183,7 +183,7 @@ hook(OptionsTypes.DIFF, (old, vnode) => {
 			if (i === "children") continue;
 
 			let value = props[i];
-			if (value && value.type === Bind) {
+			if (value && value.type === JSXBind) {
 				value = oldSignalProps?.[i] ?? computed(value.cb);
 			}
 			if (value instanceof Signal) {
@@ -472,15 +472,15 @@ export function useSignalEffect(
 	}, []);
 }
 
-function Bind({ cb }: { cb: () => unknown }) {
+function JSXBind({ cb }: { cb: () => unknown }) {
 	return h(SignalValue, {
 		data: useComputed(cb),
 	});
 }
 
-const bindPrototype = Object.getOwnPropertyDescriptors({
+const jsxBindPrototype = Object.getOwnPropertyDescriptors({
 	constructor: undefined,
-	type: Bind,
+	type: JSXBind,
 	get props() {
 		return this;
 	},
@@ -491,8 +491,8 @@ const bindPrototype = Object.getOwnPropertyDescriptors({
  * signals that derive their value from other signals. Like with `useComputed`, any non-signal
  * values used in the callback are captured at the time of binding and won't change after that.
  */
-export function bind<T>(cb: () => T): T {
-	return Object.defineProperties({ cb }, bindPrototype) as any;
+export function jsxBind<T>(cb: () => T): T {
+	return Object.defineProperties({ cb }, jsxBindPrototype) as any;
 }
 
 /**

--- a/packages/preact/test/index.test.tsx
+++ b/packages/preact/test/index.test.tsx
@@ -1,5 +1,5 @@
 import {
-	bind,
+	jsxBind,
 	computed,
 	useComputed,
 	useSignalEffect,
@@ -725,7 +725,7 @@ describe("@preact/signals", () => {
 		});
 	});
 
-	describe("inline computed bindings", () => {
+	describe("jsxBind", () => {
 		it("should bind a callback to a JSX attribute", async () => {
 			const count = signal(0);
 			const double = signal(2);
@@ -733,7 +733,9 @@ describe("@preact/signals", () => {
 
 			function App() {
 				spy();
-				return <div data-value={bind(() => count.value * double.value)}></div>;
+				return (
+					<div data-value={jsxBind(() => count.value * double.value)}></div>
+				);
 			}
 
 			render(<App />, scratch);
@@ -763,7 +765,9 @@ describe("@preact/signals", () => {
 
 			function App() {
 				spy();
-				return <div>{bind(() => `${firstName.value} ${lastName.value}`)}</div>;
+				return (
+					<div>{jsxBind(() => `${firstName.value} ${lastName.value}`)}</div>
+				);
 			}
 
 			render(<App />, scratch);
@@ -790,8 +794,8 @@ describe("@preact/signals", () => {
 			function App() {
 				renderSpy();
 				return (
-					<button disabled={bind(() => !enabled.value)}>
-						{bind(boundSpy)}
+					<button disabled={jsxBind(() => !enabled.value)}>
+						{jsxBind(boundSpy)}
 					</button>
 				);
 			}


### PR DESCRIPTION
I briefly discussed this idea with @rschristian, who said I should try to implement it. Link to the discussion: https://preact.slack.com/archives/C3NMBSJKH/p1752172452437339

The goal is to avoid needing to declare "computed expressions" with `useComputed`, enabling you to write "inline computeds" where they're needed. This is intended for computeds that are only used by one JSX attribute or JSX child.

It's as easy as wrapping a "computed callback" with `jsxBind(…)`, a function exported by the `@preact/signals` package. Only *host elements* support this feature. Currently, there is no warning when trying to use `jsxBind` with a composite element, as this would require iterating the props object. Maybe someone has an idea about how to efficiently check for such misuse.

This implementation supports use in JSX attributes *and* JSX children.

Originally, I named it `bind()`, but decided `jsxBind()` makes its purpose a bit clearer.
