### PR TITLE
Add changeset for DevTools cleanup

### DIFF
--- a/.changeset/devtools-cleanup-types.md
+++ b/.changeset/devtools-cleanup-types.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-debug": patch
+"@preact/signals-devtools-adapter": patch
+"@preact/signals-devtools-ui": patch
+---
+
+Clean up DevTools integration types and configuration payload handling. The debug package now sends normalized settings payloads, adapters accept current and legacy config/availability messages, and the UI disposes adapter subscriptions when contexts are destroyed.


### PR DESCRIPTION
## Summary
- add missing patch changesets for the DevTools cleanup work from #901
- covers `@preact/signals-debug`, `@preact/signals-devtools-adapter`, and `@preact/signals-devtools-ui`
