### PR TITLE
fix(preact): stale signal DOM binding on node reuse

### DIFF
--- a/.changeset/stale-signal-dom-binding.md
+++ b/.changeset/stale-signal-dom-binding.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Fix Signal-bound DOM props getting stranded at a stale value when Preact reuses a DOM node. The prop-binding effect now writes the applied value back into the rendered props, keeping Preact's diff baseline in sync with the DOM instead of assuming Preact applied every update.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -313,25 +313,21 @@ function createPropUpdater(
 		dom.ownerSVGElement === undefined;
 
 	const changeSignal = signal(propSignal);
-	// Track the last value we know was applied to the DOM, so we can skip
-	// redundant updates without writing back to vnode.props (which would
-	// clobber the Signal reference and break unmount/remount cycles).
-	let lastRenderedValue: any = propSignal.peek();
 	return {
 		_update: (newSignal: Signal, newProps: typeof props) => {
 			changeSignal.value = newSignal;
 			props = newProps;
-			lastRenderedValue = newSignal.peek();
 		},
 		_dispose: effect(function (this: Effect) {
 			this._notify = notifyDomUpdates;
 			const value = changeSignal.value.value;
 			// If Preact just rendered this value, don't render it again:
-			if (lastRenderedValue === value) {
-				lastRenderedValue = undefined;
-				return;
-			}
-			lastRenderedValue = undefined;
+			if (props[prop] === value) return;
+			// Write the value back into the rendered props so that Preact's next
+			// diff compares against what is actually in the DOM. The Signal
+			// reference itself lives in vnode.__np and is restored into props by
+			// the UNMOUNT hook, so this never clobbers it.
+			props[prop] = value;
 			if (setAsProperty) {
 				// @ts-ignore-next-line silly
 				dom[prop] = value;

--- a/packages/preact/test/browser/index.test.tsx
+++ b/packages/preact/test/browser/index.test.tsx
@@ -823,6 +823,45 @@ describe("@preact/signals", () => {
 			expect(widthCalls).to.have.length(0);
 		});
 
+		// https://github.com/preactjs/signals/issues/923 — changed-signal variant:
+		// the binding effect already wrote the new value to the DOM, so a later
+		// parent rerender must not re-apply it either.
+		it("should not re-apply signal props the binding effect already wrote when parent rerenders", () => {
+			const count = signal(0);
+			const width = signal(200);
+
+			function App() {
+				return (
+					<div>
+						<p>{count.value}</p>
+						{/* @ts-ignore */}
+						<canvas width={width} />
+					</div>
+				);
+			}
+
+			render(<App />, scratch);
+
+			const canvas = scratch.querySelector("canvas") as HTMLCanvasElement;
+
+			// The binding effect applies the new width directly to the DOM.
+			act(() => {
+				width.value = 300;
+			});
+			expect(canvas.getAttribute("width")).to.equal("300");
+
+			const setAttributeSpy = vi.spyOn(canvas, "setAttribute");
+
+			act(() => {
+				count.value++;
+			});
+
+			const widthCalls = setAttributeSpy.mock.calls.filter(
+				([name]) => name === "width"
+			);
+			expect(widthCalls).to.have.length(0);
+		});
+
 		it("should not strand the DOM at a stale value when a re-render reuses the node while a signal prop update is pending", async () => {
 			const disabled = signal(false);
 			const spy = vi.fn();

--- a/packages/preact/test/browser/index.test.tsx
+++ b/packages/preact/test/browser/index.test.tsx
@@ -822,6 +822,48 @@ describe("@preact/signals", () => {
 			);
 			expect(widthCalls).to.have.length(0);
 		});
+
+		it("should not strand the DOM at a stale value when a re-render reuses the node while a signal prop update is pending", async () => {
+			const disabled = signal(false);
+			const spy = vi.fn();
+
+			function App({ n }: { n: number }) {
+				spy();
+				// App never reads disabled.value, so it does not re-render when
+				// `disabled` changes — the prop-binding effect is the only updater.
+				return (
+					<div data-n={n}>
+						{/* @ts-ignore */}
+						<button disabled={disabled} />
+					</div>
+				);
+			}
+
+			render(<App n={1} />, scratch);
+			const button = scratch.querySelector("button") as HTMLButtonElement;
+			expect(button.disabled).to.equal(false);
+
+			// The binding effect writes straight to the DOM; App never re-renders,
+			// so Preact's recorded baseline (oldVNode.props.disabled) stays `false`.
+			act(() => {
+				disabled.value = true;
+			});
+			expect(button.disabled).to.equal(true);
+			expect(spy).toHaveBeenCalledOnce();
+
+			// Schedule the binding effect back to `false`, then re-render for an
+			// unrelated reason (n changed) while that update is still pending.
+			// Preact reuses the button and its prop diff compares the stale
+			// baseline (false) against disabled.peek() (false) — and skips.
+			disabled.value = false;
+			render(<App n={2} />, scratch);
+			expect(scratch.querySelector("button")).to.equal(button);
+
+			// Let the pending binding effect flush.
+			await sleep();
+
+			expect(button.disabled).to.equal(false);
+		});
 	});
 
 	describe("hooks mixed with signals", () => {


### PR DESCRIPTION
> [!NOTE]
> The initial test was created by Claude

## Problem

A Signal bound to a DOM prop can get stranded at a stale value: the binding effect writes to the DOM directly, so Preact's recorded prop baseline goes stale when the owning component doesn't subscribe to the signal. If the signal then reverts to the baseline value and the component re-renders for an unrelated reason while that update is still pending, Preact reuses the node and skips the prop (old === new), and `createPropUpdater._update` resets `lastRenderedValue` so the binding effect skips too — leaving the DOM stuck with no path to correct itself.

## Solution

Adds a regression test reproducing this deterministically with a `<button disabled={signal}>` whose parent re-renders via a plain prop change. The test currently fails (`expected true to equal false`) and should pass once `createPropUpdater` is fixed.