### PR TITLE
Add contribution guidelines for LLM usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing
 
+## Contribution guidelines
+
+We recognize that LLM's have become an integral tool for many users, however when using LLMs to help write issues or pull requests, disclose this. Transparency preserves the collaborative integrity that makes open-source communities work. It's the difference between "I used AI to help structure this bug report" (honest, helpful) and silently passing off generated content as your own analysis (deceptive, counterproductive). We as maintainers want to engage with humans rather than LLM-generated messages, put time in your issue report and that will be reflected back.
+
 ## Releasing Signals (Maintainers only)
 
 This guide is intended for core team members that have the necessary rights to merge pull requests to the `main` branch.


### PR DESCRIPTION
Added guidelines for using LLMs in contributions to ensure transparency and maintain collaborative integrity.

See https://github.com/preactjs/signals/issues/801

Maybe even better as a code of conduct so we can just close and warn? Could copy the one over from preactjs https://github.com/preactjs/preact/pull/4961
