### PR TITLE
Add preact to minimum release age exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,8 @@ packages:
   - "!**/test/**"
 
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - preact
 
 blockExoticSubdeps: true
 


### PR DESCRIPTION
## Summary
- add `preact` to pnpm's `minimumReleaseAgeExclude` list

This is mainly for our ecosystem ci