### PR TITLE
Allow For to accept readonly arrays

### DIFF
--- a/.changeset/readonly-for-inputs.md
+++ b/.changeset/readonly-for-inputs.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals": patch
+"@preact/signals-react": patch
+---
+
+Allow `<For>` to accept readonly arrays and signals containing readonly arrays.

--- a/packages/preact/utils/src/index.tsx
+++ b/packages/preact/utils/src/index.tsx
@@ -28,11 +28,13 @@ export function Show<T = boolean>(
 
 Show.displayName = "Show";
 
+type ForEach<T> =
+	| ReadonlyArray<T>
+	| Signal<ReadonlyArray<T>>
+	| ReadonlySignal<ReadonlyArray<T>>;
+
 interface ForProps<T> {
-	each:
-		| Signal<Array<T>>
-		| ReadonlySignal<Array<T>>
-		| (() => Array<T> | Signal<Array<T>> | ReadonlySignal<Array<T>>);
+	each: ForEach<T> | (() => ForEach<T>);
 	fallback?: ComponentChildren;
 	getKey?: (item: T, index: number) => string | number;
 	children: (value: T, index: number) => ComponentChildren;
@@ -41,8 +43,8 @@ interface ForProps<T> {
 export function For<T>(props: ForProps<T>): ComponentChildren | null {
 	const cache = useMemo(() => new Map(), []);
 	const list = (typeof props.each === "function" ? props.each() : props.each) as
-		| Signal<Array<T>>
-		| Array<T>;
+		| Signal<ReadonlyArray<T>>
+		| ReadonlyArray<T>;
 
 	const listValue = list instanceof Signal ? list.value : list;
 

--- a/packages/preact/utils/test/browser/index.test.tsx
+++ b/packages/preact/utils/test/browser/index.test.tsx
@@ -164,6 +164,30 @@ describe("@preact/signals-utils", () => {
 			);
 		});
 
+		it("Should accept readonly list types", () => {
+			const plain: readonly string[] = ["foo", "bar"];
+			const list = signal<readonly string[]>(["baz", "qux"]);
+			const computedList = computed((): readonly string[] => list.value);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			act(() => {
+				render(
+					<div>
+						<For each={plain}>{item => <Paragraph>{item}</Paragraph>}</For>
+						<For each={list}>{item => <Paragraph>{item}</Paragraph>}</For>
+						<For each={() => computedList}>
+							{item => <Paragraph>{item}</Paragraph>}
+						</For>
+					</div>,
+					scratch
+				);
+			});
+
+			expect(scratch.innerHTML).to.eq(
+				"<div><p>foo</p><p>bar</p><p>baz</p><p>qux</p><p>baz</p><p>qux</p></div>"
+			);
+		});
+
 		it("Should pass updated indexes to reused items after removal", () => {
 			const alice = { id: "a", label: "Alice" };
 			const bob = { id: "b", label: "Bob" };

--- a/packages/react/utils/src/index.tsx
+++ b/packages/react/utils/src/index.tsx
@@ -35,11 +35,13 @@ export function Show<T = boolean>(props: ShowProps<T>): JSX.Element | null {
 
 Show.displayName = "Show";
 
+type ForEach<T> =
+	| ReadonlyArray<T>
+	| Signal<ReadonlyArray<T>>
+	| ReadonlySignal<ReadonlyArray<T>>;
+
 interface ForProps<T> {
-	each:
-		| Signal<Array<T>>
-		| ReadonlySignal<Array<T>>
-		| (() => Array<T> | Signal<Array<T>> | ReadonlySignal<Array<T>>);
+	each: ForEach<T> | (() => ForEach<T>);
 	fallback?: ReactNode;
 	getKey?: (item: T, index: number) => string | number;
 	children: (value: T, index: number) => ReactNode;
@@ -49,8 +51,8 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 	useSignals();
 	const cache = useMemo(() => new Map(), []);
 	const list = (typeof props.each === "function" ? props.each() : props.each) as
-		| Signal<Array<T>>
-		| Array<T>;
+		| Signal<ReadonlyArray<T>>
+		| ReadonlyArray<T>;
 
 	const listValue = list instanceof Signal ? list.value : list;
 

--- a/packages/react/utils/test/browser/index.test.tsx
+++ b/packages/react/utils/test/browser/index.test.tsx
@@ -197,6 +197,29 @@ describe("@preact/signals-react-utils", () => {
 			);
 		});
 
+		it("Should accept readonly list types", async () => {
+			const plain: readonly string[] = ["foo", "bar"];
+			const list = signal<readonly string[]>(["baz", "qux"]);
+			const computedList = computed((): readonly string[] => list.value);
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			await act(() => {
+				render(
+					<div>
+						<For each={plain}>{item => <Paragraph>{item}</Paragraph>}</For>
+						<For each={list}>{item => <Paragraph>{item}</Paragraph>}</For>
+						<For each={() => computedList}>
+							{item => <Paragraph>{item}</Paragraph>}
+						</For>
+					</div>
+				);
+			});
+
+			expect(scratch.innerHTML).to.eq(
+				"<div><p>foo</p><p>bar</p><p>baz</p><p>qux</p><p>baz</p><p>qux</p></div>"
+			);
+		});
+
 		it("Should pass updated indexes to reused items after removal", async () => {
 			const alice = { id: "a", label: "Alice" };
 			const bob = { id: "b", label: "Bob" };


### PR DESCRIPTION
## Summary
- Expand `<For>` accepted list types to `ReadonlyArray<T>` for direct arrays, signals, readonly signals, and function-returned list sources
- Keep Preact and React utility implementations in sync
- Add browser utility tests for direct readonly arrays, `signal<readonly T[]>`, and computed readonly signals
- Add a patch changeset for `@preact/signals` and `@preact/signals-react`

Without this change, attempting to use a `readonly` array with `For` results in a `TS 2322` (due to assigning `readonly T[]` to `T[]`).

PR was created in collaboration with AI (Codex GPT 5.5), which was used to generate the `.changeset/readonly-for-inputs.md` and unit tests. PR was opened in draft, manually audited, and then opened for wider review