### PR TITLE
Fix stale For indexes for cached items

### DIFF
--- a/.changeset/for-stale-index.md
+++ b/.changeset/for-stale-index.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals": patch
+"@preact/signals-react": patch
+---
+
+Update cached `<For>` items when their index changes so render-prop indexes stay current after removals or reorders.

--- a/packages/preact/utils/src/index.tsx
+++ b/packages/preact/utils/src/index.tsx
@@ -40,6 +40,7 @@ interface ForProps<T> {
 
 export function For<T>(props: ForProps<T>): ComponentChildren | null {
 	const cache = useMemo(() => new Map(), []);
+	const indexes = useMemo(() => new Map(), []);
 	const list = (typeof props.each === "function" ? props.each() : props.each) as
 		| Signal<Array<T>>
 		| Array<T>;
@@ -52,12 +53,13 @@ export function For<T>(props: ForProps<T>): ComponentChildren | null {
 
 	const items = listValue.map((value, index) => {
 		removed.delete(value);
-		if (!cache.has(value)) {
+		if (!cache.has(value) || indexes.get(value) !== index) {
 			const key = props.getKey ? props.getKey(value, index) : index;
 			const result = (
 				<Item key={key} v={value} i={index} children={props.children} />
 			);
 			cache.set(value, result);
+			indexes.set(value, index);
 			return result;
 		}
 		return cache.get(value);
@@ -65,6 +67,7 @@ export function For<T>(props: ForProps<T>): ComponentChildren | null {
 
 	removed.forEach(value => {
 		cache.delete(value);
+		indexes.delete(value);
 	});
 
 	return createElement(Fragment, null, items);

--- a/packages/preact/utils/test/browser/index.test.tsx
+++ b/packages/preact/utils/test/browser/index.test.tsx
@@ -164,6 +164,78 @@ describe("@preact/signals-utils", () => {
 			);
 		});
 
+		it("Should pass updated indexes to reused items after removal", () => {
+			const alice = { id: "a", label: "Alice" };
+			const bob = { id: "b", label: "Bob" };
+			const carol = { id: "c", label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const rerender = signal(0);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			act(() => {
+				render(
+					<For each={list} getKey={item => item.id}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}:{rerender.value}
+							</Paragraph>
+						)}
+					</For>,
+					scratch
+				);
+			});
+			expect(scratch.innerHTML).to.eq(
+				"<p>Alice:0:0</p><p>Bob:1:0</p><p>Carol:2:0</p>"
+			);
+
+			// Remove the first item while keeping the remaining item references,
+			// which previously reused Bob and Carol's cached child elements
+			// with stale indexes.
+			act(() => {
+				list.value = [bob, carol];
+			});
+
+			// Force the reused children to render again. They should receive their
+			// new indexes from the updated list, not the indexes they had at mount.
+			act(() => {
+				rerender.value = 1;
+			});
+			expect(scratch.innerHTML).to.eq("<p>Bob:0:1</p><p>Carol:1:1</p>");
+		});
+
+		it("Should pass updated indexes to object items after removal without getKey", () => {
+			const alice = { label: "Alice" };
+			const bob = { label: "Bob" };
+			const carol = { label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const rerender = signal(0);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}:{rerender.value}
+							</Paragraph>
+						)}
+					</For>,
+					scratch
+				);
+			});
+			expect(scratch.innerHTML).to.eq(
+				"<p>Alice:0:0</p><p>Bob:1:0</p><p>Carol:2:0</p>"
+			);
+
+			act(() => {
+				list.value = [bob, carol];
+			});
+			act(() => {
+				rerender.value = 1;
+			});
+			expect(scratch.innerHTML).to.eq("<p>Bob:0:1</p><p>Carol:1:1</p>");
+		});
+
 		it("Should use getKey for stable identity on item removal", () => {
 			const list = signal([
 				{ id: "a", label: "Alice" },

--- a/packages/react/utils/src/index.tsx
+++ b/packages/react/utils/src/index.tsx
@@ -48,6 +48,7 @@ interface ForProps<T> {
 export function For<T>(props: ForProps<T>): JSX.Element | null {
 	useSignals();
 	const cache = useMemo(() => new Map(), []);
+	const indexes = useMemo(() => new Map(), []);
 	const list = (typeof props.each === "function" ? props.each() : props.each) as
 		| Signal<Array<T>>
 		| Array<T>;
@@ -60,12 +61,13 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 
 	const items = listValue.map((value, index) => {
 		removed.delete(value);
-		if (!cache.has(value)) {
+		if (!cache.has(value) || indexes.get(value) !== index) {
 			const key = props.getKey ? props.getKey(value, index) : index;
 			const result = (
 				<Item v={value} key={key} i={index} children={props.children} />
 			);
 			cache.set(value, result);
+			indexes.set(value, index);
 			return result;
 		}
 		return cache.get(value);
@@ -73,6 +75,7 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 
 	removed.forEach(value => {
 		cache.delete(value);
+		indexes.delete(value);
 	});
 
 	return createElement(Fragment, { children: items });

--- a/packages/react/utils/test/browser/index.test.tsx
+++ b/packages/react/utils/test/browser/index.test.tsx
@@ -197,6 +197,76 @@ describe("@preact/signals-react-utils", () => {
 			);
 		});
 
+		it("Should pass updated indexes to reused items after removal", async () => {
+			const alice = { id: "a", label: "Alice" };
+			const bob = { id: "b", label: "Bob" };
+			const carol = { id: "c", label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const rerender = signal(0);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			await act(() => {
+				render(
+					<For each={list} getKey={item => item.id}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}:{rerender.value}
+							</Paragraph>
+						)}
+					</For>
+				);
+			});
+			expect(scratch.innerHTML).to.eq(
+				"<p>Alice:0:0</p><p>Bob:1:0</p><p>Carol:2:0</p>"
+			);
+
+			// Remove the first item while keeping the remaining item references,
+			// which previously reused Bob and Carol's cached child elements
+			// with stale indexes.
+			await act(() => {
+				list.value = [bob, carol];
+			});
+
+			// Force the reused children to render again. They should receive their
+			// new indexes from the updated list, not the indexes they had at mount.
+			await act(() => {
+				rerender.value = 1;
+			});
+			expect(scratch.innerHTML).to.eq("<p>Bob:0:1</p><p>Carol:1:1</p>");
+		});
+
+		it("Should pass updated indexes to object items after removal without getKey", async () => {
+			const alice = { label: "Alice" };
+			const bob = { label: "Bob" };
+			const carol = { label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const rerender = signal(0);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			await act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}:{rerender.value}
+							</Paragraph>
+						)}
+					</For>
+				);
+			});
+			expect(scratch.innerHTML).to.eq(
+				"<p>Alice:0:0</p><p>Bob:1:0</p><p>Carol:2:0</p>"
+			);
+
+			await act(() => {
+				list.value = [bob, carol];
+			});
+			await act(() => {
+				rerender.value = 1;
+			});
+			expect(scratch.innerHTML).to.eq("<p>Bob:0:1</p><p>Carol:1:1</p>");
+		});
+
 		it("Should use getKey for stable identity on item removal", async () => {
 			const list = signal([
 				{ id: "a", label: "Alice" },


### PR DESCRIPTION
## Summary

Fixes a stale index issue in `<For />` where cached children could continue rendering with their original index after an earlier item was removed from the list.

Previously, `<For />` cached rendered items by value and reused the cached child whenever that value was still present. If the first item was removed, the remaining cached items were reused with the old `i` prop, so a later re-render could still observe the previous indexes.

This updates the cache bookkeeping to also remember the index associated with each cached value. Cached children are still keyed by the same value as before, but they are recreated when that value appears at a different index.

## Details

The fix intentionally preserves the existing cache behavior as much as possible:

- Without `getKey`, cache identity is still based on the item value/reference.
- With `getKey`, `getKey` continues to only affect the rendered element key.
- Cached children are still reused when the item remains at the same index.
- Only entries with a stale cached index are recreated.

This avoids switching to a composed cache key or changing identity semantics for object items without `getKey`.

 ## Tests

Added regression coverage for both Preact and React utils:

- `<For />` updates indexes for reused keyed items after removing the first item.
- `<For />` updates indexes for object items without `getKey`, while preserving value/reference-based cache behavior.