### PR TITLE
fix(core): treat reverting a batched signal to NaN as a no-op

### DIFF
--- a/.changeset/fix-batch-noop-nan-revert.md
+++ b/.changeset/fix-batch-noop-nan-revert.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Fix a no-op `batch` assignment that reverts a signal back to `NaN` incorrectly re-running effects. The batch snapshot reconciliation compared the final value to the pre-batch value with `===`, which is always `false` for `NaN`, so the version was never rolled back. Reverting a `NaN` value to `NaN` within a batch is now correctly treated as unchanged.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,7 +167,13 @@ function reconcileBatchSnapshots() {
 	batchSnapshots = undefined;
 
 	while (snapshots !== undefined) {
-		if (snapshots._source._value === snapshots._value) {
+		const value = snapshots._source._value;
+		const snapshot = snapshots._value;
+		// Roll back the version if the value ended up unchanged. The extra
+		// self-comparison treats a value that started and ended as NaN as
+		// unchanged, since `NaN === NaN` is `false` (avoids `Object.is` to
+		// keep ES5 output).
+		if (value === snapshot || (value !== value && snapshot !== snapshot)) {
 			snapshots._source._version = snapshots._version;
 		}
 		snapshots = snapshots._next;

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -869,6 +869,42 @@ describe("effect()", () => {
 		expect(spy).not.toHaveBeenCalled();
 	});
 
+	it("should not rerun an effect for a no-op batch assignment that reverts to NaN", () => {
+		const foo = signal(NaN);
+		const spy = vi.fn(() => {
+			foo.value;
+		});
+
+		effect(spy);
+		expect(spy).toHaveBeenCalledOnce();
+		spy.mockClear();
+
+		batch(() => {
+			foo.value = 0;
+			foo.value = NaN;
+		});
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("should rerun an effect for a batch assignment that changes the value to NaN", () => {
+		const foo = signal(1);
+		const spy = vi.fn(() => {
+			foo.value;
+		});
+
+		effect(spy);
+		expect(spy).toHaveBeenCalledOnce();
+		spy.mockClear();
+
+		batch(() => {
+			foo.value = NaN;
+		});
+
+		expect(spy).toHaveBeenCalledOnce();
+		expect(Number.isNaN(foo.value)).to.equal(true);
+	});
+
 	it("should not rerun an effect for repeated no-op top-level batches", () => {
 		const foo = signal(42);
 		const spy = vi.fn(() => {


### PR DESCRIPTION
## Summary

The no-op-batch optimization (added in c0caa20, "Propose way to not have useless effect/computed runs") is supposed to ensure that writing a signal and then reverting it to its original value **within the same `batch()`** does not re-run subscribers. This works for normal values but silently breaks for `NaN`.

`reconcileBatchSnapshots()` decides whether to roll back a signal's version by comparing the final value to the pre-batch snapshot with `===`:

```js
if (snapshots._source._value === snapshots._value) {
    snapshots._source._version = snapshots._version;
}
```

Since `NaN === NaN` is `false`, a signal that started as `NaN` and is reverted back to `NaN` inside a batch never has its version rolled back, so subscribed effects re-run even though nothing changed.

## Reproduction

```js
const foo = signal(NaN);
effect(() => { foo.value; }); // runs once

batch(() => {
  foo.value = 0;
  foo.value = NaN; // revert to original
});
// effect re-runs — but the equivalent non-NaN case does not:
//   batch(() => { foo.value = 0; foo.value = 42; })  // already suppressed
```

This is the batch-level counterpart of the asymmetry described in #614. It is scoped strictly to the no-op-batch optimization and does **not** change the plain `.value` setter semantics.

## Fix

Add a self-comparison so a value that started and ended as `NaN` is treated as unchanged. `x !== x` is `true` only for `NaN`, so this avoids `Object.is` and keeps the ES5 output:

```js
if (value === snapshot || (value !== value && snapshot !== snapshot)) {
    snapshots._source._version = snapshots._version;
}
```

A real change *to* `NaN` (e.g. `1` → `NaN` in a batch) still correctly re-runs effects — covered by a test.

## Tests

- `should not rerun an effect for a no-op batch assignment that reverts to NaN` — fails before the fix, passes after.
- `should rerun an effect for a batch assignment that changes the value to NaN` — guards the real-change direction.

Both live next to the existing `should not rerun an effect for a no-op batch assignment` test. Full `packages/core` suite is green (158 passing, 2 pre-existing skips).

Related: #614
