### PR TITLE
Always rename props on build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,18 @@
+module.exports = function (api) {
+	api.cache(true);
+
+	const rename = {};
+	const mangle = require("./mangle.json");
+	for (let prop in mangle.props.props) {
+		let name = prop;
+		if (name[0] === "$") {
+			name = name.slice(1);
+		}
+
+		rename[name] = mangle.props.props[prop];
+	}
+
+	return {
+		plugins: [["babel-plugin-transform-rename-properties", { rename }]],
+	};
+};


### PR DESCRIPTION
> Note: this is dependent on preactjs/babel-plugin-transform-rename-properties#12 to work

I'd like to produce non-minified builds of signals to help debug issues. So I've copied the same babel transform we use in Preact to always rename properties regardless of whether microbundle is minifying or not (`--no-compress`).