### PR TITLE
feat(extension): display first component parent in render info

### DIFF
--- a/packages/debug/src/devtools.ts
+++ b/packages/debug/src/devtools.ts
@@ -25,10 +25,14 @@ export interface SignalsDevToolsAPI {
 }
 
 function getComponentName(vnode: VNode): string {
+	let name;
+
 	if (typeof vnode.type === "string") {
-		return vnode.type;
+		name = vnode.type;
+	} else {
+		name = vnode.type.displayName || vnode.type.name || "Unknown";
 	}
-	const name = vnode.type.displayName || vnode.type.name || "Unknown";
+
 	if (name === "ReactiveTextNode" && vnode.__) {
 		return `${getComponentName(vnode.__)} > ${name}`;
 	}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -206,8 +206,15 @@ hook(OptionsTypes.RENDER, (old, vnode) => {
 		typeof window !== "undefined" &&
 		window.__PREACT_SIGNALS_DEVTOOLS__
 	) {
+		let parentComponent: VNode | undefined = vnode.__;
+		while (parentComponent && typeof parentComponent.type === "string") {
+			parentComponent = parentComponent.__;
+		}
 		window.__PREACT_SIGNALS_DEVTOOLS__.enterComponent(
-			vnode.type.displayName || vnode.type.name || "Unknown"
+			(parentComponent && typeof parentComponent.type !== "string"
+				? (parentComponent.type.displayName || parentComponent.type.name) +
+					" > "
+				: "") + (vnode.type.displayName || vnode.type.name || "Unknown")
 		);
 	}
 

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -206,16 +206,7 @@ hook(OptionsTypes.RENDER, (old, vnode) => {
 		typeof window !== "undefined" &&
 		window.__PREACT_SIGNALS_DEVTOOLS__
 	) {
-		let parentComponent: VNode | undefined = vnode.__;
-		while (parentComponent && typeof parentComponent.type === "string") {
-			parentComponent = parentComponent.__;
-		}
-		window.__PREACT_SIGNALS_DEVTOOLS__.enterComponent(
-			(parentComponent && typeof parentComponent.type !== "string"
-				? (parentComponent.type.displayName || parentComponent.type.name) +
-					" > "
-				: "") + (vnode.type.displayName || vnode.type.name || "Unknown")
-		);
+		window.__PREACT_SIGNALS_DEVTOOLS__.enterComponent(vnode);
 	}
 
 	// Ignore the Fragment inserted by preact.createElement().


### PR DESCRIPTION
<img width="519" height="213" alt="image" src="https://github.com/user-attachments/assets/d9e345c6-07f3-4752-96f2-ef5e3ad4dd08" />

draft for now since we're not sure if we want this yet

something along the lines of this could be useful though, to see what actually rendered. most signals end up in text nodes, so we don't really know the context of the component that actually rendered it. this could help w/ that