### PR TITLE
With our patched rename-properties plugin we surfaced a name collission

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -36,7 +36,7 @@
       "$_debugId": "a",
       "$_watched": "W",
       "$_unwatched": "Z",
-      "$_source": "S",
+      "$_source": "q",
       "$_prevSource": "p",
       "$_nextSource": "n",
       "$_target": "t",


### PR DESCRIPTION
Not sure how this worked before we mapped both _source and _subscribe to S, I chose to re-map _subscribe because the only user of that is the debug package. I am mildly concerned how this hasn't surfaced before.

My thinking is that somehow the terser mangling differentiates in this