### PR TITLE
feat(extension): dependency node styling

### DIFF
--- a/.changeset/heavy-candles-marry.md
+++ b/.changeset/heavy-candles-marry.md
@@ -1,0 +1,5 @@
+---
+"preact-signals-devtools": patch
+---
+
+Truncate titles of dependency nodes and improve styling.

--- a/extension/src/components/Graph.tsx
+++ b/extension/src/components/Graph.tsx
@@ -202,11 +202,14 @@ export function GraphVisualization() {
 					{/* Nodes */}
 					<g className="nodes">
 						{graphData.value.nodes.map(node => {
-							const radius = node.type === "component" ? 35 : 25;
+							const radius = node.type === "component" ? 40 : 30;
+							// For circles, use a smaller character limit to fit within the circle with padding
+							const maxChars = node.type === "component" ? 10 : 7;
 							const displayName =
-								node.name.length > 10
-									? node.name.slice(0, 10) + "..."
+								node.name.length > maxChars
+									? node.name.slice(0, maxChars) + "..."
 									: node.name;
+							const isTextTruncated = node.name.length > maxChars;
 
 							return (
 								<g key={node.id} className="graph-node-group">
@@ -215,11 +218,13 @@ export function GraphVisualization() {
 										<rect
 											className={`graph-node ${node.type}`}
 											x={node.x - radius}
-											y={node.y - 20}
+											y={node.y - 22}
 											width={radius * 2}
-											height={40}
-											rx="8"
-										/>
+											height={44}
+											rx="10"
+										>
+											{isTextTruncated && <title>{node.name}</title>}
+										</rect>
 									) : (
 										// Circular shape for signals/computed/effects
 										<circle
@@ -227,17 +232,21 @@ export function GraphVisualization() {
 											cx={node.x}
 											cy={node.y}
 											r={radius}
-										/>
+										>
+											{isTextTruncated && <title>{node.name}</title>}
+										</circle>
 									)}
 									<text
 										className="graph-text"
 										x={node.x}
 										y={node.y + 4}
 										textAnchor="middle"
+										dominantBaseline="middle"
 										fontSize="12"
-										fontWeight="bold"
+										fontWeight="500"
 									>
 										{displayName}
+										{isTextTruncated && <title>{node.name}</title>}
 									</text>
 								</g>
 							);

--- a/extension/styles/panel.css
+++ b/extension/styles/panel.css
@@ -417,10 +417,13 @@ body {
 .graph-node {
   cursor: pointer;
   transition: all 0.2s;
+  stroke: #fff;
+  stroke-width: 2;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.1));
 }
 
 .graph-node:hover {
-  filter: brightness(1.1);
+  filter: brightness(1.1) drop-shadow(0 2px 4px rgba(0,0,0,0.1));
 }
 
 .graph-node.signal {
@@ -437,8 +440,6 @@ body {
 
 .graph-node.component {
   fill: #9c27b0;
-  stroke: #7b1fa2;
-  stroke-width: 2;
 }
 
 .graph-link {
@@ -460,6 +461,7 @@ body {
   font-size: 12px;
   font-weight: 500;
   pointer-events: none;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.3);
 }
 
 .graph-legend {


### PR DESCRIPTION
Changes the nodes to all have truncation (i.e. if the title is too long,
we add `...` and a tooltip).

Also adds a drop shadow to nodes to make them more distinct.

<img width="703" height="283" alt="image" src="https://github.com/user-attachments/assets/c3e1845b-fa10-47d1-846c-3ba223e60552" />
<img width="178" height="128" alt="image" src="https://github.com/user-attachments/assets/4df758fb-6874-45fd-8690-5299b6089846" />

