### PR TITLE
chore: update the devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,16 @@
-FROM node:18-alpine
-RUN npm --global install pnpm
-RUN apk add --no-cache \
+FROM node:24
+RUN corepack enable
+RUN apt-get update && apt-get install -y --no-install-recommends \
   chromium \
-  git \
-  openssh \
-  ripgrep
+  ripgrep \
+  && rm -rf /var/lib/apt/lists/*
+
 USER node
-ENV CHROME_BIN=chromium-browser
+# Create directories before volumes are mounted to them, so that the
+# ownership will be correct.
+RUN mkdir ~/.vscode-server
+# Allow npm install packages with --global without sudo.
+RUN mkdir ~/.npm-global \
+  && npm config set -L user prefix ~/.npm-global
+# Add typical tool binary locations to PATH.
+ENV PATH="$PATH:/home/node/.local/bin:/home/node/.npm-global/bin"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,15 +3,35 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
+  "init": true,
+  "remoteUser": "node",
+  "mounts": [
+    // Persist the user profile across rebuilds.
+    {
+      "source": "profile-${devcontainerId}",
+      "target": "/home/node",
+      "type": "volume"
+    },
+    {
+      // An anonymous volume that gets destroyed on rebuild,
+      // which allows VS Code to reinstall extensions and dotfiles.
+      "target": "/home/node/.vscode-server",
+      "type": "volume"
+    }
+  ],
   "customizations": {
     "vscode": {
       "settings": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.codeActionsOnSave": {
+          "source.fixAll.oxc": "always"
+        },
+        "editor.defaultFormatter": "oxc.oxc-vscode",
+        "editor.formatOnSave": true,
+        "editor.formatOnSaveMode": "file",
         "explorer.excludeGitIgnore": true
       },
-      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+      "extensions": ["oxc.oxc-vscode"]
     }
   },
-  "postCreateCommand": "pnpm i",
-  "remoteUser": "node"
+  "postCreateCommand": "corepack install && pnpm install --frozen-lockfile"
 }


### PR DESCRIPTION
This pull request updates the current devcontainer setup in the following ways:

 * Update the base image Node.js version to v24 from v18.

 * Switch the base image from the Alpine based `node:18-alpine` to the Debian-based `node:24`.

 * Switches from manual pnpm install to corepack to use the version in package.json's `packageManager` field.

 * Replaces ESLint + Prettier VS Code extensions with oxc-vscode for linting and formatting.

 * Adds persistent volume mounts so the user profile and npm globals survive container rebuilds. Admittedly, it would've been cleaner to mount only specific subdirectories of `/home/node`, but people use different coding agents etc. that tend to use their own directories. Maybe an enhancement for the future?

 * Configures a user-local `~/.npm-global` prefix so global npm installs don't require sudo.

 * Adds `~/.local/bin` and `~/.npm-global/bin` to `PATH`, making it easier to use tools.

 * Sets updates postCreateCommand to use `pnpm install --frozen-lockfile`.