### PR TITLE
Fix devtools graph scaling

### DIFF
--- a/.changeset/fast-canvas-pan.md
+++ b/.changeset/fast-canvas-pan.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-devtools-ui": patch
+---
+
+Improve dependency graph fit and panning on large canvases.

--- a/packages/devtools-ui/src/components/Graph.tsx
+++ b/packages/devtools-ui/src/components/Graph.tsx
@@ -6,9 +6,97 @@ import { getContext } from "../context";
 
 interface GraphRenderData extends GraphData {
 	nodeLookup: Map<string, GraphNode>;
-	svgWidth: number;
-	svgHeight: number;
 }
+
+const DEFAULT_VIEWPORT_SIZE = { width: 800, height: 600 };
+const FIT_PADDING = 80;
+const MIN_ZOOM = 0.001;
+const MAX_ZOOM = 5;
+
+interface Point {
+	x: number;
+	y: number;
+}
+
+interface ViewportSize {
+	width: number;
+	height: number;
+}
+
+interface GraphBounds {
+	minX: number;
+	minY: number;
+	maxX: number;
+	maxY: number;
+	width: number;
+	height: number;
+}
+
+const getNodeRadius = (node: GraphNode) => {
+	const baseRadius = 30;
+	const charWidth = 6.5;
+	const padding = 16;
+	const textWidth = node.name.length * charWidth + padding;
+	return Math.max(baseRadius, Math.min(textWidth / 2, 70));
+};
+
+export const calculateGraphBounds = (
+	nodes: GraphNode[]
+): GraphBounds | null => {
+	if (nodes.length === 0) return null;
+
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+
+	for (const node of nodes) {
+		const radius = getNodeRadius(node) + 24;
+		minX = Math.min(minX, node.x - radius);
+		minY = Math.min(minY, node.y - radius);
+		maxX = Math.max(maxX, node.x + radius);
+		maxY = Math.max(maxY, node.y + radius);
+	}
+
+	return {
+		minX,
+		minY,
+		maxX,
+		maxY,
+		width: Math.max(1, maxX - minX),
+		height: Math.max(1, maxY - minY),
+	};
+};
+
+export const calculateFitTransform = (
+	bounds: GraphBounds | null,
+	viewport: ViewportSize,
+	padding = FIT_PADDING
+) => {
+	if (!bounds) return { offset: { x: 0, y: 0 }, zoom: 1 };
+
+	const viewportWidth = Math.max(1, viewport.width);
+	const viewportHeight = Math.max(1, viewport.height);
+	const availableWidth = Math.max(1, viewportWidth - padding * 2);
+	const availableHeight = Math.max(1, viewportHeight - padding * 2);
+	const nextZoom = Math.min(
+		MAX_ZOOM,
+		Math.max(
+			MIN_ZOOM,
+			Math.min(availableWidth / bounds.width, availableHeight / bounds.height)
+		)
+	);
+
+	return {
+		offset: {
+			x: (viewportWidth - bounds.width * nextZoom) / 2 - bounds.minX * nextZoom,
+			y:
+				(viewportHeight - bounds.height * nextZoom) / 2 -
+				bounds.minY * nextZoom,
+		},
+		zoom: nextZoom,
+	};
+};
 
 const copyToClipboard = (text: string) => {
 	const copyEl = document.createElement("textarea");
@@ -38,6 +126,10 @@ export function GraphVisualization() {
 	const toastText = useSignal<string>();
 	const hoveredNode = useSignal<GraphNode | null>(null);
 	const tooltipPos = useSignal({ x: 0, y: 0 });
+	const viewportSize = useSignal<ViewportSize>(DEFAULT_VIEWPORT_SIZE);
+	const hasUserAdjustedView = useSignal(false);
+	const pendingPanOffset = useRef<Point | null>(null);
+	const panAnimationFrame = useRef<number | null>(null);
 
 	useEffect(() => {
 		const handleClickOutside = (e: MouseEvent) => {
@@ -53,6 +145,51 @@ export function GraphVisualization() {
 		document.addEventListener("mousedown", handleClickOutside);
 		return () => {
 			document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, []);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		const updateViewportSize = () => {
+			const rect = container.getBoundingClientRect();
+			const width = Math.max(
+				1,
+				rect.width || container.clientWidth || DEFAULT_VIEWPORT_SIZE.width
+			);
+			const height = Math.max(
+				1,
+				rect.height || container.clientHeight || DEFAULT_VIEWPORT_SIZE.height
+			);
+			const current = viewportSize.value;
+
+			if (current.width !== width || current.height !== height) {
+				viewportSize.value = { width, height };
+			}
+		};
+
+		updateViewportSize();
+
+		let resizeObserver: ResizeObserver | undefined;
+		if (typeof ResizeObserver !== "undefined") {
+			resizeObserver = new ResizeObserver(updateViewportSize);
+			resizeObserver.observe(container);
+		}
+
+		window.addEventListener("resize", updateViewportSize);
+
+		return () => {
+			resizeObserver?.disconnect();
+			window.removeEventListener("resize", updateViewportSize);
+		};
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (panAnimationFrame.current !== null) {
+				cancelAnimationFrame(panAnimationFrame.current);
+			}
 		};
 	}, []);
 
@@ -210,8 +347,6 @@ export function GraphVisualization() {
 				nodes: [],
 				links: [],
 				nodeLookup: new Map(),
-				svgWidth: 800,
-				svgHeight: 600,
 			};
 		}
 
@@ -301,57 +436,135 @@ export function GraphVisualization() {
 		// Minimize edge crossings
 		minimizeCrossings(nodesByLayer, allLinks);
 
-		// Layout nodes with proper spacing
+		// Layout nodes with proper spacing. Keep every layer within positive graph
+		// coordinates so tall layers are pannable instead of being clipped above 0.
 		const nodeSpacing = 120;
 		const layerSpacing = 250;
-		const startX = 100;
-		const startY = 80;
+		const graphPadding = 100;
+		const maxLayerNodeCount = Math.max(
+			1,
+			...Array.from(nodesByLayer.values()).map(layerNodes => layerNodes.length)
+		);
+		const graphHeight =
+			graphPadding * 2 + Math.max(0, maxLayerNodeCount - 1) * nodeSpacing;
 
 		nodesByLayer.forEach((layerNodes, layer) => {
 			const layerHeight = (layerNodes.length - 1) * nodeSpacing;
-			const layerStartY = startY - layerHeight / 2;
+			const layerStartY =
+				graphPadding + (graphHeight - graphPadding * 2 - layerHeight) / 2;
 
 			layerNodes.forEach((node, index) => {
-				node.x = startX + layer * layerSpacing;
-				node.y = layerStartY + index * nodeSpacing + nodesByLayer.size * 50;
+				node.x = graphPadding + layer * layerSpacing;
+				node.y = layerStartY + index * nodeSpacing;
 			});
 		});
 
 		const graphNodes = Array.from(nodes.values());
 		const nodeLookup = new Map(graphNodes.map(node => [node.id, node]));
-		const svgWidth = graphNodes.reduce(
-			(maxWidth, node) => Math.max(maxWidth, node.x + 100),
-			800
-		);
-		const svgHeight = graphNodes.reduce(
-			(maxHeight, node) => Math.max(maxHeight, node.y + 100),
-			600
-		);
-
 		return {
 			nodes: graphNodes,
 			links: allLinks,
 			nodeLookup,
-			svgWidth,
-			svgHeight,
 		};
 	});
 
+	const graphBounds = useComputed(() =>
+		calculateGraphBounds(graphData.value.nodes)
+	);
+	const layoutSignature = graphBounds.value
+		? [
+				graphData.value.nodes.length,
+				graphData.value.links.length,
+				Math.round(graphBounds.value.minX),
+				Math.round(graphBounds.value.minY),
+				Math.round(graphBounds.value.maxX),
+				Math.round(graphBounds.value.maxY),
+			].join(":")
+		: "empty";
+
+	const applyViewTransform = (next: { offset: Point; zoom: number }) => {
+		if (Math.abs(zoom.value - next.zoom) > 0.001) {
+			zoom.value = next.zoom;
+		}
+
+		if (
+			Math.abs(panOffset.value.x - next.offset.x) > 0.5 ||
+			Math.abs(panOffset.value.y - next.offset.y) > 0.5
+		) {
+			panOffset.value = next.offset;
+		}
+	};
+
+	const fitView = () => {
+		applyViewTransform(
+			calculateFitTransform(graphBounds.value, viewportSize.value)
+		);
+	};
+
+	useEffect(() => {
+		if (!hasUserAdjustedView.value) {
+			fitView();
+		}
+	}, [layoutSignature, viewportSize.value.width, viewportSize.value.height]);
+
+	const getSvgPoint = (e: MouseEvent | WheelEvent): Point | null => {
+		const svg = svgRef.current;
+		if (!svg) return null;
+
+		const ctm = svg.getScreenCTM();
+		if (ctm) {
+			const point = svg.createSVGPoint();
+			point.x = e.clientX;
+			point.y = e.clientY;
+			const svgPoint = point.matrixTransform(ctm.inverse());
+			return { x: svgPoint.x, y: svgPoint.y };
+		}
+
+		const rect = svg.getBoundingClientRect();
+		if (!rect.width || !rect.height) return null;
+
+		return {
+			x: ((e.clientX - rect.left) / rect.width) * viewportSize.value.width,
+			y: ((e.clientY - rect.top) / rect.height) * viewportSize.value.height,
+		};
+	};
+
+	const schedulePanOffset = (nextOffset: Point) => {
+		pendingPanOffset.current = nextOffset;
+
+		if (panAnimationFrame.current !== null) return;
+
+		panAnimationFrame.current = requestAnimationFrame(() => {
+			panAnimationFrame.current = null;
+			if (pendingPanOffset.current) {
+				panOffset.value = pendingPanOffset.current;
+				pendingPanOffset.current = null;
+			}
+		});
+	};
+
 	const handleMouseDown = (e: MouseEvent) => {
 		if (e.button !== 0) return;
+		const point = getSvgPoint(e);
+		if (!point) return;
+
+		hasUserAdjustedView.value = true;
 		isPanning.value = true;
 		startPan.value = {
-			x: e.clientX - panOffset.value.x,
-			y: e.clientY - panOffset.value.y,
+			x: point.x - panOffset.value.x,
+			y: point.y - panOffset.value.y,
 		};
 	};
 
 	const handleMouseMove = (e: MouseEvent) => {
 		if (!isPanning.value) return;
-		panOffset.value = {
-			x: e.clientX - startPan.value.x,
-			y: e.clientY - startPan.value.y,
-		};
+		const point = getSvgPoint(e);
+		if (!point) return;
+
+		schedulePanOffset({
+			x: point.x - startPan.value.x,
+			y: point.y - startPan.value.y,
+		});
 	};
 
 	const handleMouseUp = () => {
@@ -361,28 +574,32 @@ export function GraphVisualization() {
 	const handleWheel = (e: WheelEvent) => {
 		e.preventDefault();
 
-		const container = containerRef.current;
-		if (!container) return;
+		const point = getSvgPoint(e);
+		if (!point) return;
 
-		const rect = container.getBoundingClientRect();
-		const mouseX = e.clientX - rect.left;
-		const mouseY = e.clientY - rect.top;
+		hasUserAdjustedView.value = true;
 
-		const delta = e.deltaY > 0 ? 0.96 : 1.04;
-		const newZoom = Math.min(Math.max(0.1, zoom.value * delta), 5);
+		const normalizedDeltaY =
+			e.deltaMode === WheelEvent.DOM_DELTA_LINE
+				? e.deltaY * 16
+				: e.deltaMode === WheelEvent.DOM_DELTA_PAGE
+					? e.deltaY * viewportSize.value.height
+					: e.deltaY;
+		const delta = Math.exp(-normalizedDeltaY * 0.0015);
+		const newZoom = Math.min(Math.max(MIN_ZOOM, zoom.value * delta), MAX_ZOOM);
 
 		const zoomRatio = newZoom / zoom.value;
 		panOffset.value = {
-			x: mouseX - (mouseX - panOffset.value.x) * zoomRatio,
-			y: mouseY - (mouseY - panOffset.value.y) * zoomRatio,
+			x: point.x - (point.x - panOffset.value.x) * zoomRatio,
+			y: point.y - (point.y - panOffset.value.y) * zoomRatio,
 		};
 
 		zoom.value = newZoom;
 	};
 
 	const resetView = () => {
-		panOffset.value = { x: 0, y: 0 };
-		zoom.value = 1;
+		hasUserAdjustedView.value = false;
+		fitView();
 	};
 
 	const toggleExportMenu = () => {
@@ -391,14 +608,6 @@ export function GraphVisualization() {
 
 	const mermaidIdPattern = /[^a-zA-Z0-9]/g;
 	const computeMermaidId = (id: string) => id.replace(mermaidIdPattern, "_");
-
-	const getNodeRadius = (node: GraphNode) => {
-		const baseRadius = 30;
-		const charWidth = 6.5;
-		const padding = 16;
-		const textWidth = node.name.length * charWidth + padding;
-		return Math.max(baseRadius, Math.min(textWidth / 2, 70));
-	};
 
 	const handleNodeMouseEnter = (node: GraphNode, e: MouseEvent) => {
 		hoveredNode.value = node;
@@ -490,6 +699,9 @@ export function GraphVisualization() {
 		);
 	}
 
+	const viewBoxWidth = Math.max(1, viewportSize.value.width);
+	const viewBoxHeight = Math.max(1, viewportSize.value.height);
+
 	return (
 		<div className="graph-container">
 			<div
@@ -505,9 +717,10 @@ export function GraphVisualization() {
 				<svg
 					ref={svgRef}
 					className="graph-svg"
-					width={graphData.value.svgWidth}
-					height={graphData.value.svgHeight}
-					viewBox={`0 0 ${graphData.value.svgWidth} ${graphData.value.svgHeight}`}
+					width="100%"
+					height="100%"
+					viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
+					preserveAspectRatio="none"
 				>
 					<defs>
 						<marker
@@ -600,9 +813,9 @@ export function GraphVisualization() {
 					<button
 						className="graph-reset-button"
 						onClick={resetView}
-						title="Reset view"
+						title="Fit graph to viewport"
 					>
-						⟲ Reset View
+						⟲ Fit View
 					</button>
 
 					<div ref={exportMenuRef} className="graph-export-container">

--- a/packages/devtools-ui/src/styles.css
+++ b/packages/devtools-ui/src/styles.css
@@ -511,6 +511,7 @@ body {
 /* Main Content */
 .main-content {
   flex: 1;
+  min-height: 0;
   overflow: hidden;
   position: relative;
   display: flex;
@@ -520,6 +521,7 @@ body {
 
 .tab-content {
   flex: 1;
+  min-height: 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -646,7 +648,8 @@ body {
   position: relative;
   color: var(--text-primary);
   background: var(--bg-primary);
-  min-height: 100%;
+  height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -732,12 +735,14 @@ body {
 /* Graph Visualization */
 .graph-container {
   height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
 
 .graph-content {
   flex: 1;
+  min-height: 0;
   position: relative;
   background:
     linear-gradient(90deg, var(--graph-grid) 1px, transparent 1px),
@@ -746,12 +751,14 @@ body {
   background-size: 40px 40px;
   overflow: hidden;
   user-select: none;
+  touch-action: none;
 }
 
 .graph-svg {
+  display: block;
   width: 100%;
   height: 100%;
-  min-height: 500px;
+  min-height: 0;
 }
 
 .graph-controls {

--- a/packages/devtools-ui/test/browser/index.test.tsx
+++ b/packages/devtools-ui/test/browser/index.test.tsx
@@ -16,7 +16,11 @@ import { SettingsPanel } from "../../src/components/SettingsPanel";
 import { StatusIndicator } from "../../src/components/StatusIndicator";
 import { UpdateItem } from "../../src/components/UpdateItem";
 import { UpdatesContainer } from "../../src/components/UpdatesContainer";
-import { GraphVisualization } from "../../src/components/Graph";
+import {
+	GraphVisualization,
+	calculateFitTransform,
+	calculateGraphBounds,
+} from "../../src/components/Graph";
 import type {
 	DevToolsAdapter,
 	Settings,
@@ -958,6 +962,45 @@ describe("@preact/signals-devtools-ui", () => {
 
 			context.settingsStore.toggleShowDisposedSignals();
 			expect(context.settingsStore.showDisposedSignals.value).to.be.true;
+		});
+	});
+
+	describe("GraphVisualization viewport helpers", () => {
+		it("should calculate bounds that include node radii", () => {
+			const bounds = calculateGraphBounds([
+				{
+					id: "signal-a",
+					name: "signalA",
+					type: "signal",
+					x: 100,
+					y: 100,
+					depth: 0,
+				},
+			]);
+
+			expect(bounds).to.not.be.null;
+			expect(bounds!.minX).to.be.lessThan(100);
+			expect(bounds!.minY).to.be.lessThan(100);
+			expect(bounds!.maxX).to.be.greaterThan(100);
+			expect(bounds!.maxY).to.be.greaterThan(100);
+		});
+
+		it("should fit tall graphs into short wide viewports", () => {
+			const transform = calculateFitTransform(
+				{
+					minX: 0,
+					minY: 0,
+					maxX: 600,
+					maxY: 3000,
+					width: 600,
+					height: 3000,
+				},
+				{ width: 1200, height: 400 }
+			);
+
+			expect(transform.zoom).to.be.lessThan(1);
+			expect(3000 * transform.zoom).to.be.at.most(400);
+			expect(transform.offset.x).to.be.greaterThan(0);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- fit dependency graphs to the visible viewport
- keep tall graphs pannable and speed up panning on large canvases