### PR TITLE
fix: make prefresh hmr integration easier

### DIFF
--- a/.changeset/odd-tigers-remember.md
+++ b/.changeset/odd-tigers-remember.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Fix prefresh HMR not working with `useSignal`.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -1,5 +1,5 @@
 import { options, Component, isValidElement, Fragment } from "preact";
-import { useRef, useMemo, useEffect } from "preact/hooks";
+import { useRef, useMemo, useEffect, useState } from "preact/hooks";
 import {
 	signal,
 	computed,
@@ -387,10 +387,9 @@ Component.prototype.shouldComponentUpdate = function (
 export function useSignal<T>(value: T, options?: SignalOptions<T>): Signal<T>;
 export function useSignal<T = undefined>(): Signal<T | undefined>;
 export function useSignal<T>(value?: T, options?: SignalOptions<T>) {
-	return useMemo(
-		() => signal<T | undefined>(value, options as SignalOptions),
-		[]
-	);
+	return useState(() =>
+		signal<T | undefined>(value, options as SignalOptions)
+	)[0];
 }
 
 export function useComputed<T>(compute: () => T, options?: SignalOptions<T>) {


### PR DESCRIPTION
The callback to `useMemo` is assumed to be pure during HMR and will be re-triggered. This in turn broke the `useSignal` hooks HMR as they used side-effectful callbacks.