### PR TITLE
Prevent us from returning false for updating suspended vnode trees

### DIFF
--- a/.changeset/fuzzy-ads-poke.md
+++ b/.changeset/fuzzy-ads-poke.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Fix issue where unmounted vnodes could update with signals

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -363,6 +363,9 @@ Component.prototype.shouldComponentUpdate = function (
 	props,
 	state
 ) {
+	// Suspended vnodes should always update:
+	if (this.__R) return true;
+
 	// @todo: Once preactjs/preact#3671 lands, this could just use `currentUpdater`:
 	const updater = this._updater;
 	const hasSignals = updater && updater._sources !== undefined;

--- a/packages/preact/src/internal.d.ts
+++ b/packages/preact/src/internal.d.ts
@@ -21,6 +21,8 @@ export interface AugmentedElement extends HTMLElement {
 }
 
 export interface AugmentedComponent extends Component<any, any> {
+	// onResolve --> Preact indicator for suspended subtrees
+	__R?: boolean;
 	//  hasScuFromHooks
 	// Preact 10.12 - Preact 10.25
 	u?: boolean;


### PR DESCRIPTION
When preact suspends it creates a "parked" vnode structure, the real DOM is discarded but the virtual tree remains in-memory. This means that when a component has suspended but never actually mounted that it is absent of any vnode properties.

When a suspended tree is unmounted we clear all properties another time but suspense has already cleared `_component` which means that we will never dispose the `effect`, any signal update contained within the component can therefor cause re-renders.

With this patch we rely on the __R internal property, people using native Suspense will see this error clear up.

A repro can be seen at
https://stackblitz.com/edit/vitejs-vite-bzsqxq1w?file=src%2Fsignals-patch.js,src%2Fapp.tsx&terminal=dev
- replacing signals-patch with @preact/signals will reproduce the bug.