### PR TITLE
Format more files with Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/docs/demos/animation/style.css
+++ b/docs/demos/animation/style.css
@@ -1,49 +1,49 @@
 .animation {
-	position: absolute;
-	left: 0;
-	top: 52px;
-	bottom: 0;
-	width: 100%;
-	background: #222;
-	color: #888;
-	text-rendering: optimizeSpeed;
-	touch-action: none;
-	overflow: hidden;
+  position: absolute;
+  left: 0;
+  top: 52px;
+  bottom: 0;
+  width: 100%;
+  background: #222;
+  color: #888;
+  text-rendering: optimizeSpeed;
+  touch-action: none;
+  overflow: hidden;
 }
 
 .circle {
-	position: absolute;
-	left: 0;
-	top: 0;
-	width: 8px;
-	height: 8px;
-	margin: -5px 0 0 -5px;
-	border: 2px solid #f00;
-	border-radius: 50%;
-	transform-origin: 50% 50%;
-	transition: all 250ms ease;
-	transition-property: width, height, margin;
-	pointer-events: none;
-	overflow: hidden;
-	font-size: 9px;
-	line-height: 25px;
-	text-indent: 15px;
-	white-space: nowrap;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 8px;
+  height: 8px;
+  margin: -5px 0 0 -5px;
+  border: 2px solid #f00;
+  border-radius: 50%;
+  transform-origin: 50% 50%;
+  transition: all 250ms ease;
+  transition-property: width, height, margin;
+  pointer-events: none;
+  overflow: hidden;
+  font-size: 9px;
+  line-height: 25px;
+  text-indent: 15px;
+  white-space: nowrap;
 
-	&.label {
-		overflow: visible;
-	}
+  &.label {
+    overflow: visible;
+  }
 
-	&.big {
-		width: 24px;
-		height: 24px;
-		margin: -13px 0 0 -13px;
-	}
+  &.big {
+    width: 24px;
+    height: 24px;
+    margin: -13px 0 0 -13px;
+  }
 
-	& > .label {
-		position: absolute;
-		left: 0;
-		top: 0;
-		z-index: 10;
-	}
+  & > .label {
+    position: absolute;
+    left: 0;
+    top: 0;
+    z-index: 10;
+  }
 }

--- a/docs/demos/basic.html
+++ b/docs/demos/basic.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<title>Basic Demo</title>

--- a/docs/demos/devtools.css
+++ b/docs/demos/devtools.css
@@ -37,4 +37,3 @@
   gap: 8px;
   margin-bottom: 4px;
 }
-

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<title>Demos</title>

--- a/docs/demos/nesting/style.css
+++ b/docs/demos/nesting/style.css
@@ -1,95 +1,99 @@
 .nesting {
-	position: relative;
-	margin: 10px;
-	padding: 10px;
-	max-width: 22em;
-	border: 1px solid #ddd;
-	background: #f4f2f0;
+  position: relative;
+  margin: 10px;
+  padding: 10px;
+  max-width: 22em;
+  border: 1px solid #ddd;
+  background: #f4f2f0;
 
-	& .notes {
-		color: #345;
-		margin-top: 20px;
-		border-top: 4px double #ccc;
-	}
-	& h4 {
-		margin: 1em 0 0;
-	}
-	& ul {
-		margin: 0;
-		padding: 0.25em 1em;
-	}
-	& li > ul {
-		padding-top: 0;
-		padding-bottom: 0;
-		font-size: 90%;
-	}
-	& ul > li {
-		padding: 0.25em 0;
-	}
-	& code {
-		font: 100%/1.3 "Source Code Pro", monaco, menlo;
-		color: #0a8138;
-	}
+  & .notes {
+    color: #345;
+    margin-top: 20px;
+    border-top: 4px double #ccc;
+  }
+  & h4 {
+    margin: 1em 0 0;
+  }
+  & ul {
+    margin: 0;
+    padding: 0.25em 1em;
+  }
+  & li > ul {
+    padding-top: 0;
+    padding-bottom: 0;
+    font-size: 90%;
+  }
+  & ul > li {
+    padding: 0.25em 0;
+  }
+  & code {
+    font:
+      100%/1.3 "Source Code Pro",
+      monaco,
+      menlo;
+    color: #0a8138;
+  }
 
-	& output {
-		display: inline-block;
-		vertical-align: middle;
-		margin: 0 0.25em;
-		min-width: 2.5em;
-		height: 1.3em;
-		border-radius: 0.3em;
-		text-align: center;
-		background: rgba(255, 255, 255, 0.7);
-		box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.1),
-			inset 0 2px 5px rgba(0, 0, 0, 0.1);
-	}
+  & output {
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 0.25em;
+    min-width: 2.5em;
+    height: 1.3em;
+    border-radius: 0.3em;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.7);
+    box-shadow:
+      0 0 0 0.5px rgba(0, 0, 0, 0.1),
+      inset 0 2px 5px rgba(0, 0, 0, 0.1);
+  }
 
-	& .render-count {
-		position: absolute;
-		right: 0;
-		top: 0;
-		padding: 0 0.3em;
-		font-size: 70%;
-	}
+  & .render-count {
+    position: absolute;
+    right: 0;
+    top: 0;
+    padding: 0 0.3em;
+    font-size: 70%;
+  }
 
-	& .object-editor {
-		position: relative;
-		margin: 20px 0 0;
-		padding: 10px 5px 5px;
-		border: 1px solid #abc;
-		background: #fff;
-		border-radius: 5px;
-	}
+  & .object-editor {
+    position: relative;
+    margin: 20px 0 0;
+    padding: 10px 5px 5px;
+    border: 1px solid #abc;
+    background: #fff;
+    border-radius: 5px;
+  }
 
-	& .clock {
-		position: fixed;
-		right: 0;
-		top: 3.2em;
-		width: 6em;
-		padding: 1.1em 1em 0.8em;
-		text-align: center;
-		background: burlywood;
-		color: darkolivegreen;
-	}
+  & .clock {
+    position: fixed;
+    right: 0;
+    top: 3.2em;
+    width: 6em;
+    padding: 1.1em 1em 0.8em;
+    text-align: center;
+    background: burlywood;
+    color: darkolivegreen;
+  }
 
