### PR TITLE
Delay subscribing to a component until its fully mounted

### DIFF
--- a/.changeset/nasty-rings-float.md
+++ b/.changeset/nasty-rings-float.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": major
+---
+
+Delay subscribing to signals until the component is actually mounted

--- a/mangle.json
+++ b/mangle.json
@@ -65,7 +65,9 @@
       "$_signal": "s",
       "$_updater": "__$u",
       "$_updateFlags": "__$f",
-      "$_updaters": "U"
+      "$_updaters": "U",
+      "$_subscribers": "u",
+      "$_usage": "o"
     }
   }
 }

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -116,7 +116,7 @@ function startComponentEffect(
 	prevStore: EffectStore | undefined,
 	nextStore: EffectStore
 ) {
-	nextStore._sub = Signal.prototype._subscribe;
+	nextStore._sub = prevStore ? prevStore._sub : Signal.prototype._subscribe;
 	Signal.prototype._subscribe = function (this: Signal, node: any) {
 		nextStore._subscribers.push({ signal: this, node });
 	};

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -59,6 +59,8 @@ interface Effect {
 	_dispose(): void;
 }
 
+type SubscriptionNode = Parameters<Signal["_subscribe"]>[0];
+
 /**
  * Use this flag to represent a bare `useSignals` call that doesn't manually
  * close its effect store and relies on auto-closing when the next useSignals is
@@ -102,8 +104,7 @@ export interface EffectStore {
 	getSnapshot(): number;
 	/** startEffect - begin tracking signals used in this component */
 	_start(): void;
-	_subscribers: Array<{ signal: Signal; node: any }>;
-	_sub: typeof Signal.prototype._subscribe;
+	_subscribers: Array<{ signal: Signal; node: SubscriptionNode }>;
 	/** finishEffect - stop tracking the signals used in this component */
 	f(): void;
 	[symDispose](): void;
@@ -111,29 +112,49 @@ export interface EffectStore {
 
 let currentStore: EffectStore | undefined;
 
-const realSubscribe = Signal.prototype._subscribe;
 function startComponentEffect(
 	prevStore: EffectStore | undefined,
 	nextStore: EffectStore
 ) {
-	nextStore._sub = prevStore ? prevStore._sub : realSubscribe;
-	Signal.prototype._subscribe = function (this: Signal, node: any) {
-		nextStore._subscribers.push({ signal: this, node });
+	const previousSubscribe = Signal.prototype._subscribe;
+	Signal.prototype._subscribe = function (
+		this: Signal,
+		node: SubscriptionNode
+	) {
+		if ((node as { _target: Effect })._target === nextStore.effect) {
+			nextStore._subscribers.push({ signal: this, node });
+		}
 	};
-	const endEffect = nextStore.effect._start();
+
+	let endEffect: () => void;
+	try {
+		endEffect = nextStore.effect._start();
+	} catch (error) {
+		Signal.prototype._subscribe = previousSubscribe;
+		throw error;
+	}
 	currentStore = nextStore;
 
-	return finishComponentEffect.bind(nextStore, prevStore, endEffect);
+	return finishComponentEffect.bind(
+		nextStore,
+		prevStore,
+		endEffect,
+		previousSubscribe
+	);
 }
 
 function finishComponentEffect(
 	this: EffectStore,
 	prevStore: EffectStore | undefined,
-	endEffect: () => void
+	endEffect: () => void,
+	previousSubscribe: typeof Signal.prototype._subscribe
 ) {
-	Signal.prototype._subscribe = prevStore ? prevStore._sub : realSubscribe;
-	endEffect();
-	currentStore = prevStore;
+	Signal.prototype._subscribe = previousSubscribe;
+	try {
+		endEffect();
+	} finally {
+		currentStore = prevStore;
+	}
 }
 
 /**
@@ -180,15 +201,15 @@ function createEffectStore(
 		if (onChangeNotifyReact) onChangeNotifyReact();
 	};
 
-	return {
+	const store: EffectStore = {
 		_usage,
 		_subscribers: [],
-		_sub: realSubscribe,
 		effect: effectInstance,
 		subscribe(onStoreChange) {
 			onChangeNotifyReact = onStoreChange;
 
 			return function () {
+				store._subscribers = [];
 				/**
 				 * Rotate to next version when unsubscribing to ensure that components are re-run
 				 * when subscribing again.
@@ -310,8 +331,11 @@ function createEffectStore(
 		},
 		[symDispose]() {
 			this.f();
+			this._subscribers = [];
 		},
 	};
+
+	return store;
 }
 
 const noop = () => {};
@@ -319,7 +343,6 @@ const noop = () => {};
 function createEmptyEffectStore(): EffectStore {
 	return {
 		_subscribers: [],
-		_sub: noop as any,
 		_usage: UNMANAGED,
 		effect: {
 			_sources: undefined,
@@ -385,10 +408,17 @@ export function _useSignalsImplementation(
 	if (_usage === UNMANAGED) useIsomorphicLayoutEffect(cleanupTrailingStore);
 
 	useIsomorphicLayoutEffect(() => {
-		store._subscribers.forEach(({ signal, node }) => {
-			realSubscribe.call(signal, node);
-		});
+		const subscribers = store._subscribers;
 		store._subscribers = [];
+
+		subscribers.forEach(({ signal, node }) => {
+			if (
+				(node as { _target: Effect })._target === store.effect &&
+				(node as { _version: number })._version !== -1
+			) {
+				signal._subscribe(node);
+			}
+		});
 	});
 
 	return store;

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -121,6 +121,8 @@ function startComponentEffect(
 		this: Signal,
 		node: SubscriptionNode
 	) {
+		// Only defer this effect's direct dependencies. Computed dependencies are
+		// subscribed recursively when their direct node is committed.
 		if ((node as { _target: Effect })._target === nextStore.effect) {
 			nextStore._subscribers.push({ signal: this, node });
 		}
@@ -331,7 +333,6 @@ function createEffectStore(
 		},
 		[symDispose]() {
 			this.f();
-			this._subscribers = [];
 		},
 	};
 
@@ -408,10 +409,12 @@ export function _useSignalsImplementation(
 	if (_usage === UNMANAGED) useIsomorphicLayoutEffect(cleanupTrailingStore);
 
 	useIsomorphicLayoutEffect(() => {
+		// Detach first because subscribing can synchronously invoke user callbacks.
 		const subscribers = store._subscribers;
 		store._subscribers = [];
 
 		subscribers.forEach(({ signal, node }) => {
+			// Nodes omitted from the committed render are marked with version -1.
 			if (
 				(node as { _target: Effect })._target === store.effect &&
 				(node as { _version: number })._version !== -1

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -102,6 +102,8 @@ export interface EffectStore {
 	getSnapshot(): number;
 	/** startEffect - begin tracking signals used in this component */
 	_start(): void;
+	_subscribers: Array<{ signal: Signal; node: any }>;
+	_sub: typeof Signal.prototype._subscribe;
 	/** finishEffect - stop tracking the signals used in this component */
 	f(): void;
 	[symDispose](): void;
@@ -109,10 +111,15 @@ export interface EffectStore {
 
 let currentStore: EffectStore | undefined;
 
+const realSubscribe = Signal.prototype._subscribe;
 function startComponentEffect(
 	prevStore: EffectStore | undefined,
 	nextStore: EffectStore
 ) {
+	nextStore._sub = Signal.prototype._subscribe;
+	Signal.prototype._subscribe = function (this: Signal, node: any) {
+		nextStore._subscribers.push({ signal: this, node });
+	};
 	const endEffect = nextStore.effect._start();
 	currentStore = nextStore;
 
@@ -124,6 +131,7 @@ function finishComponentEffect(
 	prevStore: EffectStore | undefined,
 	endEffect: () => void
 ) {
+	Signal.prototype._subscribe = this._sub;
 	endEffect();
 	currentStore = prevStore;
 }
@@ -174,6 +182,8 @@ function createEffectStore(
 
 	return {
 		_usage,
+		_subscribers: [],
+		_sub: realSubscribe,
 		effect: effectInstance,
 		subscribe(onStoreChange) {
 			onChangeNotifyReact = onStoreChange;
@@ -308,6 +318,8 @@ const noop = () => {};
 
 function createEmptyEffectStore(): EffectStore {
 	return {
+		_subscribers: [],
+		_sub: noop as any,
 		_usage: UNMANAGED,
 		effect: {
 			_sources: undefined,
@@ -371,6 +383,13 @@ export function _useSignalsImplementation(
 	store._start();
 	// note: _usage is a constant here, so conditional is okay
 	if (_usage === UNMANAGED) useIsomorphicLayoutEffect(cleanupTrailingStore);
+
+	useIsomorphicLayoutEffect(() => {
+		store._subscribers.forEach(({ signal, node }) => {
+			realSubscribe.call(signal, node);
+		});
+		store._subscribers = [];
+	});
 
 	return store;
 }

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -116,7 +116,7 @@ function startComponentEffect(
 	prevStore: EffectStore | undefined,
 	nextStore: EffectStore
 ) {
-	nextStore._sub = prevStore ? prevStore._sub : Signal.prototype._subscribe;
+	nextStore._sub = prevStore ? prevStore._sub : realSubscribe;
 	Signal.prototype._subscribe = function (this: Signal, node: any) {
 		nextStore._subscribers.push({ signal: this, node });
 	};
@@ -131,7 +131,7 @@ function finishComponentEffect(
 	prevStore: EffectStore | undefined,
 	endEffect: () => void
 ) {
-	Signal.prototype._subscribe = this._sub;
+	Signal.prototype._subscribe = prevStore ? prevStore._sub : realSubscribe;
 	endEffect();
 	currentStore = prevStore;
 }

--- a/packages/react/runtime/test/browser/subscription-lifecycle.test.tsx
+++ b/packages/react/runtime/test/browser/subscription-lifecycle.test.tsx
@@ -1,0 +1,318 @@
+// @ts-expect-error
+// @noUseSignals
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import React, { Component, createElement, Suspense, useState } from "react";
+import { computed, signal, Signal } from "@preact/signals-core";
+import { useSignals } from "@preact/signals-react/runtime";
+import type { EffectStore } from "@preact/signals-react/runtime";
+import {
+	Root,
+	createRoot,
+	act,
+	getConsoleErrorSpy,
+} from "../../../test/shared/utils";
+import { beforeEach, afterEach, describe, it, expect } from "vitest";
+
+function getTargets(signal: object): unknown {
+	return (signal as any)._targets;
+}
+
+class ErrorBoundary extends Component<
+	React.PropsWithChildren<{ onFallback?: () => void }>,
+	{ failed: boolean }
+> {
+	state = { failed: false };
+
+	static getDerivedStateFromError() {
+		return { failed: true };
+	}
+
+	componentDidCatch() {}
+
+	render() {
+		if (this.state.failed) {
+			this.props.onFallback?.();
+			return createElement("span", null, "error");
+		}
+		return this.props.children;
+	}
+}
+
+describe("subscription lifecycle", () => {
+	let scratch: HTMLDivElement;
+	let root: Root;
+	let originalSubscribe: typeof Signal.prototype._subscribe;
+
+	beforeEach(async () => {
+		scratch = document.createElement("div");
+		document.body.appendChild(scratch);
+		root = await createRoot(scratch);
+		getConsoleErrorSpy().mockClear();
+		originalSubscribe = Signal.prototype._subscribe;
+	});
+
+	afterEach(async () => {
+		await act(() => root.unmount());
+		scratch.remove();
+		expect(Signal.prototype._subscribe).to.equal(originalSubscribe);
+	});
+
+	it("restores the outer collector after a nested managed hook", async () => {
+		let watchedCallCount = 0;
+		const tracked = signal(0, {
+			watched() {
+				watchedCallCount++;
+			},
+		});
+		let resolve!: () => void;
+		let resolved = false;
+		const pending = new Promise<void>(r => {
+			resolve = r;
+		});
+
+		/** @noUseSignals */
+		function useInner() {
+			const store = useSignals(2);
+			try {
+				return 1;
+			} finally {
+				store.f();
+			}
+		}
+
+		/** @noUseSignals */
+		function App() {
+			const store = useSignals(1);
+			try {
+				useInner();
+				const value = tracked.value;
+				if (!resolved) throw pending;
+				return <p>{value}</p>;
+			} finally {
+				store.f();
+			}
+		}
+
+		await act(() => {
+			root.render(
+				<Suspense fallback={<span>loading</span>}>
+					<App />
+				</Suspense>
+			);
+		});
+		expect(scratch.innerHTML).to.equal("<span>loading</span>");
+		expect(watchedCallCount).to.equal(0);
+		expect(getTargets(tracked)).to.equal(undefined);
+
+		resolved = true;
+		await act(async () => {
+			resolve();
+			await pending;
+		});
+		expect(scratch.innerHTML).to.equal("<p>0</p>");
+		expect(watchedCallCount).to.equal(1);
+	});
+
+	it("does not replay computed dependencies from an abandoned update", async () => {
+		const stable = signal(0);
+		const source = signal(1);
+		const abandoned = computed(() => source.value * 2);
+		let setPhase!: (phase: number) => void;
+		let resolve!: () => void;
+		const pending = new Promise<void>(r => {
+			resolve = r;
+		});
+
+		/** @noUseSignals */
+		function App() {
+			const [phase, updatePhase] = useState(0);
+			setPhase = updatePhase;
+			const store = useSignals(1);
+			try {
+				if (phase === 1) {
+					void abandoned.value;
+					throw pending;
+				}
+				return (
+					<p>
+						{stable.value}:{phase}
+					</p>
+				);
+			} finally {
+				store.f();
+			}
+		}
+
+		await act(() => {
+			root.render(
+				<Suspense fallback={<span>loading</span>}>
+					<App />
+				</Suspense>
+			);
+		});
+		await act(() => setPhase(1));
+		expect(getTargets(source)).to.equal(undefined);
+		expect(getTargets(abandoned)).to.equal(undefined);
+
+		await act(async () => {
+			setPhase(2);
+			resolve();
+			await pending;
+		});
+		expect(scratch.textContent).to.equal("0:2");
+		expect(getTargets(source)).to.equal(undefined);
+		expect(getTargets(abandoned)).to.equal(undefined);
+	});
+
+	it("drops pending subscriptions when a suspended component unmounts", async () => {
+		const tracked = signal(0);
+		let store!: EffectStore;
+		let setSuspended!: (suspended: boolean) => void;
+		const pending = new Promise<void>(() => {});
+
+		/** @noUseSignals */
+		function App() {
+			const [suspended, updateSuspended] = useState(false);
+			setSuspended = updateSuspended;
+			store = useSignals(1);
+			try {
+				if (suspended) {
+					void tracked.value;
+					throw pending;
+				}
+				return <p>ready</p>;
+			} finally {
+				store.f();
+			}
+		}
+
+		await act(() => {
+			root.render(
+				<Suspense fallback={<span>loading</span>}>
+					<App />
+				</Suspense>
+			);
+		});
+		await act(() => setSuspended(true));
+		expect(store._subscribers.length).to.be.greaterThan(0);
+
+		await act(() => root.unmount());
+		expect(store._subscribers).to.have.length(0);
+		expect(getTargets(tracked)).to.equal(undefined);
+	});
+
+	it("restores the subscribe implementation active before rendering", async () => {
+		function subscribeWrapper(
+			this: Signal,
+			node: Parameters<Signal["_subscribe"]>[0]
+		) {
+			return originalSubscribe.call(this, node);
+		}
+		Signal.prototype._subscribe = subscribeWrapper;
+		const pending = new Promise<void>(() => {});
+		let restoredWrapper = false;
+
+		/** @noUseSignals */
+		function App(): JSX.Element {
+			const store = useSignals(1);
+			try {
+				throw pending;
+			} finally {
+				store.f();
+			}
+		}
+
+		try {
+			await act(() => {
+				root.render(
+					<Suspense fallback={<span>loading</span>}>
+						<App />
+					</Suspense>
+				);
+			});
+			restoredWrapper = Signal.prototype._subscribe === subscribeWrapper;
+		} finally {
+			Signal.prototype._subscribe = originalSubscribe;
+		}
+
+		expect(restoredWrapper).to.equal(true);
+	});
+
+	it("restores the prototype before rendering an error boundary", async () => {
+		const tracked = signal(0);
+		let subscribeSeenByFallback: typeof Signal.prototype._subscribe | undefined;
+
+		/** @noUseSignals */
+		function App(): JSX.Element {
+			const store = useSignals(1);
+			try {
+				void tracked.value;
+				throw new Error("render failed");
+			} finally {
+				store.f();
+			}
+		}
+
+		await act(() => {
+			root.render(
+				<ErrorBoundary
+					onFallback={() => {
+						subscribeSeenByFallback = Signal.prototype._subscribe;
+					}}
+				>
+					<App />
+				</ErrorBoundary>
+			);
+		});
+
+		expect(scratch.innerHTML).to.equal("<span>error</span>");
+		expect(subscribeSeenByFallback).to.equal(originalSubscribe);
+		expect(Signal.prototype._subscribe).to.equal(originalSubscribe);
+		expect(getTargets(tracked)).to.equal(undefined);
+	});
+
+	it("restores the prototype when starting an effect throws", async () => {
+		let store!: EffectStore;
+		let rerender!: () => void;
+		let subscribeSeenByFallback: typeof Signal.prototype._subscribe | undefined;
+
+		/** @noUseSignals */
+		function App() {
+			const [, setVersion] = useState(0);
+			rerender = () => setVersion(version => version + 1);
+			store = useSignals(1);
+			try {
+				return <p>ready</p>;
+			} finally {
+				store.f();
+			}
+		}
+
+		await act(() => {
+			root.render(
+				<ErrorBoundary
+					onFallback={() => {
+						subscribeSeenByFallback = Signal.prototype._subscribe;
+					}}
+				>
+					<App />
+				</ErrorBoundary>
+			);
+		});
+
+		const originalStart = store.effect._start;
+		store.effect._start = () => {
+			throw new Error("start failed");
+		};
+		try {
+			await act(() => rerender());
+		} finally {
+			store.effect._start = originalStart;
+		}
+
+		expect(scratch.innerHTML).to.equal("<span>error</span>");
+		expect(subscribeSeenByFallback).to.equal(originalSubscribe);
+		expect(Signal.prototype._subscribe).to.equal(originalSubscribe);
+	});
+});

--- a/packages/react/runtime/test/browser/subscription-lifecycle.test.tsx
+++ b/packages/react/runtime/test/browser/subscription-lifecycle.test.tsx
@@ -202,22 +202,31 @@ describe("subscription lifecycle", () => {
 		expect(getTargets(tracked)).to.equal(undefined);
 	});
 
-	it("restores the subscribe implementation active before rendering", async () => {
+	it("restores and invokes the subscribe implementation active before rendering", async () => {
+		const tracked = signal(0);
+		let wrapperCallCount = 0;
 		function subscribeWrapper(
 			this: Signal,
 			node: Parameters<Signal["_subscribe"]>[0]
 		) {
+			wrapperCallCount++;
 			return originalSubscribe.call(this, node);
 		}
 		Signal.prototype._subscribe = subscribeWrapper;
-		const pending = new Promise<void>(() => {});
+		let resolve!: () => void;
+		let resolved = false;
+		const pending = new Promise<void>(r => {
+			resolve = r;
+		});
 		let restoredWrapper = false;
 
 		/** @noUseSignals */
 		function App(): JSX.Element {
 			const store = useSignals(1);
 			try {
-				throw pending;
+				const value = tracked.value;
+				if (!resolved) throw pending;
+				return <p>{value}</p>;
 			} finally {
 				store.f();
 			}
@@ -232,11 +241,18 @@ describe("subscription lifecycle", () => {
 				);
 			});
 			restoredWrapper = Signal.prototype._subscribe === subscribeWrapper;
+
+			resolved = true;
+			await act(async () => {
+				resolve();
+				await pending;
+			});
 		} finally {
 			Signal.prototype._subscribe = originalSubscribe;
 		}
 
 		expect(restoredWrapper).to.equal(true);
+		expect(wrapperCallCount).to.equal(1);
 	});
 
 	it("restores the prototype before rendering an error boundary", async () => {

--- a/packages/react/runtime/test/browser/useSignals.test.tsx
+++ b/packages/react/runtime/test/browser/useSignals.test.tsx
@@ -16,6 +16,7 @@ const MANAGED_HOOK = 2;
 describe("useSignals", () => {
 	let scratch: HTMLDivElement;
 	let root: Root;
+	let originalSubscribe: typeof Signal.prototype._subscribe;
 
 	async function render(element: Parameters<Root["render"]>[0]) {
 		await act(() => root.render(element));
@@ -54,6 +55,7 @@ describe("useSignals", () => {
 		document.body.appendChild(scratch);
 		root = await createRoot(scratch);
 		getConsoleErrorSpy().mockClear();
+		originalSubscribe = Signal.prototype._subscribe;
 	});
 
 	afterEach(async () => {
@@ -65,6 +67,7 @@ describe("useSignals", () => {
 		//
 		// checkConsoleErrorLogs();
 		checkHangingAct();
+		expect(Signal.prototype._subscribe).to.equal(originalSubscribe);
 	});
 
 	it("should rerender components when signals they use change", async () => {


### PR DESCRIPTION
Resolves https://github.com/preactjs/signals/issues/768

This effectively addresses the "missing lifecycle" problem of React, when React suspends during mount it will discard any in progress work which means that the store won't be disposed and hence the subscriptions/... won't be discarded. We circumvent this by overriding the Signal `_subscribe` method,  which sets up the subscriptions, to track all subscriptions for a store and only subscribe them when we are sure the component is fully mounted. This prevents us from subscribing on a work-in-progress state which will just be discarded.

Why do I think this is breaking? React already has a rule not to setState during render but we can't be sure everyone expects that, hence we are marking this as breaking. No synchronous work should be able to intervene during component rendering hence this forking of `Signal.prototype._subscribe` is safe as long as we ensure it's restored in the end.

Thanks to the finally cleaning up with store.f() we are sure this restoration happens correctly. In the manual unmamaged one we might have patterns where we don't which I am fine with due to this being a major bump.

TODO:

- [x] Add tests asserting that `Signal.prototype._subscribe` is restored to its initial form