### PR TITLE
Fix redundant setAttribute calls

### DIFF
--- a/.changeset/swift-canvases-render.md
+++ b/.changeset/swift-canvases-render.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Fix redundant DOM attribute writes when a parent rerenders with unchanged signal props. The DIFFED hook no longer writes Signal references back into `vnode.props`, which was causing Preact's prop diff to see a mismatch (old: Signal, new: peeked value) and re-apply every signal-bound attribute on every parent rerender.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -294,10 +294,6 @@ hook(OptionsTypes.DIFFED, (old, vnode) => {
 					updater._update(signal, renderedProps);
 				}
 			}
-
-			for (let prop in props) {
-				renderedProps[prop] = props[prop];
-			}
 		}
 	}
 	old(vnode);
@@ -363,6 +359,16 @@ hook(OptionsTypes.UNMOUNT, (old, vnode: VNode) => {
 					let updater = updaters[prop];
 					if (updater) updater._dispose();
 				}
+			}
+		}
+		// Restore Signal references into vnode.props so that, if this vnode
+		// instance is reused for a remount, the DIFF hook can re-detect the
+		// signal-bound props (they were replaced with peeked values during diff).
+		let signalProps = vnode.__np;
+		if (signalProps) {
+			let props = vnode.props;
+			for (let prop in signalProps) {
+				props[prop] = signalProps[prop];
 			}
 		}
 		vnode.__np = undefined;

--- a/packages/preact/test/browser/index.test.tsx
+++ b/packages/preact/test/browser/index.test.tsx
@@ -788,6 +788,40 @@ describe("@preact/signals", () => {
 			expect(div.getAttribute("title")).to.equal("");
 			expect(spy).not.toHaveBeenCalled();
 		});
+
+		// https://github.com/preactjs/signals/issues/923
+		it("should not re-apply unchanged signal props when parent rerenders", () => {
+			const count = signal(0);
+			const width = signal(200);
+
+			function App() {
+				return (
+					<div>
+						<p>{count.value}</p>
+						{/* @ts-ignore */}
+						<canvas width={width} />
+					</div>
+				);
+			}
+
+			render(<App />, scratch);
+
+			const canvas = scratch.querySelector("canvas") as HTMLCanvasElement;
+			const setAttributeSpy = vi.spyOn(canvas, "setAttribute");
+
+			act(() => {
+				count.value++;
+			});
+
+			// Parent rerendered but width signal didn't change — Preact must
+			// not re-apply the attribute, otherwise non-idempotent setters
+			// like canvas width/height (which reset the bitmap to transparent
+			// even when the value is unchanged) would be triggered redundantly.
+			const widthCalls = setAttributeSpy.mock.calls.filter(
+				([name]) => name === "width"
+			);
+			expect(widthCalls).to.have.length(0);
+		});
 	});
 
 	describe("hooks mixed with signals", () => {


### PR DESCRIPTION
Fixes https://github.com/preactjs/signals/issues/923

Fix redundant DOM attribute writes when a parent rerenders with unchanged signal props. The DIFFED hook no longer writes Signal references back into `vnode.props`, which was causing Preact's prop diff to see a mismatch (old: Signal, new: peeked value) and re-apply every signal-bound attribute on every parent rerender.