-	& table {
-		table-layout: fixed;
-	}
-	& table th {
-		text-align: left;
-	}
-	& table th:first-child,
-	& table td:first-child {
-		width: 7em;
-		text-align: right;
-		font-weight: bold;
-	}
-	& table th:nth-child(2),
-	& table td:nth-child(2) {
-		width: 4em;
-		padding-left: 0.5em;
-	}
-	& table td:nth-child(3) {
-		width: 10em;
-	}
+  & table {
+    table-layout: fixed;
+  }
+  & table th {
+    text-align: left;
+  }
+  & table th:first-child,
+  & table td:first-child {
+    width: 7em;
+    text-align: right;
+    font-weight: bold;
+  }
+  & table th:nth-child(2),
+  & table td:nth-child(2) {
+    width: 4em;
+    padding-left: 0.5em;
+  }
+  & table td:nth-child(3) {
+    width: 10em;
+  }
 }

--- a/docs/demos/react/index.html
+++ b/docs/demos/react/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<title>React Demo</title>

--- a/docs/demos/react/nesting/index.html
+++ b/docs/demos/react/nesting/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<title>React Nesting Demo</title>

--- a/docs/demos/style.css
+++ b/docs/demos/style.css
@@ -1,120 +1,123 @@
 html {
-	font: 100%/1.3 system-ui, san-serif;
+  font:
+    100%/1.3 system-ui,
+    san-serif;
 }
 body {
-	margin: 0;
+  margin: 0;
 }
 
 header {
-	display: flex;
-	padding: 10px;
-	background: #ddd;
+  display: flex;
+  padding: 10px;
+  background: #ddd;
 }
 header h1 {
-	margin: 0;
-	padding-right: 0.5em;
-	font-size: 1.5em;
-	font-weight: 300;
+  margin: 0;
+  padding-right: 0.5em;
+  font-size: 1.5em;
+  font-weight: 300;
 }
 header h1 a {
-	text-decoration: none;
-	color: #555;
+  text-decoration: none;
+  color: #555;
 }
 header h1 a:hover {
-	text-decoration: underline;
-	color: #000;
+  text-decoration: underline;
+  color: #000;
 }
 nav {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: flex-start;
-	gap: 1px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1px;
 }
 nav a {
-	padding: 0.3em 0.8em;
-	border-radius: 1em;
-	color: #673ab8;
-	text-decoration: none;
-	white-space: nowrap;
+  padding: 0.3em 0.8em;
+  border-radius: 1em;
+  color: #673ab8;
+  text-decoration: none;
+  white-space: nowrap;
 }
 nav a:hover {
-	background-color: rgba(255, 255, 255, 0.5);
-	color: #56319c;
-	box-shadow: inset 0 0 0 1px #673ab8;
-	z-index: 1;
+  background-color: rgba(255, 255, 255, 0.5);
+  color: #56319c;
+  box-shadow: inset 0 0 0 1px #673ab8;
+  z-index: 1;
 }
 nav a.current {
-	background: #673ab8;
-	color: #fff;
+  background: #673ab8;
+  color: #fff;
 }
 
 main {
-	padding: 10px;
+  padding: 10px;
 }
 
 output {
-	padding: 0.3em;
-	min-width: 1.5em;
-	display: inline-block;
-	text-align: center;
+  padding: 0.3em;
+  min-width: 1.5em;
+  display: inline-block;
+  text-align: center;
 }
 
 .info {
-	position: relative;
-	padding: 0.5em 0.5em 0.5em 2em;
-	max-width: 600px;
-	background: #e6ebfc;
-	border-radius: 5px;
-	box-shadow: inset 0 0 0 0.5px #b0bee2;
-	color: #3955a1;
+  position: relative;
+  padding: 0.5em 0.5em 0.5em 2em;
+  max-width: 600px;
+  background: #e6ebfc;
+  border-radius: 5px;
+  box-shadow: inset 0 0 0 0.5px #b0bee2;
+  color: #3955a1;
 
-	&::before {
-		content: "\2139";
-		position: absolute;
-		display: inline-block;
-		text-align: center;
-		line-height: 1em;
-		width: 1.2em;
-		height: 1.2em;
-		left: 0.4em;
-		top: 50%;
-		margin-top: -0.6em;
-		background: #3955a1;
-		border-radius: 0.6em;
-		color: #fff;
-	}
+  &::before {
+    content: "\2139";
+    position: absolute;
+    display: inline-block;
+    text-align: center;
+    line-height: 1em;
+    width: 1.2em;
+    height: 1.2em;
+    left: 0.4em;
+    top: 50%;
+    margin-top: -0.6em;
+    background: #3955a1;
+    border-radius: 0.6em;
+    color: #fff;
+  }
 }
 
 .card {
-	display: inline-block;
-	padding: 0.5em 1em;
-	background: #eee;
-	box-shadow: inset 0 0 0 0.5px #ccc;
-	border-radius: 5px;
+  display: inline-block;
+  padding: 0.5em 1em;
+  background: #eee;
+  box-shadow: inset 0 0 0 0.5px #ccc;
+  border-radius: 5px;
 }
 
 .card + .card {
-	margin-left: 10px;
+  margin-left: 10px;
 }
 
 button {
-	padding: 0.3em 1em;
-	border-radius: 1em;
-	border: none;
-	background: #673ab8;
-	color: #f4eeff;
-	cursor: pointer;
+  padding: 0.3em 1em;
+  border-radius: 1em;
+  border: none;
+  background: #673ab8;
+  color: #f4eeff;
+  cursor: pointer;
 }
 button:hover {
-	background: #9359ff;
-	color: #fff;
+  background: #9359ff;
+  color: #fff;
 }
 
 table {
-	margin-top: 1em;
-	border-collapse: collapse;
+  margin-top: 1em;
+  border-collapse: collapse;
 }
