### PR TITLE
ci: declare minimum GITHUB_TOKEN permissions on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit workflow-level `permissions:` block to `main.yml`.

Scope set: `contents: read` (the minimum for checkout + the read-only steps this workflow runs).

Checklist:

- [x] Workflow does not push commits, create releases, or write issues/PRs
- [x] No `pull_request_target` trigger; this is a regular `push`/`pull_request` workflow
- [x] No `actions/cache@v3+` save path (would need `actions: write`)
- [x] YAML re-parses with `yaml.safe_load`
- [x] Matches the pattern recommended in GitHub's [token hardening docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)

This is one of the lowest-effort items on the OpenSSF Scorecard Token-Permissions check, and one of the cheaper defenses against incidents like tj-actions/changed-files compromise in March 2025 (CVE-2025-30066).
