### PR TITLE
fix(core): avoid requiring ESNext.Disposable for model types

### DIFF
--- a/.changeset/tiny-phones-trade.md
+++ b/.changeset/tiny-phones-trade.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Avoid hard-requiring `ESNext.Disposable` in consumer tsconfigs for `Model` and `effect()` types.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -839,6 +839,16 @@ type EffectFn =
 	| ((this: { dispose: () => void }) => void | (() => void))
 	| (() => void | (() => void));
 
+// Avoid hard-requiring the ESNext.Disposable lib in consuming tsconfigs.
+// When `Symbol.dispose` is available, this becomes a symbol-keyed disposer type.
+type DisposeSymbol = typeof Symbol extends { readonly dispose: infer TDispose }
+	? TDispose
+	: never;
+type DisposableLike = {
+	[K in DisposeSymbol & PropertyKey]: () => void;
+};
+type DisposeFn = (() => void) & DisposableLike;
+
 /**
  * The base class for reactive effects.
  */
@@ -942,7 +952,7 @@ Effect.prototype.dispose = function () {
  * @param fn The effect callback.
  * @returns A function for disposing the effect.
  */
-function effect(fn: EffectFn, options?: EffectOptions): () => void {
+function effect(fn: EffectFn, options?: EffectOptions): DisposeFn {
 	const effect = new Effect(fn, options);
 	try {
 		effect._callback();
@@ -954,7 +964,7 @@ function effect(fn: EffectFn, options?: EffectOptions): () => void {
 	// because bound functions seem to be just as fast and take up a lot less memory.
 	const dispose = effect._dispose.bind(effect);
 	(dispose as any)[Symbol.dispose] = dispose;
-	return dispose as any;
+	return dispose as DisposeFn;
 }
 
 //#endregion Effect
@@ -984,7 +994,7 @@ type ValidateModel<TModel> = {
 				: `Property ${Key extends string ? `'${Key}' ` : ""}is not a Signal, Action, or an object that contains only Signals and Actions.`;
 };
 
-export type Model<TModel> = ValidateModel<TModel> & Disposable;
+export type Model<TModel> = ValidateModel<TModel> & DisposableLike;
 
 export type ModelFactory<TModel, TFactoryArgs extends any[] = []> = (
 	...args: TFactoryArgs

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -794,7 +794,6 @@ describe("effect()", () => {
 		const a = signal(0);
 		const spy = vi.fn();
 		{
-			// @ts-expect-error This is a test for the dispose API
 			using _dispose = effect(() => {
 				a.value;
 				return spy;


### PR DESCRIPTION
## Summary
- replace the direct `Disposable` reference used by `Model` and `effect()` with a conditional disposer type
- preserve `[Symbol.dispose]` typing when a consumer enables `ESNext.Disposable`, without breaking model type resolution when they do not