-th, td {
-	border: 1px solid #aaa;
-	padding: 0.3em;
+th,
+td {
+  border: 1px solid #aaa;
+  padding: 0.3em;
 }

--- a/docs/demos/todo/style.css
+++ b/docs/demos/todo/style.css
@@ -1,118 +1,118 @@
 .todo-container {
-	max-width: 600px;
-	margin: 0 auto;
-	padding: 20px;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
 }
 
 .todo-header {
-	text-align: center;
-	margin-bottom: 20px;
+  text-align: center;
+  margin-bottom: 20px;
 }
 
 .todo-description {
-	text-align: center;
-	color: #666;
-	margin-bottom: 30px;
+  text-align: center;
+  color: #666;
+  margin-bottom: 30px;
 }
 
 .todo-form {
-	margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .todo-input {
-	width: 100%;
-	padding: 12px;
-	font-size: 16px;
-	border: 2px solid #ddd;
-	border-radius: 4px;
-	box-sizing: border-box;
+  width: 100%;
+  padding: 12px;
+  font-size: 16px;
+  border: 2px solid #ddd;
+  border-radius: 4px;
+  box-sizing: border-box;
 }
 
 .todo-list {
-	margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .todo-item {
-	display: flex;
-	align-items: center;
-	padding: 12px;
-	border-bottom: 1px solid #eee;
-	gap: 12px;
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  border-bottom: 1px solid #eee;
+  gap: 12px;
 }
 
 .todo-checkbox {
-	width: 20px;
-	height: 20px;
-	cursor: pointer;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
 }
 
 .todo-text {
-	flex: 1;
-	font-size: 16px;
-	color: #333;
+  flex: 1;
+  font-size: 16px;
+  color: #333;
 }
 
 .todo-text.completed {
-	text-decoration: line-through;
-	color: #999;
+  text-decoration: line-through;
+  color: #999;
 }
 
 .todo-delete-btn {
-	padding: 6px 12px;
-	background: #ff6b6b;
-	color: white;
-	border: none;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: 14px;
+  padding: 6px 12px;
+  background: #ff6b6b;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
 }
 
 .todo-footer {
-	padding: 12px;
-	background: #f9f9f9;
-	border-radius: 4px;
+  padding: 12px;
+  background: #f9f9f9;
+  border-radius: 4px;
 }
 
 .todo-footer-stats {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin-bottom: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
 }
 
 .todo-stats-text {
-	font-size: 14px;
-	color: #666;
+  font-size: 14px;
+  color: #666;
 }
 
 .todo-clear-btn {
-	padding: 6px 12px;
-	background: #673ab8;
-	color: white;
-	border: none;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: 14px;
+  padding: 6px 12px;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
 }
 
 .todo-filters {
-	display: flex;
-	gap: 8px;
-	justify-content: center;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
 }
 
 .todo-filter-btn {
-	padding: 6px 16px;
-	background: white;
-	color: #333;
-	border: 1px solid #673ab8;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: 14px;
-	text-transform: capitalize;
+  padding: 6px 16px;
+  background: white;
+  color: #333;
+  border: 1px solid #673ab8;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  text-transform: capitalize;
 }
 
 .todo-filter-btn.active {
-	background: #673ab8;
-	color: white;
+  background: #673ab8;
+  color: white;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 	<head>
 		<title>Demos</title>

--- a/extension/devtools.html
+++ b/extension/devtools.html
@@ -1,9 +1,8 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <script src="devtools-init.js"></script>
-</head>
-<body>
-</body>
+	<head>
+		<meta charset="utf-8" />
+		<script src="devtools-init.js"></script>
+	</head>
+	<body></body>
 </html>

--- a/extension/panel.html
+++ b/extension/panel.html
@@ -1,15 +1,15 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Preact Signals DevTools</title>
-  <link rel="stylesheet" href="styles/panel.css">
-</head>
-<body>
-  <div id="app">
-    <!-- Content will be rendered by Preact -->
-  </div>
+	<head>
+		<meta charset="utf-8" />
+		<title>Preact Signals DevTools</title>
+		<link rel="stylesheet" href="styles/panel.css" />
+	</head>
+	<body>
+		<div id="app">
+			<!-- Content will be rendered by Preact -->
+		</div>
 
-  <script type="module" src="dist/panel.js"></script>
-</body>
+		<script type="module" src="dist/panel.js"></script>
+	</body>
 </html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,115 +1,116 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Preact Signals DevTools</title>
-  <style>
-    body {
-      width: 300px;
-      padding: 16px;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      font-size: 14px;
-    }
+	<head>
+		<meta charset="utf-8" />
+		<title>Preact Signals DevTools</title>
+		<style>
+			body {
+				width: 300px;
+				padding: 16px;
+				font-family:
+					-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+				font-size: 14px;
+			}
 
-    .header {
-      text-align: center;
-      margin-bottom: 16px;
-    }
+			.header {
+				text-align: center;
+				margin-bottom: 16px;
+			}
 
-    .header h1 {
-      margin: 0 0 8px 0;
-      font-size: 18px;
-      color: #673ab7;
-    }
+			.header h1 {
+				margin: 0 0 8px 0;
+				font-size: 18px;
+				color: #673ab7;
+			}
 
-    .header p {
-      margin: 0;
-      color: #666;
-      font-size: 12px;
-    }
+			.header p {
+				margin: 0;
+				color: #666;
+				font-size: 12px;
+			}
 
-    .status {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px;
-      border-radius: 6px;
-      margin-bottom: 16px;
-      font-size: 13px;
-    }
+			.status {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				padding: 12px;
+				border-radius: 6px;
+				margin-bottom: 16px;
+				font-size: 13px;
+			}
 
-    .status.connected {
-      background: #e8f5e8;
-      color: #2e7d32;
-    }
+			.status.connected {
+				background: #e8f5e8;
+				color: #2e7d32;
+			}
 
-    .status.disconnected {
-      background: #ffebee;
-      color: #c62828;
-    }
+			.status.disconnected {
+				background: #ffebee;
+				color: #c62828;
+			}
 
-    .status-indicator {
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-    }
+			.status-indicator {
+				width: 8px;
+				height: 8px;
+				border-radius: 50%;
+			}
 
-    .status.connected .status-indicator {
-      background: #4caf50;
-    }
+			.status.connected .status-indicator {
+				background: #4caf50;
+			}
 
-    .status.disconnected .status-indicator {
-      background: #f44336;
-    }
+			.status.disconnected .status-indicator {
+				background: #f44336;
+			}
 
-    .actions {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
+			.actions {
+				display: flex;
+				flex-direction: column;
+				gap: 8px;
+			}
 
-    .btn {
-      padding: 8px 16px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      background: white;
-      cursor: pointer;
-      font-size: 13px;
-      transition: all 0.2s;
-    }
+			.btn {
+				padding: 8px 16px;
+				border: 1px solid #ccc;
+				border-radius: 4px;
+				background: white;
+				cursor: pointer;
+				font-size: 13px;
+				transition: all 0.2s;
+			}
 
-    .btn:hover {
-      background: #f5f5f5;
-    }
+			.btn:hover {
+				background: #f5f5f5;
+			}
 
-    .btn.primary {
-      background: #2196f3;
-      border-color: #2196f3;
-      color: white;
-    }
+			.btn.primary {
+				background: #2196f3;
+				border-color: #2196f3;
+				color: white;
+			}
 
-    .btn.primary:hover {
-      background: #1976d2;
-    }
+			.btn.primary:hover {
+				background: #1976d2;
+			}
 
-    .info {
-      margin-top: 16px;
-      padding: 12px;
-      background: #f5f5f5;
-      border-radius: 4px;
-      font-size: 12px;
-      color: #666;
-    }
-  </style>
-</head>
-<body>
-  <div class="header">
-    <h1>Preact Signals</h1>
-    <p>DevTools Extension</p>
-  </div>
+			.info {
+				margin-top: 16px;
+				padding: 12px;
+				background: #f5f5f5;
+				border-radius: 4px;
+				font-size: 12px;
+				color: #666;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="header">
+			<h1>Preact Signals</h1>
+			<p>DevTools Extension</p>
+		</div>
 
-  <div id="app"></div>
+		<div id="app"></div>
 
-  <script type="module" src="dist/popup.js"></script>
-</body>
+		<script type="module" src="dist/popup.js"></script>
+	</body>
 </html>

--- a/extension/styles/panel.css
+++ b/extension/styles/panel.css
@@ -7,7 +7,8 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 13px;
   line-height: 1.4;
   color: #333;
@@ -54,10 +55,10 @@ body {
 }
 
 .divider {
-	width: 100%;
-	height: 2px;
-	background: #e0e0e0;
-	margin: 8px 0;
+  width: 100%;
+  height: 2px;
+  background: #e0e0e0;
+  margin: 8px 0;
 }
 
 .status-indicator {
@@ -86,8 +87,13 @@ body {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 .header-controls {
@@ -151,7 +157,7 @@ body {
   background: white;
   border: 1px solid #d0d0d0;
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   z-index: 1000;
   max-height: 400px;
   overflow-y: auto;
@@ -316,15 +322,15 @@ body {
 }
 
 .component-name-header {
-	margin-right: 8px;
+  margin-right: 8px;
 }
 
 .component-list {
-	list-style: none;
-	display: flex;
-	padding: 0;
-	margin: 0;
-	font-family: monospace;
+  list-style: none;
+  display: flex;
+  padding: 0;
+  margin: 0;
+  font-family: monospace;
   background: #f8f9fa;
   padding: 4px 6px;
   border-radius: 3px;
@@ -464,14 +470,14 @@ body {
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: all 0.2s;
 }
 
 .graph-reset-button:hover,
 .graph-export-button:hover {
   background: #f5f5f5;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
 .graph-reset-button:active,
@@ -492,7 +498,7 @@ body {
   background: white;
   border: 1px solid #e0e0e0;
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   overflow: hidden;
   min-width: 180px;
 }
@@ -527,11 +533,11 @@ body {
   transition: all 0.2s;
   stroke: #fff;
   stroke-width: 2;
-  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.1));
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
 }
 
 .graph-node:hover {
-  filter: brightness(1.1) drop-shadow(0 2px 4px rgba(0,0,0,0.1));
+  filter: brightness(1.1) drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
 }
 
 .graph-node.signal {
@@ -569,7 +575,7 @@ body {
   font-size: 12px;
   font-weight: 500;
   pointer-events: none;
-  text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 .graph-legend {
@@ -581,7 +587,7 @@ body {
   border-radius: 4px;
   padding: 12px;
   font-size: 12px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .legend-item {
@@ -634,7 +640,7 @@ body {
   border-radius: 4px;
   font-size: 13px;
   font-weight: 500;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   z-index: 1000;
   animation: slideInFade 0.3s ease-out;
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ci:build": "pnpm build && pnpm docs:build",
     "ci:test": "pnpm lint && pnpm test",
     "prepare": "husky install && playwright install chromium",
-    "format": "prettier --ignore-path .gitignore --write '**/*.{js,jsx,ts,tsx,yml,json,md}'",
+    "format": "prettier --write .",
     "version": "pnpm changeset version && pnpm i --lockfile-only"
   },
   "authors": [
@@ -88,7 +88,7 @@
     "vite": "^6.3.5"
   },
   "lint-staged": {
-    "**/*.{js,jsx,ts,tsx,yml,json,md}": [
+    "**/*.{js,mjs,jsx,ts,tsx,yml,yaml,json,md,html,css}": [
       "prettier --write"
     ]
   },
@@ -120,6 +120,6 @@
   },
   "packageManager": "pnpm@10.7.0",
   "volta": {
-    "node": "18.18.0"
+    "node": "24.13.0"
   }
 }

--- a/packages/devtools-ui/examples/embedded-demo.html
+++ b/packages/devtools-ui/examples/embedded-demo.html
@@ -1,134 +1,135 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Embedded Signals DevTools Demo</title>
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      margin: 0;
-      padding: 20px;
-      background: #f0f0f0;
-    }
-    
-    h1 {
-      color: #333;
-    }
-    
-    .demo-container {
-      display: flex;
-      gap: 20px;
-      max-width: 1400px;
-      margin: 0 auto;
-    }
-    
-    .app-section {
-      flex: 1;
-      background: white;
-      border-radius: 8px;
-      padding: 20px;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    
-    .devtools-section {
-      flex: 1;
-      background: white;
-      border-radius: 8px;
-      overflow: hidden;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-      height: 600px;
-    }
-    
-    #devtools-container {
-      height: 100%;
-    }
-    
-    .counter {
-      font-size: 48px;
-      font-weight: bold;
-      color: #673ab7;
-      margin: 20px 0;
-    }
-    
-    .controls button {
-      padding: 10px 20px;
-      font-size: 16px;
-      margin-right: 8px;
-      cursor: pointer;
-      border: none;
-      border-radius: 4px;
-      background: #673ab7;
-      color: white;
-    }
-    
-    .controls button:hover {
-      background: #5e35b1;
-    }
-  </style>
-</head>
-<body>
-  <h1>Embedded Signals DevTools Demo</h1>
-  
-  <div class="demo-container">
-    <!-- Your Application -->
-    <div class="app-section">
-      <h2>Demo App</h2>
-      <p>This is a simple counter app using Preact Signals.</p>
-      <div class="counter" id="counter-display">0</div>
-      <div class="controls">
-        <button id="increment">Increment</button>
-        <button id="decrement">Decrement</button>
-        <button id="reset">Reset</button>
-      </div>
-    </div>
-    
-    <!-- Embedded DevTools -->
-    <div class="devtools-section">
-      <div id="devtools-container"></div>
-    </div>
-  </div>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Embedded Signals DevTools Demo</title>
+		<style>
+			body {
+				font-family:
+					-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+				margin: 0;
+				padding: 20px;
+				background: #f0f0f0;
+			}
 
-  <!-- Load your app with signals-debug -->
-  <script type="module">
-    // First, import and set up the debug package
-    import { signal, computed, effect } from "@preact/signals";
-    import "@preact/signals-debug";
-    
-    // Create some signals for the demo
-    const count = signal(0);
-    const doubled = computed(() => count.value * 2);
-    
-    // Update display
-    effect(() => {
-      document.getElementById("counter-display").textContent = count.value;
-    });
-    
-    // Set up button handlers
-    document.getElementById("increment").addEventListener("click", () => {
-      count.value++;
-    });
-    
-    document.getElementById("decrement").addEventListener("click", () => {
-      count.value--;
-    });
-    
-    document.getElementById("reset").addEventListener("click", () => {
-      count.value = 0;
-    });
-    
-    // Now, mount the DevTools UI
-    import { mount } from "@preact/signals-devtools-ui";
-    import { createDirectAdapter } from "@preact/signals-devtools-adapter";
-    
-    const adapter = createDirectAdapter();
-    
-    mount({
-      adapter,
-      container: document.getElementById("devtools-container"),
-    }).then(() => {
-      console.log("DevTools mounted successfully!");
-    });
-  </script>
-</body>
+			h1 {
+				color: #333;
+			}
+
+			.demo-container {
+				display: flex;
+				gap: 20px;
+				max-width: 1400px;
+				margin: 0 auto;
+			}
+
+			.app-section {
+				flex: 1;
+				background: white;
+				border-radius: 8px;
+				padding: 20px;
+				box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+			}
+
+			.devtools-section {
+				flex: 1;
+				background: white;
+				border-radius: 8px;
+				overflow: hidden;
+				box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+				height: 600px;
+			}
+
+			#devtools-container {
+				height: 100%;
+			}
+
+			.counter {
+				font-size: 48px;
+				font-weight: bold;
+				color: #673ab7;
+				margin: 20px 0;
+			}
+
+			.controls button {
+				padding: 10px 20px;
+				font-size: 16px;
+				margin-right: 8px;
+				cursor: pointer;
+				border: none;
+				border-radius: 4px;
+				background: #673ab7;
+				color: white;
+			}
+
+			.controls button:hover {
+				background: #5e35b1;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Embedded Signals DevTools Demo</h1>
+
+		<div class="demo-container">
+			<!-- Your Application -->
+			<div class="app-section">
+				<h2>Demo App</h2>
+				<p>This is a simple counter app using Preact Signals.</p>
+				<div class="counter" id="counter-display">0</div>
+				<div class="controls">
+					<button id="increment">Increment</button>
+					<button id="decrement">Decrement</button>
+					<button id="reset">Reset</button>
+				</div>
+			</div>
+
+			<!-- Embedded DevTools -->
+			<div class="devtools-section">
+				<div id="devtools-container"></div>
+			</div>
+		</div>
+
+		<!-- Load your app with signals-debug -->
+		<script type="module">
+			// First, import and set up the debug package
+			import { signal, computed, effect } from "@preact/signals";
+			import "@preact/signals-debug";
+
+			// Create some signals for the demo
+			const count = signal(0);
+			const doubled = computed(() => count.value * 2);
+
+			// Update display
+			effect(() => {
+				document.getElementById("counter-display").textContent = count.value;
+			});
+
+			// Set up button handlers
+			document.getElementById("increment").addEventListener("click", () => {
+				count.value++;
+			});
+
+			document.getElementById("decrement").addEventListener("click", () => {
+				count.value--;
+			});
+
+			document.getElementById("reset").addEventListener("click", () => {
+				count.value = 0;
+			});
+
+			// Now, mount the DevTools UI
+			import { mount } from "@preact/signals-devtools-ui";
+			import { createDirectAdapter } from "@preact/signals-devtools-adapter";
+
+			const adapter = createDirectAdapter();
+
+			mount({
+				adapter,
+				container: document.getElementById("devtools-container"),
+			}).then(() => {
+				console.log("DevTools mounted successfully!");
+			});
+		</script>
+	</body>
 </html>

--- a/packages/devtools-ui/examples/iframe-panel.html
+++ b/packages/devtools-ui/examples/iframe-panel.html
@@ -1,52 +1,55 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Signals DevTools - Iframe Demo</title>
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-      height: 100vh;
-      overflow: hidden;
-    }
-    #devtools-container {
-      height: 100%;
-    }
-  </style>
-  <link rel="stylesheet" href="../dist/styles.css">
-</head>
-<body>
-  <div id="devtools-container"></div>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Signals DevTools - Iframe Demo</title>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				height: 100vh;
+				overflow: hidden;
+			}
+			#devtools-container {
+				height: 100%;
+			}
+		</style>
+		<link rel="stylesheet" href="../dist/styles.css" />
+	</head>
+	<body>
+		<div id="devtools-container"></div>
 
-  <script type="module">
-    import { mount } from "@preact/signals-devtools-ui";
-    import { createPostMessageAdapter } from "@preact/signals-devtools-adapter";
-    
-    // Get the parent window origin from query params or default
-    const params = new URLSearchParams(window.location.search);
-    const parentOrigin = params.get("origin") || window.location.origin;
-    
-    // Create adapter that communicates with the parent window
-    const adapter = createPostMessageAdapter({
-      sourceWindow: window,
-      sourceOrigin: parentOrigin,
-      targetWindow: window.parent,
-      targetOrigin: parentOrigin,
-    });
-    
-    // Mount the DevTools UI
-    mount({
-      adapter,
-      container: document.getElementById("devtools-container"),
-      hideHeader: params.get("hideHeader") === "true",
-    }).then(() => {
-      console.log("Iframe DevTools mounted!");
-      
-      // Notify parent that we're ready
-      window.parent.postMessage({ type: "DEVTOOLS_IFRAME_READY" }, parentOrigin);
-    });
-  </script>
-</body>
+		<script type="module">
+			import { mount } from "@preact/signals-devtools-ui";
+			import { createPostMessageAdapter } from "@preact/signals-devtools-adapter";
+
+			// Get the parent window origin from query params or default
+			const params = new URLSearchParams(window.location.search);
+			const parentOrigin = params.get("origin") || window.location.origin;
+
+			// Create adapter that communicates with the parent window
+			const adapter = createPostMessageAdapter({
+				sourceWindow: window,
+				sourceOrigin: parentOrigin,
+				targetWindow: window.parent,
+				targetOrigin: parentOrigin,
+			});
+
+			// Mount the DevTools UI
+			mount({
+				adapter,
+				container: document.getElementById("devtools-container"),
+				hideHeader: params.get("hideHeader") === "true",
+			}).then(() => {
+				console.log("Iframe DevTools mounted!");
+
+				// Notify parent that we're ready
+				window.parent.postMessage(
+					{ type: "DEVTOOLS_IFRAME_READY" },
+					parentOrigin
+				);
+			});
+		</script>
+	</body>
 </html>

--- a/packages/devtools-ui/src/styles.css
+++ b/packages/devtools-ui/src/styles.css
@@ -7,7 +7,8 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 13px;
   line-height: 1.4;
   color: #333;
@@ -54,10 +55,10 @@ body {
 }
 
 .divider {
-	width: 100%;
-	height: 2px;
-	background: #e0e0e0;
-	margin: 8px 0;
+  width: 100%;
+  height: 2px;
+  background: #e0e0e0;
+  margin: 8px 0;
 }
 
 .status-indicator {
@@ -86,8 +87,13 @@ body {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 .header-controls {
@@ -151,7 +157,7 @@ body {
   background: white;
   border: 1px solid #d0d0d0;
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   z-index: 1000;
   overflow-y: auto;
 }
@@ -315,15 +321,15 @@ body {
 }
 
 .component-name-header {
-	margin-right: 8px;
+  margin-right: 8px;
 }
 
 .component-list {
-	list-style: none;
-	display: flex;
-	padding: 0;
-	margin: 0;
-	font-family: monospace;
+  list-style: none;
+  display: flex;
+  padding: 0;
+  margin: 0;
+  font-family: monospace;
   background: #f8f9fa;
   padding: 4px 6px;
   border-radius: 3px;
@@ -439,8 +445,7 @@ body {
   position: relative;
   background:
     linear-gradient(90deg, #e5e7eb 1px, transparent 1px),
-    linear-gradient(180deg, #e5e7eb 1px, transparent 1px),
-    #f8fafc;
+    linear-gradient(180deg, #e5e7eb 1px, transparent 1px), #f8fafc;
   background-size: 40px 40px;
   overflow: hidden;
   user-select: none;
@@ -472,7 +477,7 @@ body {
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
   transition: all 0.15s ease;
 }
 
@@ -480,7 +485,7 @@ body {
 .graph-export-button:hover {
   background: #fff;
   border-color: #cbd5e1;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.12);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
   transform: translateY(-1px);
 }
 
@@ -502,7 +507,7 @@ body {
   background: white;
   border: 1px solid #e0e0e0;
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   overflow: hidden;
   min-width: 180px;
 }
@@ -542,21 +547,23 @@ body {
   font-size: 11px;
   font-weight: 600;
   font-family: monospace;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   min-width: 48px;
   text-align: center;
 }
 
 .graph-node {
   cursor: pointer;
-  transition: transform 0.15s ease, filter 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    filter 0.15s ease;
   stroke: #fff;
   stroke-width: 2.5;
-  filter: drop-shadow(0 3px 6px rgba(0,0,0,0.15));
+  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.15));
 }
 
 .graph-node-group.hovered .graph-node {
-  filter: brightness(1.15) drop-shadow(0 4px 12px rgba(0,0,0,0.25));
+  filter: brightness(1.15) drop-shadow(0 4px 12px rgba(0, 0, 0, 0.25));
   stroke-width: 3;
 }
 
@@ -580,7 +587,9 @@ body {
   stroke: #94a3b8;
   stroke-width: 2;
   fill: none;
-  transition: stroke 0.2s, stroke-width 0.2s;
+  transition:
+    stroke 0.2s,
+    stroke-width 0.2s;
 }
 
 .graph-link.highlighted {
@@ -595,7 +604,7 @@ body {
   font-size: 12px;
   font-weight: 600;
   pointer-events: none;
-  text-shadow: 0 1px 3px rgba(0,0,0,0.4);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
   letter-spacing: 0.2px;
 }
 
@@ -607,7 +616,7 @@ body {
   padding: 10px 14px;
   border-radius: 8px;
   font-size: 12px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
   z-index: 1000;
   pointer-events: none;
   transform: translateY(-50%);
@@ -679,7 +688,7 @@ body {
   border-radius: 8px;
   padding: 14px 16px;
   font-size: 12px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
 
 .legend-item {
@@ -697,7 +706,7 @@ body {
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.15);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 .component-boundary {
@@ -733,7 +742,7 @@ body {
   border-radius: 4px;
   font-size: 13px;
   font-weight: 500;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   z-index: 1000;
   animation: slideInFade 0.3s ease-out;
 }

--- a/packages/devtools-ui/vitest.config.mjs
+++ b/packages/devtools-ui/vitest.config.mjs
@@ -1,18 +1,18 @@
-import { defineConfig } from 'vitest/config';
-import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
 
 export default defineConfig({
 	optimizeDeps: {
 		include: ["preact/jsx-dev-runtime"],
 	},
 	test: {
-		include: ['./test/browser/**/*.test.tsx'],
+		include: ["./test/browser/**/*.test.tsx"],
 		browser: {
 			provider: playwright(),
 			enabled: true,
 			screenshotFailures: false,
 			headless: true,
-			instances: [{ browser: 'chromium' }]
-		}
-	}
+			instances: [{ browser: "chromium" }],
+		},
+	},
 });

--- a/scripts/mangle-plugin.mjs
+++ b/scripts/mangle-plugin.mjs
@@ -1,20 +1,20 @@
-import { readFileSync } from 'node:fs';
-import { transformAsync } from '@babel/core';
+import { readFileSync } from "node:fs";
+import { transformAsync } from "@babel/core";
 const rename = {};
-const mangle = readFileSync('./mangle.json', 'utf8');
+const mangle = readFileSync("./mangle.json", "utf8");
 const mangleJson = JSON.parse(mangle);
 for (let prop in mangleJson.props.props) {
 	let name = prop;
-	if (name[0] === '$') {
+	if (name[0] === "$") {
 		name = name.slice(1);
 	}
 
 	rename[name] = mangleJson.props.props[prop];
 }
 export const manglePlugin = {
-	name: 'rename-mangle-properties',
+	name: "rename-mangle-properties",
 	async transform(code, id) {
-		if (id.includes('node_modules')) {
+		if (id.includes("node_modules")) {
 			return null;
 		}
 
@@ -23,17 +23,17 @@ export const manglePlugin = {
 			configFile: false,
 			plugins: [
 				[
-					'babel-plugin-transform-rename-properties',
+					"babel-plugin-transform-rename-properties",
 					{
-						rename
-					}
-				]
-			]
+						rename,
+					},
+				],
+			],
 		});
 
 		return {
 			code: transformed.code,
-			map: transformed.map
+			map: transformed.map,
 		};
-	}
+	},
 };

--- a/scripts/transform-plugin.mjs
+++ b/scripts/transform-plugin.mjs
@@ -1,24 +1,31 @@
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-import { transformAsync } from '@babel/core';
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { transformAsync } from "@babel/core";
 
 export function createEsbuildPlugin() {
 	const pending = new Map();
 	const cache = new Map();
 	const __dirname = path.dirname(fileURLToPath(import.meta.url));
-	const projectRoot = path.resolve(__dirname, '..');
+	const projectRoot = path.resolve(__dirname, "..");
 
 	return {
-		name: 'react-transform',
-		enforce: 'pre',
+		name: "react-transform",
+		enforce: "pre",
 		async transform(code, id) {
-			if (id.includes("node_modules") ||
-					(!id.includes("packages/react/test/shared") &&
-					!id.includes("packages/react/runtime/test"))) {
+			if (
+				id.includes("node_modules") ||
+				(!id.includes("packages/react/test/shared") &&
+					!id.includes("packages/react/runtime/test"))
+			) {
 				return null;
 			}
 
-			if (!id.endsWith('.js') && !id.endsWith('.ts') && !id.endsWith('.jsx') && !id.endsWith('.tsx')) {
+			if (
+				!id.endsWith(".js") &&
+				!id.endsWith(".ts") &&
+				!id.endsWith(".jsx") &&
+				!id.endsWith(".tsx")
+			) {
 				return null;
 			}
 
@@ -54,7 +61,10 @@ export function createEsbuildPlugin() {
 					},
 				];
 
-				const transformPath = path.join(projectRoot, "packages/react-transform");
+				const transformPath = path.join(
+					projectRoot,
+					"packages/react-transform"
+				);
 				const signalsTransform = [
 					transformPath,
 					{
@@ -66,9 +76,7 @@ export function createEsbuildPlugin() {
 					filename: id,
 					sourceMaps: true,
 					presets: [ts, jsx],
-					plugins: [
-						signalsTransform,
-					],
+					plugins: [signalsTransform],
 				});
 				result = (tmp && tmp.code) || result;
 				map = (tmp && tmp.map) || map;
@@ -90,6 +98,6 @@ export function createEsbuildPlugin() {
 				code: result,
 				map,
 			};
-		}
+		},
 	};
 }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,74 +1,92 @@
-import { defineConfig } from 'vitest/config';
-import { playwright } from '@vitest/browser-playwright'
-import { manglePlugin } from './scripts/mangle-plugin.mjs';
-import { createEsbuildPlugin } from './scripts/transform-plugin.mjs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+import { manglePlugin } from "./scripts/mangle-plugin.mjs";
+import { createEsbuildPlugin } from "./scripts/transform-plugin.mjs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const MINIFY = process.env.MINIFY === "true";
-const COVERAGE = process.env.COVERAGE === 'true';
+const COVERAGE = process.env.COVERAGE === "true";
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
 	resolve: {
-		alias: MINIFY ? {
-			'@preact/signals-core': path.join(
-				dirname, './packages/core/dist/signals-core.module.js'
-			),
-			'@preact/signals/utils': path.join(
-				dirname, './packages/preact/utils/dist/utils.module.js'
-			),
-			'@preact/signals': path.join(
-				dirname, './packages/preact/dist/signals.module.js'
-			),
-			'@preact/signals-react/runtime': path.join(
-				dirname, './packages/react/runtime/dist/runtime.module.js'
-			),
-			'@preact/signals-react/utils': path.join(
-				dirname, './packages/react/utils/dist/utils.module.js'
-			),
-			'@preact/signals-react': path.join(
-				dirname, './packages/react/dist/signals.module.js'
-			),
-			'@preact/signals-react-runtime': path.join(
-				dirname, './packages/react/runtime/dist/runtime.module.js'
-			),
-			'@preact/signals-react-utils': path.join(
-				dirname, './packages/react/utils/dist/utils.module.js'
-			),
-			'@preact/signals-react-transform': path.join(
-				dirname ,'./packages/react-transform/dist/signals-transform.mjs'
-			),
-			'@preact/signals-utils': path.join(
-				dirname, './packages/preact/utils/dist/utils.module.js'
-			),
-		} : {}
+		alias: MINIFY
+			? {
+					"@preact/signals-core": path.join(
+						dirname,
+						"./packages/core/dist/signals-core.module.js"
+					),
+					"@preact/signals/utils": path.join(
+						dirname,
+						"./packages/preact/utils/dist/utils.module.js"
+					),
+					"@preact/signals": path.join(
+						dirname,
+						"./packages/preact/dist/signals.module.js"
+					),
+					"@preact/signals-react/runtime": path.join(
+						dirname,
+						"./packages/react/runtime/dist/runtime.module.js"
+					),
+					"@preact/signals-react/utils": path.join(
+						dirname,
+						"./packages/react/utils/dist/utils.module.js"
+					),
+					"@preact/signals-react": path.join(
+						dirname,
+						"./packages/react/dist/signals.module.js"
+					),
+					"@preact/signals-react-runtime": path.join(
+						dirname,
+						"./packages/react/runtime/dist/runtime.module.js"
+					),
+					"@preact/signals-react-utils": path.join(
+						dirname,
+						"./packages/react/utils/dist/utils.module.js"
+					),
+					"@preact/signals-react-transform": path.join(
+						dirname,
+						"./packages/react-transform/dist/signals-transform.mjs"
+					),
+					"@preact/signals-utils": path.join(
+						dirname,
+						"./packages/preact/utils/dist/utils.module.js"
+					),
+				}
+			: {},
 	},
 	plugins: [
 		manglePlugin,
 		createEsbuildPlugin(),
 		{
-			name: 'react-create-root-legacy-fallback',
-			enforce: 'pre',
+			name: "react-create-root-legacy-fallback",
+			enforce: "pre",
 			async resolveId(source, importer) {
-				if (!importer.startsWith(path.join(dirname, 'packages/react/'))) {
+				if (!importer.startsWith(path.join(dirname, "packages/react/"))) {
 					return null;
 				}
 				const resolved = await this.resolve(source, importer);
-				if (!resolved || resolved.id !== path.join(dirname, 'packages/react/test/shared/create-root.ts')) {
+				if (
+					!resolved ||
+					resolved.id !==
+						path.join(dirname, "packages/react/test/shared/create-root.ts")
+				) {
 					return null;
 				}
-				const hasClient = await this.resolve('react-dom/client', importer);
+				const hasClient = await this.resolve("react-dom/client", importer);
 				if (!hasClient) {
-					return this.resolve(path.join(
-						dirname,
-						'packages/react/test/shared/create-root-legacy.ts'
-					), importer);
+					return this.resolve(
+						path.join(
+							dirname,
+							"packages/react/test/shared/create-root-legacy.ts"
+						),
+						importer
+					);
 				}
 				return null;
 			},
 		},
-
 	],
 	// TODO (43081j): stop faking node globals and sort out the transform
 	// tests. Either run them in node, or somehow run babel in node but the
@@ -76,50 +94,48 @@ export default defineConfig({
 	define: {
 		IS_REACT_ACT_ENVIRONMENT: true,
 		process: {
-			env: {}
-		}
+			env: {},
+		},
 	},
 	test: {
 		coverage: {
 			enabled: COVERAGE,
 			include: [
-				'packages/**/dist/**/*.js',
-				'packages/react-transform/src/**/*.ts'
+				"packages/**/dist/**/*.js",
+				"packages/react-transform/src/**/*.ts",
 			],
-			provider: 'v8',
-			reporter: ['text-summary', 'lcov'],
-			reportsDirectory: './coverage'
+			provider: "v8",
+			reporter: ["text-summary", "lcov"],
+			reportsDirectory: "./coverage",
 		},
 		projects: [
 			{
 				extends: true,
 				test: {
-					include: [
-						'./packages/**/test/**/*.test.tsx',
-					],
+					include: ["./packages/**/test/**/*.test.tsx"],
 					exclude: [
-						'./packages/**/test/browser/**/*.test.tsx',
-						'**/node_modules/**'
-					]
-				}
+						"./packages/**/test/browser/**/*.test.tsx",
+						"**/node_modules/**",
+					],
+				},
 			},
 			{
 				extends: true,
 				test: {
-					include: ['./packages/**/test/browser/**/*.test.tsx'],
+					include: ["./packages/**/test/browser/**/*.test.tsx"],
 					exclude: [
-						'./packages/devtools-ui/test/browser/**/*.test.tsx',
-						'**/node_modules/**'
+						"./packages/devtools-ui/test/browser/**/*.test.tsx",
+						"**/node_modules/**",
 					],
 					browser: {
 						provider: playwright(),
 						enabled: true,
 						screenshotFailures: false,
 						headless: true,
-						instances: [{ browser: 'chromium' }]
-					}
-				}
-			}
-		]
-	}
+						instances: [{ browser: "chromium" }],
+					},
+				},
+			},
+		],
+	},
 });


### PR DESCRIPTION
Recently when modifying some files I discovered our configured formatting rules were inconsistently being applied. This reformats the repo and allows prettier to figure out what files to format, including some missing files.

Prettier also now already ignores anything in .gitignore so I just added `pnpm-lock.yaml` file to be additionally ignored since it is checked in but shouldn't be formatted.

Most of the updates are just fixing spaces to tabs or the opposite to match what our `.editorconfig` file specifies.