### PR TITLE
Try an alternative approach to component tracking

### DIFF
--- a/docs/demos/index.tsx
+++ b/docs/demos/index.tsx
@@ -13,6 +13,7 @@ const demos = {
 	Sum,
 	GlobalCounter,
 	DuelingCounters,
+	UnmountTest: lazy(() => import("./unmount-test")),
 	Devtools: lazy(() => import("./devtools")),
 	Nesting: lazy(() => import("./nesting")),
 	Animation: lazy(() => import("./animation")),

--- a/docs/demos/unmount-test.tsx
+++ b/docs/demos/unmount-test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Test demo for verifying component mount/unmount behavior with the devtools.
+ *
+ * This demo specifically tests:
+ * 1. When 2 components of the same type are mounted, they get reported correctly
+ * 2. When one unmounts, the signal should still show the remaining component re-renders
+ * 3. When both unmount, the signal should no longer show any component re-renders
+ */
+import { useSignal } from "@preact/signals";
+import { signal, computed } from "@preact/signals-core";
+import { useEffect, useRef } from "preact/hooks";
+import { mount } from "@preact/signals-devtools-ui";
+import "@preact/signals-devtools-ui/styles";
+import { createDirectAdapter } from "@preact/signals-devtools-adapter";
+import "./devtools.css";
+
+// Shared signal that multiple components will subscribe to
+const sharedCounter = signal(0, { name: "sharedCounter" });
+
+// Computed that depends on sharedCounter
+const doubleCounter = computed(() => sharedCounter.value * 2, {
+	name: "doubleCounter",
+});
+
+// Counter component that subscribes to the shared signal
+function Counter({ id }: { id: number }) {
+	// This component reads the shared signal, so it should be tracked as an owner
+	const count = sharedCounter.value;
+	const double = doubleCounter.value;
+
+	return (
+		<div class="counter-instance" data-id={id}>
+			<h3>Counter Instance #{id}</h3>
+			<p>
+				Count: {count} | Double: {double}
+			</p>
+		</div>
+	);
+}
+
+// Embedded DevTools panel component
+function EmbeddedDevTools() {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!containerRef.current) return;
+
+		const adapter = createDirectAdapter();
+
+		let cleanup: (() => void) | null = null;
+
+		mount({
+			adapter,
+			container: containerRef.current,
+			hideHeader: false,
+			initialTab: "updates",
+		}).then((unmount: () => void) => {
+			cleanup = unmount;
+		});
+
+		return () => {
+			if (cleanup) cleanup();
+		};
+	}, []);
+
+	return <div ref={containerRef} class="devtools-panel" />;
+}
+
+// Main demo component
+export default function UnmountTestDemo() {
+	const showFirstCounter = useSignal(true, { name: "showFirstCounter" });
+	const showSecondCounter = useSignal(true, { name: "showSecondCounter" });
+
+	return (
+		<div class="devtools-demo-container">
+			<div class="app-section">
+				<h1>Component Unmount Test</h1>
+				<p>
+					This demo tests that when 2 components of the same type are mounted:
+				</p>
+				<ol>
+					<li>Both are tracked as owners of the shared signal</li>
+					<li>
+						When one unmounts, the signal still shows the remaining component
+					</li>
+					<li>
+						When both unmount, the signal no longer shows any component owners
+					</li>
+				</ol>
+
+				<div class="controls">
+					<h2>Controls</h2>
+					<button onClick={() => (sharedCounter.value += 1)}>
+						Increment Counter (current: {sharedCounter.value})
+					</button>
+
+					<div class="toggle-buttons">
+						<button
+							onClick={() => (showFirstCounter.value = !showFirstCounter.value)}
+						>
+							{showFirstCounter.value
+								? "Hide First Counter"
+								: "Show First Counter"}
+						</button>
+						<button
+							onClick={() =>
+								(showSecondCounter.value = !showSecondCounter.value)
+							}
+						>
+							{showSecondCounter.value
+								? "Hide Second Counter"
+								: "Show Second Counter"}
+						</button>
+					</div>
+				</div>
+
+				<div class="counters">
+					<h2>
+						Counter Instances (
+						{(showFirstCounter.value ? 1 : 0) +
+							(showSecondCounter.value ? 1 : 0)}{" "}
+						mounted)
+					</h2>
+
+					{showFirstCounter.value && <Counter id={1} />}
+					{showSecondCounter.value && <Counter id={2} />}
+
+					{!showFirstCounter.value && !showSecondCounter.value && (
+						<p class="no-counters">
+							No counters mounted. The sharedCounter signal should no longer
+							show any component owners.
+						</p>
+					)}
+				</div>
+
+				<div class="instructions">
+					<h2>Testing Instructions</h2>
+					<ol>
+						<li>Open the DevTools panel (or embedded devtools below)</li>
+						<li>
+							Click "Increment Counter" and verify both Counter components are
+							shown as owners in the graph
+						</li>
+						<li>Click "Hide First Counter" to unmount it</li>
+						<li>
+							Click "Increment Counter" again - only the second Counter should
+							be shown as owner
+						</li>
+						<li>Click "Hide Second Counter" to unmount it</li>
+						<li>
+							Click "Increment Counter" - no component should be shown as owner
+							of the signal
+						</li>
+					</ol>
+				</div>
+			</div>
+			<div class="devtools-section">
+				<EmbeddedDevTools />
+			</div>
+		</div>
+	);
+}

