### PR TITLE
Fix live-signal updating other components from render

### DIFF
--- a/.changeset/angry-donuts-repeat.md
+++ b/.changeset/angry-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-react": patch
+---
+
+Update `live-signal` within an effect to avoid the `cannot update component while rendering other component` error in react.

--- a/packages/react/utils/src/index.tsx
+++ b/packages/react/utils/src/index.tsx
@@ -1,7 +1,14 @@
 import { ReadonlySignal, Signal } from "@preact/signals-core";
 import { useSignal } from "@preact/signals-react";
 import { useSignals } from "@preact/signals-react/runtime";
-import { Fragment, createElement, useMemo, ReactNode } from "react";
+import {
+	Fragment,
+	createElement,
+	useMemo,
+	ReactNode,
+	useLayoutEffect,
+	useEffect,
+} from "react";
 
 interface ShowProps<T = boolean> {
 	when: Signal<T> | ReadonlySignal<T> | (() => T);
@@ -73,9 +80,14 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 
 For.displayName = "For";
 
+const useIsomorphicLayoutEffect =
+	typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
 export function useLiveSignal<T>(value: T): Signal<T> {
 	const s = useSignal(value);
-	if (s.peek() !== value) s.value = value;
+	useIsomorphicLayoutEffect(() => {
+		if (s.peek() !== value) s.value = value;
+	}, [value]);
 	return s;
 }
 

--- a/packages/react/utils/test/browser/index.test.tsx
+++ b/packages/react/utils/test/browser/index.test.tsx
@@ -1,13 +1,24 @@
-import { For, Show, useSignalRef } from "@preact/signals-react/utils";
+import {
+	For,
+	Show,
+	useSignalRef,
+	useLiveSignal,
+} from "@preact/signals-react/utils";
 import {
 	act,
 	checkHangingAct,
 	createRoot,
 	Root,
 } from "../../../test/shared/utils";
-import { computed, signal } from "@preact/signals-react";
+import {
+	computed,
+	Signal,
+	signal,
+	useSignalEffect,
+} from "@preact/signals-react";
 import { createElement } from "react";
-import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+import { useSignals } from "@preact/signals-react/runtime";
 
 describe("@preact/signals-react-utils", () => {
 	let scratch: HTMLDivElement;
@@ -26,6 +37,66 @@ describe("@preact/signals-react-utils", () => {
 		checkHangingAct();
 		await act(() => root.unmount());
 		scratch.remove();
+	});
+
+	describe("useLiveSignal", () => {
+		it("should work", async () => {
+			const logs: string[] = [];
+			const App = (props: { count: number }) => {
+				useSignals();
+				const count = useLiveSignal(props.count);
+
+				useSignalEffect(() => {
+					logs.push("Count is " + count.value);
+				});
+
+				return <p>{count.value}</p>;
+			};
+
+			await act(() => {
+				render(<App count={0} />);
+			});
+			expect(scratch.innerHTML).to.eq("<p>0</p>");
+			expect(logs).to.deep.eq(["Count is 0"]);
+
+			await act(() => {
+				render(<App count={1} />);
+			});
+			expect(scratch.innerHTML).to.eq("<p>1</p>");
+			expect(logs).to.deep.eq(["Count is 0", "Count is 1"]);
+		});
+
+		it("Should not cause a react error when used in a component that re-renders", async () => {
+			const consoleError = vi.spyOn(console, "error");
+			const consoleWarn = vi.spyOn(console, "warn");
+
+			const Counter = (props: { count: Signal<number> }) => {
+				useSignals();
+				return <p>{props.count.value}</p>;
+			};
+
+			const App = (props: { count: number }) => {
+				const count = useLiveSignal(props.count);
+				return (
+					<div>
+						<Counter count={count} />
+						<Counter count={count} />
+					</div>
+				);
+			};
+
+			await act(async () => {
+				await render(<App count={0} />);
+			});
+			expect(scratch.innerHTML).to.eq("<div><p>0</p><p>0</p></div>");
+
+			await act(async () => {
+				await render(<App count={1} />);
+			});
+			expect(scratch.innerHTML).to.eq("<div><p>1</p><p>1</p></div>");
+			expect(consoleError).toBeCalledTimes(0);
+			expect(consoleWarn).toBeCalledTimes(0);
+		});
 	});
 
 	describe("<Show />", () => {


### PR DESCRIPTION
The famous `can't update component x from the render of component y` is back, and it's because we are indeed updating a signal during render :D