### PR TITLE
Discover dependencies without updates

### DIFF
--- a/packages/debug/src/devtools.ts
+++ b/packages/debug/src/devtools.ts
@@ -1,4 +1,4 @@
-import { UpdateInfo } from "./internal";
+import { UpdateInfo, DependencyInfo } from "./internal";
 import {
 	getSignalId,
 	getSignalName,
@@ -17,8 +17,8 @@ export interface FormattedSignalUpdate {
 	timestamp: number;
 	depth: number;
 	subscribedTo?: string;
-	/** All signal IDs this computed/effect currently depends on */
-	allDependencies?: string[];
+	/** All dependencies this computed/effect currently depends on (with rich info) */
+	allDependencies?: DependencyInfo[];
 }
 
 /** Formatted signal disposal event for external consumers */

--- a/packages/debug/src/internal.ts
+++ b/packages/debug/src/internal.ts
@@ -16,6 +16,12 @@ export type Node = {
 	_rollbackNode?: Node;
 };
 
+export interface DependencyInfo {
+	id: string;
+	name: string;
+	type: "signal" | "computed";
+}
+
 export type UpdateInfo = ValueUpdate | EffectUpdate;
 
 export interface ValueUpdate {
@@ -26,7 +32,7 @@ export interface ValueUpdate {
 	timestamp: number;
 	depth: number;
 	subscribedTo?: string; // signalId of the signal this effect is subscribed to
-	allDependencies?: string[]; // All signalIds this computed depends on
+	allDependencies?: DependencyInfo[]; // All dependencies this computed depends on
 }
 
 interface EffectUpdate {
@@ -35,5 +41,5 @@ interface EffectUpdate {
 	signal: Effect;
 	depth: number;
 	subscribedTo?: string; // signalId of the signal this effect is subscribed to
-	allDependencies?: string[]; // All signalIds this effect depends on
+	allDependencies?: DependencyInfo[]; // All dependencies this effect depends on
 }

--- a/packages/devtools-adapter/src/index.ts
+++ b/packages/devtools-adapter/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	AdapterFactory,
 	Unsubscribe,
 	SignalUpdate,
+	DependencyInfo,
 	Settings,
 	ConnectionStatus,
 	ConnectionStatusType,

--- a/packages/devtools-adapter/src/types.ts
+++ b/packages/devtools-adapter/src/types.ts
@@ -1,4 +1,13 @@
 /**
+ * Rich dependency information for a signal/computed
+ */
+export interface DependencyInfo {
+	id: string;
+	name: string;
+	type: "signal" | "computed";
+}
+
+/**
  * Represents a signal update event from the debug system
  */
 export interface SignalUpdate {
@@ -12,8 +21,8 @@ export interface SignalUpdate {
 	receivedAt: number;
 	depth?: number;
 	subscribedTo?: string;
-	/** All signal IDs this computed/effect currently depends on */
-	allDependencies?: string[];
+	/** All dependencies this computed/effect currently depends on (with rich info) */
+	allDependencies?: DependencyInfo[];
 }
 
 /**

--- a/packages/devtools-ui/src/components/Graph.tsx
+++ b/packages/devtools-ui/src/components/Graph.tsx
@@ -89,16 +89,30 @@ export function GraphVisualization() {
 
 			// Process all dependencies to show complete dependency graph
 			// This ensures we see all edges, not just the one that triggered the update
+			// It also creates nodes for dependencies that haven't had their own updates
 			if (update.allDependencies && update.allDependencies.length > 0) {
-				for (const depId of update.allDependencies) {
+				for (const dep of update.allDependencies) {
 					// Skip links to/from disposed signals
-					const sourceDisposed = !showDisposed && disposed.has(depId);
+					const sourceDisposed = !showDisposed && disposed.has(dep.id);
 					if (sourceDisposed) continue;
 
-					const linkKey = `${depId}->${update.signalId}`;
+					// Create node for the dependency if it doesn't exist
+					// This allows showing dependencies in the graph even if they haven't updated
+					if (!nodes.has(dep.id)) {
+						nodes.set(dep.id, {
+							id: dep.id,
+							name: dep.name,
+							type: dep.type,
+							x: 0,
+							y: 0,
+							depth: 0, // Base dependencies are at depth 0
+						});
+					}
+
+					const linkKey = `${dep.id}->${update.signalId}`;
 					if (!links.has(linkKey)) {
 						links.set(linkKey, {
-							source: depId,
+							source: dep.id,
 							target: update.signalId,
 						});
 					}

--- a/packages/devtools-ui/src/context.ts
+++ b/packages/devtools-ui/src/context.ts
@@ -5,6 +5,7 @@ import type {
 	ConnectionStatusType,
 	Settings,
 	SignalDisposed,
+	DependencyInfo,
 } from "@preact/signals-devtools-adapter";
 
 export interface DevToolsContext {
@@ -74,8 +75,8 @@ export interface SignalUpdate {
 	receivedAt: number;
 	depth?: number;
 	subscribedTo?: string;
-	/** All signal IDs this computed/effect currently depends on */
-	allDependencies?: string[];
+	/** All dependencies this computed/effect currently depends on (with rich info) */
+	allDependencies?: DependencyInfo[];
 }
 
 export type Divider = { type: "divider" };

--- a/packages/devtools-ui/src/types.ts
+++ b/packages/devtools-ui/src/types.ts
@@ -4,6 +4,7 @@
 export type {
 	SignalUpdate,
 	SignalDisposed,
+	DependencyInfo,
 	Settings,
 	ConnectionStatus,
 	ConnectionStatusType,


### PR DESCRIPTION
Before this change we discovered all dependencies of a given effect/computed by running through its _sources linked list. You can see that in the `getAllCurrentDependencies` function where we actually get all of the depenencies. However, while we do discover all entities, the graph in devtools-ui won't show any that it hasn't seen updates from yet. This because we derive the graph solely from the update events we receive.

This adds a way to show the untracked nodes without adding them to updates, with this change we might need a better algorithm to sort the graph as it currently can fold pretty oddly for the Devtools demo.

Try typing a bit into the input and then selecting all the Done things, best done in local development as production bundling has some quirks for netlify