### PR TITLE
Add signal names

### DIFF
--- a/.changeset/old-cycles-swim.md
+++ b/.changeset/old-cycles-swim.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react-transform": minor
+---
+
+Surface component-name and automatically name signals/computeds during the transform. This is gated behind the `experimental.debug` option

--- a/extension/src/components/Graph.tsx
+++ b/extension/src/components/Graph.tsx
@@ -14,7 +14,6 @@ export function GraphVisualization({
 }: {
 	updates: Signal<(SignalUpdate | Divider)[]>;
 }) {
-	console.log(updates);
 	const svgRef = useRef<SVGSVGElement>(null);
 
 	// Build graph data from updates signal using a computed

--- a/packages/react-transform/test/node/index.test.tsx
+++ b/packages/react-transform/test/node/index.test.tsx
@@ -798,6 +798,154 @@ describe("React Signals Babel Transform", () => {
 		});
 	});
 
+	describe("signal naming", () => {
+		const DEBUG_OPTIONS = { mode: "auto", experimental: { debug: true } };
+
+		const PREAMBLE = `if (window.__PREACT_SIGNALS_DEVTOOLS__) {
+	window.__PREACT_SIGNALS_DEVTOOLS__.enterComponent(
+		"MyComponent:Component.js"
+	);
+}`;
+
+		const POSTAMBLE = `	if (window.__PREACT_SIGNALS_DEVTOOLS__) {
+	window.__PREACT_SIGNALS_DEVTOOLS__.exitComponent();
+}`;
+
+		const runDebugTest = (
+			inputCode: string,
+			expectedOutput: string,
+			fileName: string
+		) => {
+			// @ts-expect-error
+			runTest(inputCode, expectedOutput, DEBUG_OPTIONS, fileName);
+		};
+
+		it("injects names for signal calls", () => {
+			const inputCode = `
+				function MyComponent() {
+					const count = signal(0);
+					const double = computed(() => count.value * 2);
+					return <div>{double.value}</div>;
+				}
+			`;
+
+			const expectedOutput = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+					    ${PREAMBLE}
+						const count = signal(0, {
+							name: "count (Component.js:3)",
+						});
+						const double = computed(() => count.value * 2, {
+							name: "double (Component.js:4)",
+						});
+						return <div>{double.value}</div>;
+					} finally {
+						_effect.f();
+						${POSTAMBLE}
+					}
+				}
+			`;
+
+			runDebugTest(inputCode, expectedOutput, "Component.js");
+		});
+
+		it("injects names for useSignal calls", () => {
+			const inputCode = `
+				function MyComponent() {
+					const count = useSignal(0);
+					const message = useSignal("hello");
+					return <div>{count.value} {message.value}</div>;
+				}
+			`;
+
+			const expectedOutput = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+					    ${PREAMBLE}
+						const count = useSignal(0, {
+							name: "count (Component.js:3)",
+						});
+						const message = useSignal("hello", {
+							name: "message (Component.js:4)",
+						});
+						return <div>{count.value} {message.value}</div>;
+					} finally {
+						_effect.f();
+						${POSTAMBLE}
+					}
+				}
+			`;
+
+			runDebugTest(inputCode, expectedOutput, "Component.js");
+		});
+
+		it("doesn't inject names when already provided", () => {
+			const inputCode = `
+				function MyComponent() {
+					const count = signal(0, { name: "myCounter" });
+					const data = useSignal(null, { name: "userData", watched: () => {} });
+					return <div>{count.value}</div>;
+				}
+			`;
+
+			const expectedOutput = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+					    ${PREAMBLE}
+						const count = signal(0, {
+							name: "myCounter",
+						});
+						const data = useSignal(null, {
+							name: "userData",
+							watched: () => {},
+						});
+						return <div>{count.value}</div>;
+					} finally {
+						_effect.f();
+						${POSTAMBLE}
+					}
+				}
+			`;
+
+			runDebugTest(inputCode, expectedOutput, "Component.js");
+		});
+
+		it("handles signals with no initial value", () => {
+			const inputCode = `
+				function MyComponent() {
+					const count = useSignal();
+					return <div>{count.value}</div>;
+				}
+			`;
+
+			const expectedOutput = `
+				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
+				function MyComponent() {
+					var _effect = _useSignals(1);
+					try {
+					    ${PREAMBLE}
+						const count = useSignal(undefined, {
+							name: "count (Component.js:3)",
+						});
+						return <div>{count.value}</div>;
+					} finally {
+						_effect.f();
+						${POSTAMBLE}
+					}
+				}
+			`;
+
+			runDebugTest(inputCode, expectedOutput, "Component.js");
+		});
+	});
+
 	describe("detectTransformedJSX option", () => {
 		it("detects elements created using react/jsx-runtime import", () => {
 			const inputCode = `


### PR DESCRIPTION
Related to #727

We inject a name for every computed/signal we encounter this makes the debugging a lot more convenient, in addition to that this adds a block to every react component so we can track the signals used within it. 