### PR TITLE
ci: Fix 'strip-hash' regex for compressed-size

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           pattern: "{packages/*/dist/!(*.module|*.min).{js,mjs},docs/dist/**/*.{js,css}}"
           build-script: "ci:build"
-          strip-hash: "[.-](\\w{8,9})\\.(?:js|css)$"
+          strip-hash: "[.-](.{8})\\.(?:js|css)$"


### PR DESCRIPTION
I've noticed this in a few PRs now, thought I'd correct it.

Vite's hash isn't just word characters but also includes hyphens, and is always 8 characters long.