### PR TITLE
Remove seeing useContext as HOOKS_STATE

### DIFF
--- a/.changeset/lucky-pears-brake.md
+++ b/.changeset/lucky-pears-brake.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Stop treating `useContext` as hook state in the auto-memoization heuristic. Context updates force-update their subscribers in Preact, bypassing `shouldComponentUpdate` entirely, so context consumers can safely keep the props-based render skipping.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -389,7 +389,7 @@ hook(OptionsTypes.UNMOUNT, (old, vnode: VNode) => {
 
 /** Mark components that use hook state so we can skip sCU optimization. */
 hook(OptionsTypes.HOOK, (old, component, index, type) => {
-	if (type < 3 || type === 9)
+	if (type < 3)
 		(component as AugmentedComponent)._updateFlags |= HAS_HOOK_STATE;
 	old(component, index, type);
 });


### PR DESCRIPTION
The `HAS_HOOK_STATE` flag exists so the auto-`shouldComponentUpdate` optimization never skips a render carrying pending hook state. `useContext` (hook type 9) doesn't need this guard: when a provider's value changes, Preact force-updates every subscriber, bypassing `shouldComponentUpdate` entirely (https://github.com/preactjs/preact/blob/main/src/create-context.js#L24).

Flagging context consumers as stateful only disabled the props-based render skipping for them. Common combinations like signals + theme/router context lost the optimization for no correctness benefit. With the flag removed, context updates still propagate (covered by the "signals should not stop context from propagating" test) while parent-driven re-renders with unchanged props can be skipped again.