--- a/packages/devtools-adapter/src/base-adapter.ts
+++ b/packages/devtools-adapter/src/base-adapter.ts
@@ -23,6 +23,9 @@ export abstract class BaseAdapter implements DevToolsAdapter {
 		connectionStatusChanged: new Set(),
 		backgroundReady: new Set(),
 		contentScriptDisconnected: new Set(),
+		componentMount: new Set(),
+		componentUnmount: new Set(),
+		componentRender: new Set(),
 	};
 
 	protected connectionStatus: ConnectionStatus = {

--- a/packages/devtools-adapter/src/direct-adapter.ts
+++ b/packages/devtools-adapter/src/direct-adapter.ts
@@ -143,6 +143,34 @@ export class DirectAdapter extends BaseAdapter {
 		});
 		this.cleanupFns.push(initUnsubscribe);
 
+		// Subscribe to component lifecycle events
+		if (api.onComponentMount) {
+			const componentMountUnsub = api.onComponentMount(
+				(info: { componentName: string; instanceCount: number }) => {
+					this.emit("componentMount", info);
+				}
+			);
+			this.cleanupFns.push(componentMountUnsub);
+		}
+
+		if (api.onComponentUnmount) {
+			const componentUnmountUnsub = api.onComponentUnmount(
+				(info: { componentName: string; remainingInstances: number }) => {
+					this.emit("componentUnmount", info);
+				}
+			);
+			this.cleanupFns.push(componentUnmountUnsub);
+		}
+
+		if (api.onComponentRender) {
+			const componentRenderUnsub = api.onComponentRender(
+				(info: { componentName: string }) => {
+					this.emit("componentRender", info);
+				}
+			);
+			this.cleanupFns.push(componentRenderUnsub);
+		}
+
 		this.setSignalsAvailable(true);
 		this.setConnectionStatus({
 			status: "connected",

--- a/packages/devtools-adapter/src/types.ts
+++ b/packages/devtools-adapter/src/types.ts
@@ -67,6 +67,18 @@ export interface AdapterEvents {
 	backgroundReady: (contentScriptConnected: boolean) => void;
 	/** Content script disconnected (browser extension specific) */
 	contentScriptDisconnected: () => void;
+	/** Component mounted */
+	componentMount: (info: {
+		componentName: string;
+		instanceCount: number;
+	}) => void;
+	/** Component unmounted */
+	componentUnmount: (info: {
+		componentName: string;
+		remainingInstances: number;
+	}) => void;
+	/** Component re-rendered due to signal change */
+	componentRender: (info: { componentName: string }) => void;
 }
 
 /**

--- a/packages/react-transform/src/index.ts
+++ b/packages/react-transform/src/index.ts
@@ -494,20 +494,13 @@ try {
 	STORE_IDENTIFIER.f();
 }`;
 
+// Debug template passes component name to useSignals for devtools tracking
 const debugTryCatchTemplate = template.statements(
-	`var STORE_IDENTIFIER = HOOK_IDENTIFIER(HOOK_USAGE);
+	`var STORE_IDENTIFIER = HOOK_IDENTIFIER(HOOK_USAGE, COMPONENT_NAME);
 try {
-	if (window.__PREACT_SIGNALS_DEVTOOLS__) {
-		window.__PREACT_SIGNALS_DEVTOOLS__.enterComponent(
-			COMPONENT_NAME
-		);
-	}
 	BODY
 } finally {
 	STORE_IDENTIFIER.f();
-	if (window.__PREACT_SIGNALS_DEVTOOLS__) {
-		window.__PREACT_SIGNALS_DEVTOOLS__.exitComponent();
-	}
 }`,
 	{
 		placeholderWhitelist: new Set([
@@ -516,7 +509,6 @@ try {
 			"HOOK_IDENTIFIER",
 			"BODY",
 			"COMPONENT_NAME",
-			"STORE_IDENTIFIER",
 		]),
 		placeholderPattern: false,
 	}
@@ -533,6 +525,7 @@ function wrapInTryFinally(
 	const stopTrackingIdentifier = path.scope.generateUidIdentifier("effect");
 
 	if (isDebug) {
+		// Debug mode: pass component name to useSignals for devtools tracking
 		const statements = debugTryCatchTemplate({
 			COMPONENT_NAME: t.stringLiteral(componentName),
 			STORE_IDENTIFIER: stopTrackingIdentifier,
@@ -544,6 +537,7 @@ function wrapInTryFinally(
 		});
 		return t.blockStatement(statements);
 	} else {
+		// Non-debug mode: no component name passed
 		const statements = tryCatchTemplate({
 			STORE_IDENTIFIER: stopTrackingIdentifier,
 			HOOK_IDENTIFIER: get(state, getHookIdentifier)(),

--- a/packages/react-transform/test/node/index.test.tsx
+++ b/packages/react-transform/test/node/index.test.tsx
@@ -802,16 +802,6 @@ describe("React Signals Babel Transform", () => {
 	describe("signal naming", () => {
 		const DEBUG_OPTIONS = { mode: "auto", experimental: { debug: true } };
 
-		const PREAMBLE = `if (window.__PREACT_SIGNALS_DEVTOOLS__) {
-	window.__PREACT_SIGNALS_DEVTOOLS__.enterComponent(
-		"MyComponent:Component.js"
-	);
-}`;
-
-		const POSTAMBLE = `	if (window.__PREACT_SIGNALS_DEVTOOLS__) {
-	window.__PREACT_SIGNALS_DEVTOOLS__.exitComponent();
-}`;
-
 		const runDebugTest = (
 			inputCode: string,
 			expectedOutput: string,
@@ -833,9 +823,8 @@ describe("React Signals Babel Transform", () => {
 			const expectedOutput = `
 				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
 				function MyComponent() {
-					var _effect = _useSignals(1);
+					var _effect = _useSignals(1, "MyComponent:Component.js");
 					try {
-					    ${PREAMBLE}
 						const count = signal(0, {
 							name: "count (Component.js:3)",
 						});
@@ -845,7 +834,6 @@ describe("React Signals Babel Transform", () => {
 						return <div>{double.value}</div>;
 					} finally {
 						_effect.f();
-						${POSTAMBLE}
 					}
 				}
 			`;
@@ -865,9 +853,8 @@ describe("React Signals Babel Transform", () => {
 			const expectedOutput = `
 				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
 				function MyComponent() {
-					var _effect = _useSignals(1);
+					var _effect = _useSignals(1, "MyComponent:Component.js");
 					try {
-					    ${PREAMBLE}
 						const count = useSignal(0, {
 							name: "count (Component.js:3)",
 						});
@@ -877,7 +864,6 @@ describe("React Signals Babel Transform", () => {
 						return <div>{count.value} {message.value}</div>;
 					} finally {
 						_effect.f();
-						${POSTAMBLE}
 					}
 				}
 			`;
@@ -897,9 +883,8 @@ describe("React Signals Babel Transform", () => {
 			const expectedOutput = `
 				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
 				function MyComponent() {
-					var _effect = _useSignals(1);
+					var _effect = _useSignals(1, "MyComponent:Component.js");
 					try {
-					    ${PREAMBLE}
 						const count = signal(0, {
 							name: "myCounter",
 						});
@@ -910,7 +895,6 @@ describe("React Signals Babel Transform", () => {
 						return <div>{count.value}</div>;
 					} finally {
 						_effect.f();
-						${POSTAMBLE}
 					}
 				}
 			`;
@@ -929,16 +913,14 @@ describe("React Signals Babel Transform", () => {
 			const expectedOutput = `
 				import { useSignals as _useSignals } from "@preact/signals-react/runtime";
 				function MyComponent() {
-					var _effect = _useSignals(1);
+					var _effect = _useSignals(1, "MyComponent:Component.js");
 					try {
-					    ${PREAMBLE}
 						const count = useSignal(undefined, {
 							name: "count (Component.js:3)",
 						});
 						return <div>{count.value}</div>;
 					} finally {
 						_effect.f();
-						${POSTAMBLE}
 					}
 				}
 			`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1870,10 +1870,6 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  ansi-styles@6.1.0:
-    resolution: {integrity: sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==}
-    engines: {node: '>=12'}
-
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2427,7 +2423,6 @@ packages:
 
   deepcopy@2.1.0:
     resolution: {integrity: sha512-8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==}
-    deprecated: No longer maintained. Use structuredClone instead.
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -7454,8 +7449,6 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  ansi-styles@6.1.0: {}
-
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -10695,7 +10688,7 @@ snapshots:
 
   slice-ansi@5.0.0:
     dependencies:
-      ansi-styles: 6.1.0
+      ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
   smartwrap@2.0.2:
@@ -11345,7 +11338,7 @@ snapshots:
 
   wrap-ansi@8.1.0:
     dependencies:
-      ansi-styles: 6.1.0
+      ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.0.1
 


### PR DESCRIPTION
This tries to provide a better way to subscribe and especially unsubscribe components in the devtools.

Before we had a very manual `mount`/`unmount` sequence but this ended up being hard to track. Now instead of doing all of the manual labour we consider the `effect` a special case.