### PR TITLE
fix(core): stale computed values after a batch reverts a signal

### DIFF
--- a/.changeset/olive-poems-refuse.md
+++ b/.changeset/olive-poems-refuse.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-core": patch
+---
+
+Fix computeds returning stale values after a batch reverts a signal to its original value.
+
+Reconciling a reverted batch write used to roll the signal's version number back, breaking version monotonicity. A lazy computed that read the signal during the batch had already observed the intermediate version, so a later write could re-mint that same version number for a different value and the computed would treat it as unchanged forever. Subscriber nodes that saw the pre-batch version are now fast-forwarded instead, keeping the no-op skip optimization without ever reusing version numbers.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -182,8 +182,24 @@ function reconcileBatchSnapshots() {
 	batchSnapshots = undefined;
 
 	while (snapshots !== undefined) {
-		if (snapshots._source._value === snapshots._value) {
-			snapshots._source._version = snapshots._version;
+		const source = snapshots._source;
+		if (source._value === snapshots._value) {
+			// The value was reverted to its pre-batch state. Version numbers must
+			// stay monotonic: a lazy computed may have observed an intermediate
+			// version during the batch, and rolling the version back would let a
+			// future write re-mint that observed number for a different value,
+			// making the computed treat it as unchanged forever. Instead,
+			// fast-forward subscribers that last saw the pre-batch version so
+			// they skip recomputing for the no-op change.
+			for (
+				let node = source._targets;
+				node !== undefined;
+				node = node._nextTarget
+			) {
+				if (node._version === snapshots._version) {
+					node._version = source._version;
+				}
+			}
 		}
 		snapshots = snapshots._next;
 	}

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -893,6 +893,57 @@ describe("effect()", () => {
 		expect(spy).not.toHaveBeenCalled();
 	});
 
+	it("should not rerun an effect subscribed through a computed for a no-op batch assignment", () => {
+		const foo = signal(42);
+		const double = computed(() => foo.value * 2);
+		const spy = vi.fn(() => {
+			double.value;
+		});
+
+		effect(spy);
+		expect(spy).toHaveBeenCalledOnce();
+		spy.mockClear();
+
+		batch(() => {
+			foo.value = 0;
+			foo.value = 42;
+		});
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("should keep unsubscribed computeds coherent when they are read during a reverted batch", () => {
+		const foo = signal("A");
+		const double = computed(() => foo.value + "!");
+		expect(double.value).toBe("A!");
+
+		batch(() => {
+			foo.value = "B";
+			// A lazy read inside the batch observes the intermediate version.
+			expect(double.value).toBe("B!");
+			foo.value = "A";
+		});
+
+		// The next write must not collide with the version observed mid-batch.
+		foo.value = "C";
+		expect(double.value).toBe("C!");
+	});
+
+	it("should keep unsubscribed computeds coherent when they are peeked during a reverted batch", () => {
+		const foo = signal(1);
+		const double = computed(() => foo.value * 2);
+		expect(double.peek()).toBe(2);
+
+		batch(() => {
+			foo.value = 2;
+			expect(double.peek()).toBe(4);
+			foo.value = 1;
+		});
+
+		foo.value = 3;
+		expect(double.peek()).toBe(6);
+	});
+
 	it("should not rerun parent effect if a nested child effect's signal's value changes", () => {
 		const parentSignal = signal(0);
 		const childSignal = signal(0);


### PR DESCRIPTION
## Root cause

`reconcileBatchSnapshots` rolls a signal's `_version` **backwards** when a batch ends with the value equal to its pre-batch state. Version numbers are the only invalidation mechanism, and they must be monotonic: a lazy (unsubscribed) computed that reads the signal *during* the batch records the intermediate version on its dependency node. After the rollback, the next distinct write re-mints that exact version number for a different value, so `needsToRecompute` sees matching versions and the computed serves its stale cache — permanently, on every read, even though the signal holds a new value:

```js
const s = signal("A");
const c = computed(() => s.value + "!");
c.value;                                        // "A!"
batch(() => { s.value = "B"; c.value; s.value = "A"; });
s.value = "C";
c.value;                                        // "B!" — stale forever
```

Reading a modified signal inside a batch is explicitly supported per `batch`'s documentation, and this shipped in `@preact/signals-core@1.14.0`.

## Fix

Never roll versions back. Instead, when a batch reverts a value, fast-forward the subscriber nodes that last saw the pre-batch version to the current version. Subscribed effects/computeds still skip recomputing on no-op batches (the point of the original optimization), while any node that observed an intermediate version keeps its mismatch and recomputes correctly. Lazy computeds that saw only the pre-batch version now do one value-equal recompute instead of being skipped — trading a micro-optimization for correctness.

Note: this PR was authored by Claude and @JoviDeCroock.