### PR TITLE
fix(linter): sync plugin meta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ci:test": "pnpm lint && pnpm test",
     "prepare": "husky install",
     "format": "oxfmt",
-    "version": "pnpm changeset version && pnpm i --lockfile-only"
+    "version": "pnpm changeset version && node scripts/sync-eslint-plugin-meta-version.mjs && pnpm i --lockfile-only"
   },
   "authors": [
     "The Preact Authors (https://github.com/preactjs/signals/contributors)"

--- a/packages/eslint-plugin-signals/test/plugin-meta.test.mjs
+++ b/packages/eslint-plugin-signals/test/plugin-meta.test.mjs
@@ -1,9 +1,18 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import plugin from "../src/index.mjs";
+
+const packageJson = JSON.parse(
+	await readFile(new URL("../package.json", import.meta.url), "utf8")
+);
 
 describe("plugin meta", () => {
 	it("should expose the package name", () => {
 		assert.equal(plugin.meta.name, "@preact/eslint-plugin-signals");
+	});
+
+	it("should expose the package version", () => {
+		assert.equal(plugin.meta.version, packageJson.version);
 	});
 });

--- a/scripts/sync-eslint-plugin-meta-version.mjs
+++ b/scripts/sync-eslint-plugin-meta-version.mjs
@@ -1,0 +1,27 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const packageJsonUrl = new URL(
+	"../packages/eslint-plugin-signals/package.json",
+	import.meta.url
+);
+const pluginUrl = new URL(
+	"../packages/eslint-plugin-signals/src/index.mjs",
+	import.meta.url
+);
+
+const packageJson = JSON.parse(await readFile(packageJsonUrl, "utf8"));
+const pluginSource = await readFile(pluginUrl, "utf8");
+const versionPattern = /(\bversion:\s*")[^"]+(")/;
+
+if (!versionPattern.test(pluginSource)) {
+	throw new Error("Unable to update eslint plugin meta.version");
+}
+
+const nextSource = pluginSource.replace(
+	versionPattern,
+	`$1${packageJson.version}$2`
+);
+
+if (nextSource !== pluginSource) {
+	await writeFile(pluginUrl, nextSource);
+}


### PR DESCRIPTION
Keeps the ESLint plugin's hardcoded meta.version aligned with package.json whenever Changesets bumps package versions. Explicit gaps: the release path previously left that metadata stale, and there was no regression test proving the plugin meta version matched the published package version.