### PR TITLE
fix(utils): For mis-renders duplicate items and reuses stale keys after removal

### DIFF
--- a/.changeset/plenty-pandas-shake.md
+++ b/.changeset/plenty-pandas-shake.md
@@ -1,0 +1,8 @@
+---
+"@preact/signals": patch
+"@preact/signals-react": patch
+---
+
+Fix `For` mis-rendering duplicate items and reusing stale keys.
+
+The item cache was keyed by item identity with the vnode key frozen at creation time. Duplicate primitives collapsed into a single cache entry (same vnode emitted twice with one shared index signal), and after removing an item the frozen positional keys could collide with a newly added item's key, handing the new item another row's DOM and state. Without `getKey`, the cache now keeps one entry per occurrence and mints keys from a counter so a key is never reused for a different item. With `getKey`, the cache is keyed by the user key and the row re-renders when the item value behind a key changes.

--- a/packages/preact/utils/src/index.tsx
+++ b/packages/preact/utils/src/index.tsx
@@ -39,7 +39,12 @@ interface ForProps<T> {
 }
 
 export function For<T>(props: ForProps<T>): ComponentChildren | null {
-	const cache = useMemo(() => new Map(), []);
+	const hasGetKey = !!props.getKey;
+	const state = useMemo(
+		() => ({ cache: new Map(), nextKey: 0 }),
+		// The cache layout differs between keyed and unkeyed mode.
+		[hasGetKey]
+	);
 	const list = (typeof props.each === "function" ? props.each() : props.each) as
 		| Signal<Array<T>>
 		| Array<T>;
@@ -48,31 +53,85 @@ export function For<T>(props: ForProps<T>): ComponentChildren | null {
 
 	if (!listValue.length) return props.fallback || null;
 
-	const removed = new Set(cache.keys());
+	const cache = state.cache;
+	let items: ComponentChildren[];
 
-	const items = listValue.map((value, index) => {
-		removed.delete(value);
-		let entry = cache.get(value);
-		if (!entry) {
-			const i = signal(index);
-			const key = props.getKey ? props.getKey(value, index) : index;
-			const vnode = (
-				<Item key={key} v={value} i={i} children={props.children} />
-			);
-			entry = { vnode, i };
-			cache.set(value, entry);
-		} else if (entry.i.peek() !== index) {
-			// Index changed (e.g. an earlier item was removed/reordered). Push the
-			// new index through the per-item signal so the cached vnode is reused
-			// and the child re-renders reactively instead of being recreated.
-			entry.i.value = index;
-		}
-		return entry.vnode;
-	});
-
-	removed.forEach(value => {
-		cache.delete(value);
-	});
+	if (props.getKey) {
+		// The cache is keyed by the user-provided key, so duplicate or replaced
+		// item values with the same key resolve to one stable entry.
+		const removed = new Set(cache.keys());
+		items = listValue.map((value, index) => {
+			const key = props.getKey!(value, index);
+			removed.delete(key);
+			let entry = cache.get(key);
+			if (!entry) {
+				const i = signal(index);
+				entry = {
+					v: value,
+					i,
+					vnode: <Item key={key} v={value} i={i} children={props.children} />,
+				};
+				cache.set(key, entry);
+			} else {
+				if (entry.i.peek() !== index) {
+					// Index changed (e.g. an earlier item was removed/reordered). Push
+					// the new index through the per-item signal so the cached vnode is
+					// reused and the child re-renders reactively instead of being
+					// recreated.
+					entry.i.value = index;
+				}
+				if (entry.v !== value) {
+					// Same key, new item value: recreate the vnode so the child sees
+					// the new value while the stable key preserves DOM identity.
+					entry.v = value;
+					entry.vnode = (
+						<Item key={key} v={value} i={entry.i} children={props.children} />
+					);
+				}
+			}
+			return entry.vnode;
+		});
+		removed.forEach(key => {
+			cache.delete(key);
+		});
+	} else {
+		// Without getKey the cache follows item identity so reordered items keep
+		// their DOM/state. Duplicate items get one cache entry per occurrence,
+		// and keys are minted from a counter so a key is never reused for a
+		// different item (a positional key could collide after remove + append).
+		const seen = new Map();
+		items = listValue.map((value, index) => {
+			const occurrence = seen.get(value) || 0;
+			seen.set(value, occurrence + 1);
+			let entries = cache.get(value);
+			if (!entries) cache.set(value, (entries = []));
+			let entry = entries[occurrence];
+			if (!entry) {
+				const i = signal(index);
+				entries[occurrence] = entry = {
+					i,
+					vnode: (
+						<Item
+							key={state.nextKey++}
+							v={value}
+							i={i}
+							children={props.children}
+						/>
+					),
+				};
+			} else if (entry.i.peek() !== index) {
+				entry.i.value = index;
+			}
+			return entry.vnode;
+		});
+		// Drop cache entries for items (and duplicate occurrences) that left
+		// the list.
+		cache.forEach((entries, value) => {
+			const used = seen.get(value) || 0;
+			if (used === 0) cache.delete(value);
+			else if (entries.length > used) entries.length = used;
+		});
+	}
 
 	return createElement(Fragment, null, items);
 }

--- a/packages/preact/utils/test/browser/index.test.tsx
+++ b/packages/preact/utils/test/browser/index.test.tsx
@@ -264,6 +264,91 @@ describe("@preact/signals-utils", () => {
 			expect(bobNodeAfter).to.equal(bobNodeBefore);
 		});
 
+		it("Should render duplicate primitive items as separate entries", () => {
+			const list = signal(["A", "B", "A"]);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+			act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item}:{index}
+							</Paragraph>
+						)}
+					</For>,
+					scratch
+				);
+			});
+			expect(scratch.innerHTML).to.eq("<p>A:0</p><p>B:1</p><p>A:2</p>");
+
+			// Removing one duplicate must keep the other occurrence intact.
+			act(() => {
+				list.value = ["B", "A"];
+			});
+			expect(scratch.innerHTML).to.eq("<p>B:0</p><p>A:1</p>");
+		});
+
+		it("Should not reuse keys for new items after removal without getKey", () => {
+			const list = signal(["A", "B", "C"]);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+			act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item}:{index}
+							</Paragraph>
+						)}
+					</For>,
+					scratch
+				);
+			});
+			const aNode = scratch.querySelectorAll("p")[0];
+			const bNode = scratch.querySelectorAll("p")[1];
+			const cNode = scratch.querySelectorAll("p")[2];
+
+			// Remove A and prepend a new item. With frozen positional keys the new
+			// item would collide with A's key and inherit A's DOM node and state.
+			act(() => {
+				list.value = ["D", "B", "C"];
+			});
+			expect(scratch.innerHTML).to.eq("<p>D:0</p><p>B:1</p><p>C:2</p>");
+			expect(scratch.querySelectorAll("p")[0]).not.to.equal(aNode);
+			expect(scratch.querySelectorAll("p")[1]).to.equal(bNode);
+			expect(scratch.querySelectorAll("p")[2]).to.equal(cNode);
+
+			// Remove the head and append: the appended item must not collide with
+			// C's creation-time key either.
+			act(() => {
+				list.value = ["B", "C", "E"];
+			});
+			expect(scratch.innerHTML).to.eq("<p>B:0</p><p>C:1</p><p>E:2</p>");
+			expect(scratch.querySelectorAll("p")[0]).to.equal(bNode);
+			expect(scratch.querySelectorAll("p")[1]).to.equal(cNode);
+		});
+
+		it("Should re-render an item when its value changes for the same key", () => {
+			const list = signal([{ id: "a", label: "Alice" }]);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+			act(() => {
+				render(
+					<For each={list} getKey={item => item.id}>
+						{item => <Paragraph>{item.label}</Paragraph>}
+					</For>,
+					scratch
+				);
+			});
+			const node = scratch.querySelector("p");
+			expect(scratch.innerHTML).to.eq("<p>Alice</p>");
+
+			act(() => {
+				list.value = [{ id: "a", label: "Alicia" }];
+			});
+			expect(scratch.innerHTML).to.eq("<p>Alicia</p>");
+			// The stable key must preserve the DOM node.
+			expect(scratch.querySelector("p")).to.equal(node);
+		});
+
 		it("Should use getKey for stable identity on item removal", () => {
 			const list = signal([
 				{ id: "a", label: "Alice" },

--- a/packages/react/utils/src/index.tsx
+++ b/packages/react/utils/src/index.tsx
@@ -47,7 +47,12 @@ interface ForProps<T> {
 
 export function For<T>(props: ForProps<T>): JSX.Element | null {
 	useSignals();
-	const cache = useMemo(() => new Map(), []);
+	const hasGetKey = !!props.getKey;
+	const state = useMemo(
+		() => ({ cache: new Map(), nextKey: 0 }),
+		// The cache layout differs between keyed and unkeyed mode.
+		[hasGetKey]
+	);
 	const list = (typeof props.each === "function" ? props.each() : props.each) as
 		| Signal<Array<T>>
 		| Array<T>;
@@ -56,31 +61,85 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 
 	if (!listValue.length) return (props.fallback as JSX.Element) || null;
 
-	const removed = new Set(cache.keys());
+	const cache = state.cache;
+	let items: ReactNode[];
 
-	const items = listValue.map((value, index) => {
-		removed.delete(value);
-		let entry = cache.get(value);
-		if (!entry) {
-			const i = signal(index);
-			const key = props.getKey ? props.getKey(value, index) : index;
-			const vnode = (
-				<Item v={value} key={key} i={i} children={props.children} />
-			);
-			entry = { vnode, i };
-			cache.set(value, entry);
-		} else if (entry.i.peek() !== index) {
-			// Index changed (e.g. an earlier item was removed/reordered). Push the
-			// new index through the per-item signal so the cached vnode is reused
-			// and the child re-renders reactively instead of being recreated.
-			entry.i.value = index;
-		}
-		return entry.vnode;
-	});
-
-	removed.forEach(value => {
-		cache.delete(value);
-	});
+	if (props.getKey) {
+		// The cache is keyed by the user-provided key, so duplicate or replaced
+		// item values with the same key resolve to one stable entry.
+		const removed = new Set(cache.keys());
+		items = listValue.map((value, index) => {
+			const key = props.getKey!(value, index);
+			removed.delete(key);
+			let entry = cache.get(key);
+			if (!entry) {
+				const i = signal(index);
+				entry = {
+					v: value,
+					i,
+					vnode: <Item v={value} key={key} i={i} children={props.children} />,
+				};
+				cache.set(key, entry);
+			} else {
+				if (entry.i.peek() !== index) {
+					// Index changed (e.g. an earlier item was removed/reordered). Push
+					// the new index through the per-item signal so the cached vnode is
+					// reused and the child re-renders reactively instead of being
+					// recreated.
+					entry.i.value = index;
+				}
+				if (entry.v !== value) {
+					// Same key, new item value: recreate the vnode so the child sees
+					// the new value while the stable key preserves DOM identity.
+					entry.v = value;
+					entry.vnode = (
+						<Item v={value} key={key} i={entry.i} children={props.children} />
+					);
+				}
+			}
+			return entry.vnode;
+		});
+		removed.forEach(key => {
+			cache.delete(key);
+		});
+	} else {
+		// Without getKey the cache follows item identity so reordered items keep
+		// their DOM/state. Duplicate items get one cache entry per occurrence,
+		// and keys are minted from a counter so a key is never reused for a
+		// different item (a positional key could collide after remove + append).
+		const seen = new Map();
+		items = listValue.map((value, index) => {
+			const occurrence = seen.get(value) || 0;
+			seen.set(value, occurrence + 1);
+			let entries = cache.get(value);
+			if (!entries) cache.set(value, (entries = []));
+			let entry = entries[occurrence];
+			if (!entry) {
+				const i = signal(index);
+				entries[occurrence] = entry = {
+					i,
+					vnode: (
+						<Item
+							v={value}
+							key={state.nextKey++}
+							i={i}
+							children={props.children}
+						/>
+					),
+				};
+			} else if (entry.i.peek() !== index) {
+				entry.i.value = index;
+			}
+			return entry.vnode;
+		});
+		// Drop cache entries for items (and duplicate occurrences) that left
+		// the list.
+		cache.forEach((entries, value) => {
+			const used = seen.get(value) || 0;
+			if (used === 0) cache.delete(value);
+			else if (entries.length > used) entries.length = used;
+		});
+	}
 
 	return createElement(Fragment, { children: items });
 }

--- a/packages/react/utils/test/browser/index.test.tsx
+++ b/packages/react/utils/test/browser/index.test.tsx
@@ -294,6 +294,88 @@ describe("@preact/signals-react-utils", () => {
 			expect(bobNodeAfter).to.equal(bobNodeBefore);
 		});
 
+		it("Should render duplicate primitive items as separate entries", async () => {
+			const list = signal(["A", "B", "A"]);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+			await act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item}:{index}
+							</Paragraph>
+						)}
+					</For>
+				);
+			});
+			expect(scratch.innerHTML).to.eq("<p>A:0</p><p>B:1</p><p>A:2</p>");
+
+			// Removing one duplicate must keep the other occurrence intact.
+			await act(() => {
+				list.value = ["B", "A"];
+			});
+			expect(scratch.innerHTML).to.eq("<p>B:0</p><p>A:1</p>");
+		});
+
+		it("Should not reuse keys for new items after removal without getKey", async () => {
+			const list = signal(["A", "B", "C"]);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+			await act(() => {
+				render(
+					<For each={list}>
+						{(item, index) => (
+							<Paragraph>
+								{item}:{index}
+							</Paragraph>
+						)}
+					</For>
+				);
+			});
+			const aNode = scratch.querySelectorAll("p")[0];
+			const bNode = scratch.querySelectorAll("p")[1];
+			const cNode = scratch.querySelectorAll("p")[2];
+
+			// Remove A and prepend a new item. With frozen positional keys the new
+			// item would collide with A's key and inherit A's DOM node and state.
+			await act(() => {
+				list.value = ["D", "B", "C"];
+			});
+			expect(scratch.innerHTML).to.eq("<p>D:0</p><p>B:1</p><p>C:2</p>");
+			expect(scratch.querySelectorAll("p")[0]).not.to.equal(aNode);
+			expect(scratch.querySelectorAll("p")[1]).to.equal(bNode);
+			expect(scratch.querySelectorAll("p")[2]).to.equal(cNode);
+
+			// Remove the head and append: the appended item must not collide with
+			// C's creation-time key either.
+			await act(() => {
+				list.value = ["B", "C", "E"];
+			});
+			expect(scratch.innerHTML).to.eq("<p>B:0</p><p>C:1</p><p>E:2</p>");
+			expect(scratch.querySelectorAll("p")[0]).to.equal(bNode);
+			expect(scratch.querySelectorAll("p")[1]).to.equal(cNode);
+		});
+
+		it("Should re-render an item when its value changes for the same key", async () => {
+			const list = signal([{ id: "a", label: "Alice" }]);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+			await act(() => {
+				render(
+					<For each={list} getKey={item => item.id}>
+						{item => <Paragraph>{item.label}</Paragraph>}
+					</For>
+				);
+			});
+			const node = scratch.querySelector("p");
+			expect(scratch.innerHTML).to.eq("<p>Alice</p>");
+
+			await act(() => {
+				list.value = [{ id: "a", label: "Alicia" }];
+			});
+			expect(scratch.innerHTML).to.eq("<p>Alicia</p>");
+			// The stable key must preserve the DOM node.
+			expect(scratch.querySelector("p")).to.equal(node);
+		});
+
 		it("Should use getKey for stable identity on item removal", async () => {
 			const list = signal([
 				{ id: "a", label: "Alice" },


### PR DESCRIPTION
## Root cause

`For`'s item cache is a `Map` keyed by item identity, with the vnode `key` computed once on cache miss (defaulting to the item's creation-time index) and frozen into the cached vnode forever. Two consequences:

1. **Duplicate items collapse.** `each={signal(["A", "B", "A"])}` — the shape of the README example — resolves both `"A"`s to one cache entry: the identical vnode object is emitted twice with duplicate keys, and the single shared index signal ends up holding the last occurrence's index, so both rows render the same index.
2. **Frozen keys collide.** After `["A","B","C"]` → `["D","B","C"]`, the new item D is keyed by its index (0), which is removed A's frozen key — the reconciler hands A's DOM node and state (input value, focus, checkbox state) to D.

## Fix

Two cache layouts, picked by whether `getKey` is provided:

- **Without `getKey`** the cache still follows item identity (reordered items keep their DOM/state, per the existing DOM-identity test), but each occurrence of a duplicate item gets its own entry with its own index signal, and vnode keys are minted from a monotonic counter so a key is never reused for a different item.
- **With `getKey`** the cache is keyed by the user-provided key, so replaced item values with a stable key reuse one entry, and the row vnode is recreated (same key, so DOM is preserved) when the item value behind a key changes.

Applied to both `@preact/signals/utils` and `@preact/signals-react/utils`, with regression tests in both suites.

Note: this PR was authored by Claude and @JoviDeCroock.