### PR TITLE
Add environment-gated publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
@@ -72,7 +71,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,10 @@ on:
 jobs:
   release:
     name: Release
+    outputs:
+      has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
       contents: write
-      id-token: write
       issues: read
       pull-requests: write
     runs-on: ubuntu-latest
@@ -38,9 +39,51 @@ jobs:
         run: pnpm install
 
       - name: Create Release Pull Request
+        id: changesets
         uses: changesets/action@v1.5.3
         with:
           version: pnpm run version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    needs: release
+    if: needs.release.outputs.has_changesets == 'false'
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/org/preact
+    permissions:
+      contents: write
+      id-token: write
+      issues: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.7.0
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@11.11
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Publish packages
+        uses: changesets/action@v1.5.3
+        with:
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@
 
 This guide is intended for core team members that have the necessary rights to merge pull requests to the `main` branch.
 
-To create a new release, merge "Version Packages" PR opened by the changesets-action. The release workflow will automatically create new releases for the packages that have changesets.
+To create a new release, merge the "Version Packages" PR opened by the changesets-action. The release workflow will pause at the `npm` environment approval gate, then publish packages and create GitHub releases after approval.


### PR DESCRIPTION
## Summary
- Split the changesets release workflow so publishing runs in a separate job after the version PR is merged.
- Gate npm publishing behind the `npm` GitHub Environment with OIDC provenance permissions.
- Update maintainer release docs to mention the environment approval step.

## Checks
- `git diff --check -- .github/workflows/release.yml CONTRIBUTING.md`
- YAML parse check for `.github/workflows/release.yml`
- Verified publishable packages have public provenance publish config