### PR TITLE
ci: harden trusted publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 11.0.0
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           package-manager-cache: false
           node-version: 24
@@ -45,7 +45,7 @@ jobs:
 
       - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@v1.5.3
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           version: pnpm run version
         env:
@@ -66,15 +66,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 11.0.0
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           package-manager-cache: false
           node-version: 24
@@ -87,7 +87,7 @@ jobs:
         run: pnpm install
 
       - name: Publish packages
-        uses: changesets/action@v1.5.3
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           publish: pnpm changeset publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
+          package-manager-cache: false
           node-version: 24
           registry-url: "https://registry.npmjs.org"
 
@@ -75,6 +76,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
+          package-manager-cache: false
           node-version: 24
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary
- Explicitly disables setup-node package-manager auto-caching in the trusted publishing workflow.
- Removes existing publish-workflow dependency cache usage where present.
- Pins external GitHub Actions in the trusted publish workflow to full commit SHAs, keeping the original tag as a comment breadcrumb.

## Why
Trusted publishing/OIDC workflows should not restore shared dependency caches, and tag-based action references can be retargeted after compromise. The StepSecurity advisory for `actions-cool/issues-helper` is the concrete failure mode: tags were moved to an imposter commit, while full-SHA pinned workflows were unaffected.

## Verification
- Parsed the edited workflow YAML locally with PyYAML.
- Re-scanned release workflows for `actions/setup-node` without `package-manager-cache: false` and for `actions/cache` usage.
- Re-scanned trusted publish workflow `uses:` entries and confirmed all external actions are pinned to 40-character commit SHAs.
