### PR TITLE
Fix stale For indexes for cached items

### DIFF
--- a/.changeset/for-reactive-index.md
+++ b/.changeset/for-reactive-index.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals": patch
+"@preact/signals-react": patch
+---
+
+Fix stale `<For>` render-prop indexes after removals/reorders by making each cached item's index reactive (a per-item signal) instead of a frozen prop. Cached children are reused and re-render with the new index rather than being recreated, so DOM/component identity is preserved.

--- a/packages/preact/utils/src/index.tsx
+++ b/packages/preact/utils/src/index.tsx
@@ -1,4 +1,4 @@
-import { ReadonlySignal, Signal } from "@preact/signals-core";
+import { ReadonlySignal, Signal, signal } from "@preact/signals-core";
 import { useSignal } from "@preact/signals";
 import { Fragment, createElement, ComponentChildren } from "preact";
 import { useMemo } from "preact/hooks";
@@ -11,7 +11,7 @@ interface ShowProps<T = boolean> {
 
 const Item = (props: any) => {
 	return typeof props.children === "function"
-		? props.children(props.v, props.i)
+		? props.children(props.v, props.i ? props.i.value : undefined)
 		: props.children;
 };
 
@@ -52,15 +52,22 @@ export function For<T>(props: ForProps<T>): ComponentChildren | null {
 
 	const items = listValue.map((value, index) => {
 		removed.delete(value);
-		if (!cache.has(value)) {
+		let entry = cache.get(value);
+		if (!entry) {
+			const i = signal(index);
 			const key = props.getKey ? props.getKey(value, index) : index;
-			const result = (
-				<Item key={key} v={value} i={index} children={props.children} />
+			const vnode = (
+				<Item key={key} v={value} i={i} children={props.children} />
 			);
-			cache.set(value, result);
-			return result;
+			entry = { vnode, i };
+			cache.set(value, entry);
+		} else if (entry.i.peek() !== index) {
+			// Index changed (e.g. an earlier item was removed/reordered). Push the
+			// new index through the per-item signal so the cached vnode is reused
+			// and the child re-renders reactively instead of being recreated.
+			entry.i.value = index;
 		}
-		return cache.get(value);
+		return entry.vnode;
 	});
 
 	removed.forEach(value => {

--- a/packages/preact/utils/test/browser/index.test.tsx
+++ b/packages/preact/utils/test/browser/index.test.tsx
@@ -164,6 +164,106 @@ describe("@preact/signals-utils", () => {
 			);
 		});
 
+		it("Should pass updated indexes to reused items after removal", () => {
+			const alice = { id: "a", label: "Alice" };
+			const bob = { id: "b", label: "Bob" };
+			const carol = { id: "c", label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const rerender = signal(0);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			act(() => {
+				render(
+					<For each={list} getKey={item => item.id}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}:{rerender.value}
+							</Paragraph>
+						)}
+					</For>,
+					scratch
+				);
+			});
+			expect(scratch.innerHTML).to.eq(
+				"<p>Alice:0:0</p><p>Bob:1:0</p><p>Carol:2:0</p>"
+			);
+
+			act(() => {
+				list.value = [bob, carol];
+			});
+			act(() => {
+				rerender.value = 1;
+			});
+			expect(scratch.innerHTML).to.eq("<p>Bob:0:1</p><p>Carol:1:1</p>");
+		});
+
+		it("Should pass updated indexes to object items after removal without getKey", () => {
+			const alice = { label: "Alice" };
+			const bob = { label: "Bob" };
+			const carol = { label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const rerender = signal(0);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}:{rerender.value}
+							</Paragraph>
+						)}
+					</For>,
+					scratch
+				);
+			});
+			expect(scratch.innerHTML).to.eq(
+				"<p>Alice:0:0</p><p>Bob:1:0</p><p>Carol:2:0</p>"
+			);
+
+			act(() => {
+				list.value = [bob, carol];
+			});
+			act(() => {
+				rerender.value = 1;
+			});
+			expect(scratch.innerHTML).to.eq("<p>Bob:0:1</p><p>Carol:1:1</p>");
+		});
+
+		it("Should preserve DOM identity of reused items after a re-index without getKey", () => {
+			const alice = { label: "Alice" };
+			const bob = { label: "Bob" };
+			const carol = { label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}
+							</Paragraph>
+						)}
+					</For>,
+					scratch
+				);
+			});
+			const bobNodeBefore = scratch.querySelectorAll("p")[1];
+
+			act(() => {
+				list.value = [bob, carol];
+			});
+
+			// Bob's index changed 1 -> 0. Because the cached vnode is reused (not
+			// recreated with a new positional key), Bob keeps the very same DOM
+			// node. Recreating the vnode here would re-key it to 0 and reconcile
+			// Bob into Alice's old node, losing focus/state.
+			const bobNodeAfter = scratch.querySelectorAll("p")[0];
+			expect(scratch.innerHTML).to.eq("<p>Bob:0</p><p>Carol:1</p>");
+			expect(bobNodeAfter).to.equal(bobNodeBefore);
+		});
+
 		it("Should use getKey for stable identity on item removal", () => {
 			const list = signal([
 				{ id: "a", label: "Alice" },

--- a/packages/react/utils/src/index.tsx
+++ b/packages/react/utils/src/index.tsx
@@ -1,4 +1,4 @@
-import { ReadonlySignal, Signal } from "@preact/signals-core";
+import { ReadonlySignal, Signal, signal } from "@preact/signals-core";
 import { useSignal } from "@preact/signals-react";
 import { useSignals } from "@preact/signals-react/runtime";
 import {
@@ -19,7 +19,7 @@ interface ShowProps<T = boolean> {
 const Item = (props: any) => {
 	useSignals();
 	return typeof props.children === "function"
-		? props.children(props.v, props.i)
+		? props.children(props.v, props.i ? props.i.value : undefined)
 		: props.children;
 };
 
@@ -60,15 +60,22 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 
 	const items = listValue.map((value, index) => {
 		removed.delete(value);
-		if (!cache.has(value)) {
+		let entry = cache.get(value);
+		if (!entry) {
+			const i = signal(index);
 			const key = props.getKey ? props.getKey(value, index) : index;
-			const result = (
-				<Item v={value} key={key} i={index} children={props.children} />
+			const vnode = (
+				<Item v={value} key={key} i={i} children={props.children} />
 			);
-			cache.set(value, result);
-			return result;
+			entry = { vnode, i };
+			cache.set(value, entry);
+		} else if (entry.i.peek() !== index) {
+			// Index changed (e.g. an earlier item was removed/reordered). Push the
+			// new index through the per-item signal so the cached vnode is reused
+			// and the child re-renders reactively instead of being recreated.
+			entry.i.value = index;
 		}
-		return cache.get(value);
+		return entry.vnode;
 	});
 
 	removed.forEach(value => {

--- a/packages/react/utils/test/browser/index.test.tsx
+++ b/packages/react/utils/test/browser/index.test.tsx
@@ -197,6 +197,103 @@ describe("@preact/signals-react-utils", () => {
 			);
 		});
 
+		it("Should pass updated indexes to reused items after removal", async () => {
+			const alice = { id: "a", label: "Alice" };
+			const bob = { id: "b", label: "Bob" };
+			const carol = { id: "c", label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const rerender = signal(0);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			await act(() => {
+				render(
+					<For each={list} getKey={item => item.id}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}:{rerender.value}
+							</Paragraph>
+						)}
+					</For>
+				);
+			});
+			expect(scratch.innerHTML).to.eq(
+				"<p>Alice:0:0</p><p>Bob:1:0</p><p>Carol:2:0</p>"
+			);
+
+			await act(() => {
+				list.value = [bob, carol];
+			});
+			await act(() => {
+				rerender.value = 1;
+			});
+			expect(scratch.innerHTML).to.eq("<p>Bob:0:1</p><p>Carol:1:1</p>");
+		});
+
+		it("Should pass updated indexes to object items after removal without getKey", async () => {
+			const alice = { label: "Alice" };
+			const bob = { label: "Bob" };
+			const carol = { label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const rerender = signal(0);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			await act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}:{rerender.value}
+							</Paragraph>
+						)}
+					</For>
+				);
+			});
+			expect(scratch.innerHTML).to.eq(
+				"<p>Alice:0:0</p><p>Bob:1:0</p><p>Carol:2:0</p>"
+			);
+
+			await act(() => {
+				list.value = [bob, carol];
+			});
+			await act(() => {
+				rerender.value = 1;
+			});
+			expect(scratch.innerHTML).to.eq("<p>Bob:0:1</p><p>Carol:1:1</p>");
+		});
+
+		it("Should preserve DOM identity of reused items after a re-index without getKey", async () => {
+			const alice = { label: "Alice" };
+			const bob = { label: "Bob" };
+			const carol = { label: "Carol" };
+			const list = signal([alice, bob, carol]);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			await act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item.label}:{index}
+							</Paragraph>
+						)}
+					</For>
+				);
+			});
+			const bobNodeBefore = scratch.querySelectorAll("p")[1];
+
+			await act(() => {
+				list.value = [bob, carol];
+			});
+
+			// Bob's index changed 1 -> 0. Because the cached element is reused (not
+			// recreated with a new positional key), Bob keeps the very same DOM
+			// node. Recreating the element here would re-key it to 0 and reconcile
+			// Bob into Alice's old node, losing focus/state.
+			const bobNodeAfter = scratch.querySelectorAll("p")[0];
+			expect(scratch.innerHTML).to.eq("<p>Bob:0</p><p>Carol:1</p>");
+			expect(bobNodeAfter).to.equal(bobNodeBefore);
+		});
+
 		it("Should use getKey for stable identity on item removal", async () => {
 			const list = signal([
 				{ id: "a", label: "Alice" },


### PR DESCRIPTION
Keeps `<For>` render-prop indexes current after removals/reorders by making each cached item's index reactive (a per-item signal) instead of a frozen prop. When an item's index changes, the new value is pushed through its signal so the cached child re-renders reactively rather than being recreated — preserving the cache, the element key, and DOM/component identity (including on the no-`getKey` path).

Supersedes #933.