### PR TITLE
Prevent expanding list

### DIFF
--- a/.changeset/unlucky-ladybugs-care.md
+++ b/.changeset/unlucky-ladybugs-care.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals": patch
+"@preact/signals-react": patch
+---
+
+Prevent `For` cache from expanding infinitely

--- a/packages/preact/utils/src/index.tsx
+++ b/packages/preact/utils/src/index.tsx
@@ -41,13 +41,20 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 
 	if (!list.length) return props.fallback || null;
 
+	const removed = new Set(cache.keys());
+
 	const items = list.map((value, key) => {
+		removed.delete(value);
 		if (!cache.has(value)) {
 			const result = <Item v={value} i={key} children={props.children} />;
 			cache.set(value, result);
 			return result;
 		}
 		return cache.get(value);
+	});
+
+	removed.forEach(value => {
+		cache.delete(value);
 	});
 
 	return createElement(Fragment, null, items);

--- a/packages/react/utils/src/index.tsx
+++ b/packages/react/utils/src/index.tsx
@@ -44,7 +44,10 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 
 	if (!list.length) return props.fallback || null;
 
+	const removed = new Set(cache.keys());
+
 	const items = list.map((value, key) => {
+		removed.delete(value);
 		if (!cache.has(value)) {
 			const result = (
 				<Item v={value} key={key} i={key} children={props.children} />
@@ -54,6 +57,11 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 		}
 		return cache.get(value);
 	});
+
+	removed.forEach(value => {
+		cache.delete(value);
+	});
+
 	return createElement(Fragment, { children: items });
 }
 


### PR DESCRIPTION
Cleanup unmounted nodes from the cache to prevent a memory leak if a List is used for i.e. windowing