### PR TITLE
fix(preact): stale prop updater keeps writing to the DOM after all signal props are removed

### DIFF
--- a/.changeset/tidy-donuts-argue.md
+++ b/.changeset/tidy-donuts-argue.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals": patch
+---
+
+Dispose signal prop updaters when an element re-renders without any signal props.
+
+The disposal pass only ran when the new render still carried at least one signal-bound prop. When every signal prop was replaced by plain values, the old updater effect stayed subscribed and kept writing the previous signal's values straight into the DOM, overriding whatever Preact rendered.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -268,18 +268,24 @@ hook(OptionsTypes.DIFFED, (old, vnode) => {
 	if (typeof vnode.type === "string" && (dom = vnode.__e as Element)) {
 		let props = vnode.__np;
 		let renderedProps = vnode.props;
-		if (props) {
-			let updaters = dom._updaters;
-			if (updaters) {
-				for (let prop in updaters) {
-					let updater = updaters[prop];
-					if (updater !== undefined && !(prop in props)) {
-						updater._dispose();
-						// @todo we could just always invoke _dispose() here
-						updaters[prop] = undefined;
-					}
+		let updaters = dom._updaters;
+		if (updaters) {
+			// Dispose updaters for props that are no longer bound to a signal.
+			// This must also run when the re-render carried no signal props at
+			// all (`vnode.__np` is undefined), otherwise the stale updater stays
+			// subscribed and keeps writing the old signal's values into the DOM.
+			for (let prop in updaters) {
+				let updater = updaters[prop];
+				if (updater !== undefined && (!props || !(prop in props))) {
+					updater._dispose();
+					// @todo we could just always invoke _dispose() here
+					updaters[prop] = undefined;
 				}
-			} else {
+			}
+		}
+
+		if (props) {
+			if (!updaters) {
 				updaters = {};
 				dom._updaters = updaters;
 			}

--- a/packages/preact/test/browser/index.test.tsx
+++ b/packages/preact/test/browser/index.test.tsx
@@ -575,6 +575,25 @@ describe("@preact/signals", () => {
 			expect(scratch.firstChild).to.have.property("checked", false);
 		});
 
+		it("should dispose the updater when re-rendering without any signal props", async () => {
+			const s = signal("bound");
+			// @ts-ignore
+			render(<input value={s} />, scratch);
+			expect(scratch.firstChild).to.have.property("value", "bound");
+
+			// Re-render the same element with no signal props at all.
+			render(<input value="plain" />, scratch);
+			expect(scratch.firstChild).to.have.property("value", "plain");
+
+			// The old binding must be disposed; a write to the previously bound
+			// signal must not clobber what Preact rendered.
+			act(() => {
+				s.value = "stale write";
+			});
+			await sleep();
+			expect(scratch.firstChild).to.have.property("value", "plain");
+		});
+
 		it("should update props without re-rendering", async () => {
 			const s = signal("initial");
 			const spy = vi.fn();


### PR DESCRIPTION
## Root cause

In the `DIFFED` hook, the loop that disposes updaters for props no longer bound to a signal is nested inside `if (props)` where `props = vnode.__np`. When a re-render passes **no** signal props for the element — e.g. `<input value={editing ? draft : "saved"} />` flipping to the plain-string branch — `vnode.__np` is `undefined` and the whole block, including disposal, is skipped. The old `PropertyUpdater` effect stays subscribed to the previous signal and keeps writing its values straight into the DOM property, clobbering whatever Preact rendered, until the element unmounts.

## Fix

Run the disposal pass over `dom._updaters` unconditionally, treating a missing `vnode.__np` the same as "no props are signal-bound anymore", and only lazily create the updaters map when the new render actually has signal props. The regression test renders `<input value={signal} />`, re-renders with a plain string, then writes to the signal and asserts the DOM keeps the rendered value.

Note: this PR was authored by Claude and @JoviDeCroock.