### PR TITLE
preact/signals: Make useComputed always use the initial compute function

### DIFF
--- a/.changeset/wise-coins-drop.md
+++ b/.changeset/wise-coins-drop.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Make useComputed always use the initial compute function

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -421,11 +421,12 @@ export function useSignal<T>(value?: T, options?: SignalOptions<T>) {
 	)[0];
 }
 
-export function useComputed<T>(compute: () => T, options?: SignalOptions<T>) {
-	const $compute = useRef(compute);
-	$compute.current = compute;
+export function useComputed<T>(
+	compute: () => T,
+	options?: SignalOptions<T>
+): ReadonlySignal<T> {
 	(currentComponent as AugmentedComponent)._updateFlags |= HAS_COMPUTEDS;
-	return useMemo(() => computed<T>(() => $compute.current(), options), []);
+	return useState(() => computed(compute, options))[0];
 }
 
 function safeRaf(callback: () => void) {


### PR DESCRIPTION
This pull request implements alternative 2 for @preact/signals's `useComputed` as described in https://github.com/preactjs/signals/issues/753: Always use the initial compute function givent to `useComputed` and only recompute whenever one of the signal dependencies change.

This is a mutually exclusive alternative for #754. At least one of these PRs should be eventually closed without merging.