### PR TITLE
Name internal Preact signals

### DIFF
--- a/.changeset/friendly-signals-debug.md
+++ b/.changeset/friendly-signals-debug.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Name signals created internally by the Preact adapter and `useLiveSignal` so debugging tools can identify them.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -108,6 +108,7 @@ function SignalValue(this: AugmentedComponent, { data }: { data: Signal }) {
 	// Store the props.data signal in another signal so that
 	// passing a new signal reference re-runs the text computed:
 	const currentSignal = useSignal(data);
+	currentSignal.name = "ReactiveDom";
 	currentSignal.value = data;
 
 	const [isText, s] = useMemo(() => {

--- a/packages/preact/utils/src/index.tsx
+++ b/packages/preact/utils/src/index.tsx
@@ -86,6 +86,7 @@ For.displayName = "For";
 
 export function useLiveSignal<T>(value: T): Signal<T> {
 	const s = useSignal(value);
+	s.name = "useLiveSignal";
 	if (s.peek() !== value) s.value = value;
 	return s;
 }


### PR DESCRIPTION
Internal signals created by the Preact adapter and `useLiveSignal` appear under minified names in debugging tools.

Assign stable `ReactiveDom` and `useLiveSignal` names so they are identifiable.