### PR TITLE
Add sleep to devtools-ui build

### DIFF
--- a/packages/devtools-ui/package.json
+++ b/packages/devtools-ui/package.json
@@ -44,7 +44,7 @@
     "README.md"
   ],
   "scripts": {
-    "prepublishOnly": "cd ../.. && pnpm build",
+    "prepublishOnly": "cd ../.. && sleep 60 && pnpm build:devtools-adapter && pnpm build:preact && pnpm _build:devtools-ui",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
This is a bit of a hack for when we publish dependencies of the devtools-ui simultaneously with the ui itself. This only affects publishing so should not be too problematic as seen in https://github.com/preactjs/signals/actions/runs/21255002408/attempts/1