### PR TITLE
Fix scu bail

### DIFF
--- a/.changeset/curvy-ducks-remain.md
+++ b/.changeset/curvy-ducks-remain.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Revert https://github.com/preactjs/signals/pull/728 - this might entail work in prefresh but currently the presence of `uesState` makes every sCU bail

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -1,5 +1,5 @@
 import { options, Component, isValidElement, Fragment } from "preact";
-import { useRef, useMemo, useEffect, useState } from "preact/hooks";
+import { useRef, useMemo, useEffect } from "preact/hooks";
 import {
 	signal,
 	computed,
@@ -413,9 +413,10 @@ Component.prototype.shouldComponentUpdate = function (
 export function useSignal<T>(value: T, options?: SignalOptions<T>): Signal<T>;
 export function useSignal<T = undefined>(): Signal<T | undefined>;
 export function useSignal<T>(value?: T, options?: SignalOptions<T>) {
-	return useState(() =>
-		signal<T | undefined>(value, options as SignalOptions)
-	)[0];
+	return useMemo(
+		() => signal<T | undefined>(value, options as SignalOptions),
+		[]
+	);
 }
 
 export function useComputed<T>(compute: () => T, options?: SignalOptions<T>) {


### PR DESCRIPTION
Due to us leveraging useState the shouldComponentUpdate override isn't effective