### PR TITLE
feat(extension): support grouped updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{*.json,.*rc,*.yml}]
+[{*.json,.*rc,*.yml,*.css}]
 indent_style = space
 indent_size = 2
 insert_final_newline = false

--- a/extension/src/components/UpdateItem.tsx
+++ b/extension/src/components/UpdateItem.tsx
@@ -2,9 +2,10 @@ import { SignalUpdate } from "../types";
 
 interface UpdateItemProps {
 	update: SignalUpdate;
+	count?: number;
 }
 
-export function UpdateItem({ update }: UpdateItemProps) {
+export function UpdateItem({ update, count }: UpdateItemProps) {
 	const time = new Date(
 		update.timestamp || update.receivedAt
 	).toLocaleTimeString();
@@ -23,6 +24,11 @@ export function UpdateItem({ update }: UpdateItemProps) {
 		}
 		return String(value);
 	};
+	const countLabel = count && (
+		<span class="update-count" title="Number of grouped identical updates">
+			x{count}
+		</span>
+	);
 
 	if (update.type === "effect") {
 		return (
@@ -30,6 +36,7 @@ export function UpdateItem({ update }: UpdateItemProps) {
 				<div className="update-header">
 					<span className="signal-name">
 						↪️ {update.signalName}
+						{countLabel}
 						{update.componentNames && update.componentNames.length > 0 && (
 							<ul class="component-list">
 								<span class="component-name-header">Rerendered</span>
@@ -56,6 +63,7 @@ export function UpdateItem({ update }: UpdateItemProps) {
 			<div class="update-header">
 				<span class="signal-name">
 					{update.depth === 0 ? "🎯" : "↪️"} {update.signalName}
+					{countLabel}
 				</span>
 				<span class="update-time">{time}</span>
 			</div>

--- a/extension/src/components/UpdateTreeNode.tsx
+++ b/extension/src/components/UpdateTreeNode.tsx
@@ -4,9 +4,10 @@ import { UpdateItem } from "./UpdateItem";
 
 interface UpdateTreeNodeProps {
 	node: UpdateTreeNode;
+	count?: number;
 }
 
-export function UpdateTreeNodeComponent({ node }: UpdateTreeNodeProps) {
+export function UpdateTreeNodeComponent({ node, count }: UpdateTreeNodeProps) {
 	const isCollapsed = useSignal(false);
 
 	const toggleCollapse = () => {
@@ -29,7 +30,7 @@ export function UpdateTreeNodeComponent({ node }: UpdateTreeNodeProps) {
 				)}
 				{!hasChildren && <div className="collapse-spacer" />}
 				<div className="update-content">
-					<UpdateItem update={node.update} />
+					<UpdateItem update={node.update} count={count} />
 				</div>
 			</div>
 

--- a/extension/src/components/UpdatesContainer.tsx
+++ b/extension/src/components/UpdatesContainer.tsx
@@ -1,11 +1,48 @@
 import { useRef } from "preact/hooks";
-import { updatesStore } from "../models/UpdatesModel";
+import { updatesStore, type UpdateTreeNode } from "../models/UpdatesModel";
 import { UpdateTreeNodeComponent } from "./UpdateTreeNode";
 import { useSignalEffect } from "@preact/signals";
+import { settingsStore } from "../models/SettingsModel";
+
+const nodesAreEqual = (a: UpdateTreeNode, b: UpdateTreeNode): boolean => {
+	return (
+		a.update.signalId === b.update.signalId &&
+		a.children.length === b.children.length &&
+		a.children.every((child, index) => nodesAreEqual(child, b.children[index]))
+	);
+};
+
+interface CollapsedTree {
+	tree: UpdateTreeNode[];
+	counts: WeakMap<UpdateTreeNode, number>;
+}
+
+const collapseTree = (nodes: UpdateTreeNode[]): CollapsedTree => {
+	const tree: UpdateTreeNode[] = [];
+	let lastNode: UpdateTreeNode | null = null;
+	const counts = new WeakMap<UpdateTreeNode, number>();
+
+	for (const node of nodes) {
+		if (lastNode && nodesAreEqual(lastNode, node)) {
+			// If the current node is equal to the last one, skip it
+			counts.set(lastNode, (counts.get(lastNode) ?? 1) + 1);
+			continue;
+		}
+		tree.push(node);
+		lastNode = node;
+	}
+
+	return { tree, counts };
+};
 
 export function UpdatesContainer() {
 	const updatesListRef = useRef<HTMLDivElement>(null);
 	const updateTree = updatesStore.updateTree.value;
+	let collapsedTree = updateTree;
+	let counts: WeakMap<UpdateTreeNode, number> | undefined;
+	if (settingsStore.settings.grouped) {
+		({ tree: collapsedTree, counts } = collapseTree(updateTree));
+	}
 
 	useSignalEffect(() => {
 		// Register scroll restoration
@@ -30,8 +67,12 @@ export function UpdatesContainer() {
 			</div>
 
 			<div className="updates-list" ref={updatesListRef}>
-				{updateTree.map(node => (
-					<UpdateTreeNodeComponent key={node.id} node={node} />
+				{collapsedTree.map(node => (
+					<UpdateTreeNodeComponent
+						key={node.id}
+						node={node}
+						count={counts?.get(node)}
+					/>
 				))}
 			</div>
 		</div>

--- a/extension/styles/panel.css
+++ b/extension/styles/panel.css
@@ -324,6 +324,14 @@ body {
   margin-bottom: 4px;
 }
 
+.update-count {
+  display: inline-block;
+  padding: 0 6px;
+  background: #e0e0e0;
+  border-radius: 12px;
+  margin: 0 2px;
+}
+
 .signal-name {
   font-weight: 600;
   color: #673ab7;


### PR DESCRIPTION
This makes the existing "group updates" setting work.

When enabled, repeated updates of the same tree will be grouped into one node with a count.

The updates are not lost, in that the setting can be disable to re-expand the nodes.

Fixes #736 

---


https://github.com/user-attachments/assets/4b585ea2-f13a-4acd-8b76-9b553eb92f58

