### PR TITLE
feat(linter): add no-useless-computed lint rule

### DIFF
--- a/.changeset/add-no-useless-computed.md
+++ b/.changeset/add-no-useless-computed.md
@@ -1,0 +1,5 @@
+---
+"@preact/eslint-plugin-signals": minor
+---
+
+Add `no-useless-computed` rule that flags `computed()`/`useComputed()` callbacks which only return a single signal's `.value` without transformation

--- a/packages/eslint-plugin-signals/README.md
+++ b/packages/eslint-plugin-signals/README.md
@@ -11,6 +11,7 @@ An [Oxlint](https://oxc.rs)/ESLint plugin that catches common signal misuse patt
 | [`signals/no-signal-truthiness`](#no-signal-truthiness)               | warn     | Warn when a signal object itself is evaluated for truthiness                         |
 | [`signals/no-signal-in-component-body`](#no-signal-in-component-body) | error    | Disallow calling `signal`/`computed`/`effect` in a component body; use hooks instead |
 | [`signals/no-conditional-value-read`](#no-conditional-value-read)     | error    | Warn when `.value` is read conditionally behind a non-reactive guard                 |
+| [`signals/no-useless-computed`](#no-useless-computed)                 | warn     | Disallow a `computed()` that only returns another signal's `.value` unchanged        |
 
 ## Installation
 
@@ -31,6 +32,7 @@ pnpm add -D @preact/eslint-plugin-signals
 		"@preact/signals/no-signal-truthiness": "warn",
 		"@preact/signals/no-signal-in-component-body": "error",
 		"@preact/signals/no-conditional-value-read": "error",
+		"@preact/signals/no-useless-computed": "warn",
 	},
 }
 ```
@@ -60,6 +62,7 @@ export default [
 			"signals/no-signal-truthiness": "warn",
 			"signals/no-signal-in-component-body": "error",
 			"signals/no-conditional-value-read": "error",
+			"signals/no-useless-computed": "warn",
 		},
 	},
 ];
@@ -232,6 +235,36 @@ effect(() => {
 	doSomething(v);
 });
 ```
+
+### `no-useless-computed`
+
+Warns when `computed()` or `useComputed()` only returns another signal's
+`.value` unchanged.
+
+This creates an extra reactive graph node and subscription without deriving a
+new value. Transformations, property reads from the value, and multi-step
+callbacks are allowed.
+
+```js
+const count = signal(0);
+
+// ❌ Bad
+const duplicate = computed(() => count.value);
+const alsoDuplicate = useComputed(() => {
+	return count.value;
+});
+
+// ✅ Good
+const doubled = computed(() => count.value * 2);
+const visible = computed(() => !hidden.value);
+const name = computed(() => user.value.name);
+const direct = count;
+```
+
+> **Note:** If you use this pattern to expose a readonly view in TypeScript,
+> prefer `const view: ReadonlySignal<number> = count;`. `ReadonlySignal` is
+> structural, so a writable `Signal` satisfies it. JavaScript consumers who
+> need a runtime write barrier can disable this rule for that line.
 
 ## How Detection Works
 

--- a/packages/eslint-plugin-signals/src/index.mjs
+++ b/packages/eslint-plugin-signals/src/index.mjs
@@ -11,6 +11,7 @@
  *   - signals/no-signal-truthiness
  *   - signals/no-signal-in-component-body
  *   - signals/no-conditional-value-read
+ *   - signals/no-useless-computed
  */
 
 import noSignalWriteInComputed from "./rules/no-signal-write-in-computed.mjs";
@@ -18,6 +19,7 @@ import noValueAfterAwait from "./rules/no-value-after-await.mjs";
 import noSignalTruthiness from "./rules/no-signal-truthiness.mjs";
 import noSignalInComponentBody from "./rules/no-signal-in-component-body.mjs";
 import noConditionalValueRead from "./rules/no-conditional-value-read.mjs";
+import noUselessComputed from "./rules/no-useless-computed.mjs";
 
 const plugin = {
 	meta: {
@@ -30,6 +32,7 @@ const plugin = {
 		"no-signal-truthiness": noSignalTruthiness,
 		"no-signal-in-component-body": noSignalInComponentBody,
 		"no-conditional-value-read": noConditionalValueRead,
+		"no-useless-computed": noUselessComputed,
 	},
 };
 

--- a/packages/eslint-plugin-signals/src/rules/no-useless-computed.mjs
+++ b/packages/eslint-plugin-signals/src/rules/no-useless-computed.mjs
@@ -1,0 +1,122 @@
+/**
+ * Warn when a computed/useComputed callback only returns another signal's
+ * `.value` unchanged.
+ *
+ * Such a computed adds an extra graph node and subscription without deriving
+ * any new value. Real derivations like `sig.value * 2`, `!sig.value`, or
+ * `sig.value.foo` are intentionally allowed.
+ */
+
+import {
+	COMPUTED_CREATORS,
+	getSignalsCallName,
+	isKnownSignal,
+	isSignalByTypeChecker,
+} from "../utils/signals-scope.mjs";
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+	meta: {
+		type: "suggestion",
+		docs: {
+			description:
+				"Disallow computed/useComputed callbacks that only return another signal's `.value` without transformation",
+			recommended: true,
+		},
+		messages: {
+			uselessComputed:
+				"This {{ fn }}() only returns `{{ name }}.value` without transforming it. Use the signal `{{ name }}` directly instead.",
+		},
+		schema: [],
+	},
+
+	create(context) {
+		const sourceCode = context.sourceCode ?? context.getSourceCode();
+		const parserServices = context.parserServices ?? sourceCode?.parserServices;
+
+		function getSoleReturnedExpression(fnNode) {
+			if (fnNode.async || fnNode.generator) return null;
+			if (fnNode.body.type !== "BlockStatement") return fnNode.body;
+			if (fnNode.body.body.length !== 1) return null;
+
+			const stmt = fnNode.body.body[0];
+			if (stmt.type !== "ReturnStatement" || !stmt.argument) return null;
+			return stmt.argument;
+		}
+
+		function unwrapChainExpression(node) {
+			return node.type === "ChainExpression" ? node.expression : node;
+		}
+
+		function isPlainPropertyChain(node) {
+			let current = node;
+			while (current.type === "MemberExpression") {
+				if (
+					current.computed ||
+					current.property.type !== "Identifier" ||
+					current.property.name === "value"
+				) {
+					return false;
+				}
+				current = unwrapChainExpression(current.object);
+			}
+			return current.type === "Identifier";
+		}
+
+		function isSignalObject(node) {
+			const unwrapped = unwrapChainExpression(node);
+			if (unwrapped.type === "Identifier") {
+				return (
+					isKnownSignal(sourceCode, unwrapped) ||
+					isSignalByTypeChecker(parserServices, unwrapped)
+				);
+			}
+			if (
+				unwrapped.type === "MemberExpression" &&
+				isPlainPropertyChain(unwrapped)
+			) {
+				return isSignalByTypeChecker(parserServices, unwrapped);
+			}
+			return false;
+		}
+
+		return {
+			CallExpression(node) {
+				const fnName = getSignalsCallName(sourceCode, node, COMPUTED_CREATORS);
+				if (!fnName) return;
+				if (node.arguments.length > 1) return;
+
+				const cb = node.arguments[0];
+				if (
+					!cb ||
+					(cb.type !== "ArrowFunctionExpression" &&
+						cb.type !== "FunctionExpression")
+				) {
+					return;
+				}
+
+				let returned = getSoleReturnedExpression(cb);
+				if (!returned) return;
+				returned = unwrapChainExpression(returned);
+				if (
+					returned.type !== "MemberExpression" ||
+					returned.computed ||
+					returned.property.type !== "Identifier" ||
+					returned.property.name !== "value"
+				) {
+					return;
+				}
+
+				if (!isSignalObject(returned.object)) return;
+
+				context.report({
+					node,
+					messageId: "uselessComputed",
+					data: { fn: fnName, name: sourceCode.getText(returned.object) },
+				});
+			},
+		};
+	},
+};
+
+export default rule;

--- a/packages/eslint-plugin-signals/test/no-useless-computed.test.mjs
+++ b/packages/eslint-plugin-signals/test/no-useless-computed.test.mjs
@@ -1,0 +1,190 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { RuleTester } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import rule from "../src/rules/no-useless-computed.mjs";
+
+const tester = new RuleTester({
+	languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+const tsTester = new RuleTester({
+	languageOptions: {
+		ecmaVersion: 2022,
+		sourceType: "module",
+		parser: tsParser,
+	},
+});
+
+describe("no-useless-computed", () => {
+	it("should pass RuleTester", () => {
+		tester.run("no-useless-computed", rule, {
+			valid: [
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => s.value * 2);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => !s.value);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal({ count: 0 });
+				 const c = computed(() => s.value.count);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => {
+				   const value = s.value;
+				   return value;
+				 });`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const a = signal(0);
+				 const b = signal(1);
+				 const c = computed(() => a.value + b.value);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => s.peek());`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => s["value"]);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(async () => s.value);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => { return; });`,
+
+				`import { computed } from "@preact/signals-core";
+				 const c = computed(() => x.value);`,
+
+				`import { computed } from "totally-unrelated-lib";
+				 import { signal } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => s.value);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => (0, s.value));`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const fn = () => s.value;
+				 const c = computed(fn);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => s);`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const s = signal(0);
+				 const c = computed(() => s.value, { name: "x" });`,
+
+				`import { signal, computed } from "@preact/signals-core";
+				 const a = signal(signal(0));
+				 const c = computed(() => a.value.value);`,
+			],
+			invalid: [
+				{
+					code: `import { signal, computed } from "@preact/signals-core";
+					       const s = signal(0);
+					       const c = computed(() => s.value);`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { signal, computed } from "@preact/signals-core";
+					       const s = signal(0);
+					       const c = computed(() => { return s.value; });`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { signal, computed } from "@preact/signals-core";
+					       const s = signal(0);
+					       const c = computed(function () { return s.value; });`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { useSignal, useComputed } from "@preact/signals";
+					       const s = useSignal(0);
+					       const c = useComputed(() => s.value);`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { signal, computed as c } from "@preact/signals-core";
+					       const s = signal(0);
+					       const value = c(() => s.value);`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import * as core from "@preact/signals-core";
+					       const s = core.signal(0);
+					       const c = core.computed(() => s.value);`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { signal, computed } from "@preact/signals-core";
+					       const s = signal(0);
+					       const c = computed(() => (s.value));`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { signal, computed } from "@preact/signals-core";
+					       const s = signal(0);
+					       const c = computed(() => s?.value);`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { signal, computed } from "@preact/signals-core";
+					       const s = signal(0);
+					       const a = computed(() => s.value * 2);
+					       const b = computed(() => a.value);`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+			],
+		});
+	});
+
+	it("should detect typed signals", () => {
+		tsTester.run("no-useless-computed-types", rule, {
+			valid: [
+				`import { computed } from "@preact/signals-core";
+				 import type { Signal } from "@preact/signals-core";
+				 declare const s: Signal<number>;
+				 const c = computed(() => s.value * 2);`,
+
+				`import { computed } from "@preact/signals-core";
+				 type NotASignal = { value: number };
+				 const s: NotASignal = { value: 0 };
+				 const c = computed(() => s.value);`,
+			],
+			invalid: [
+				{
+					code: `import { computed } from "@preact/signals-core";
+					       import type { Signal } from "@preact/signals-core";
+					       const s: Signal<number> = getS();
+					       const c = computed(() => s.value);`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { computed } from "@preact/signals-core";
+					       import type { ReadonlySignal } from "@preact/signals-core";
+					       const s: ReadonlySignal<number> = getS();
+					       const c = computed(() => s.value);`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+				{
+					code: `import { computed } from "@preact/signals-core";
+					       import type { Signal } from "@preact/signals-core";
+					       function make(s: Signal<number>) {
+					         return computed(() => s.value);
+					       }`,
+					errors: [{ messageId: "uselessComputed" }],
+				},
+			],
+		});
+	});
+});


### PR DESCRIPTION
Adds `no-useless-computed` to flag `computed()`/`useComputed()` callbacks that only return another signal’s `.value`, avoiding redundant graph nodes/subscriptions while keeping real derivations allowed. Gaps called out: no autofix because replacement can widen readonly types, indirect/non-inline callbacks stay out of scope, and patterns like `computed(() => s)` / `s.peek()` are left for a separate rule.

> [!NOTE]
> This is co-authored by GPT5.5
