### PR TITLE
Format mangle.json using JSON.stringify

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "preactjs/signals" }],
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "preactjs/signals"
+    }
+  ],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/mangle.json
+++ b/mangle.json
@@ -5,7 +5,11 @@
   },
   "minify": {
     "mangle": {
-      "reserved": ["useSignal", "useComputed", "useSignalEffect"],
+      "reserved": [
+        "useSignal",
+        "useComputed",
+        "useSignalEffect"
+      ],
       "keep_classnames": true,
       "properties": {
         "regex": "^_[^_]",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,18 @@
   },
   "prettier": {
     "arrowParens": "avoid",
-    "trailingComma": "es5"
+    "trailingComma": "es5",
+    "overrides": [
+      {
+        "files": [
+          "package.json",
+          "mangle.json"
+        ],
+        "options": {
+          "parser": "json-stringify"
+        }
+      }
+    ]
   },
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
Microbundle will overwrite the mangle.json file on every build, so I'm updating our prettier config to format JSON using the same formatter microbundle uses (`JSON.stringify`) so they don't conflict with each other anymore