### PR TITLE
Add fallback names to signal transforms

### DIFF
--- a/.changeset/calm-effects-debug.md
+++ b/.changeset/calm-effects-debug.md
@@ -1,0 +1,6 @@
+---
+"@preact/signals-preact-transform": patch
+"@preact/signals-react-transform": patch
+---
+
+Name effects and signal effects during debug transforms, and use their source location when no contextual name can be derived.

--- a/packages/preact-transform/src/index.ts
+++ b/packages/preact-transform/src/index.ts
@@ -19,14 +19,16 @@ function basename(filename: string | undefined): string | undefined {
 function isSignalCall(path: NodePath<BabelTypes.CallExpression>): boolean {
 	const callee = path.get("callee");
 
-	// Check direct function calls like signal(), computed(), useSignal(), useComputed()
+	// Check direct calls to APIs that accept debug names.
 	if (callee.isIdentifier()) {
 		const name = callee.node.name;
 		return (
 			name === "signal" ||
 			name === "computed" ||
+			name === "effect" ||
 			name === "useSignal" ||
-			name === "useComputed"
+			name === "useComputed" ||
+			name === "useSignalEffect"
 		);
 	}
 
@@ -141,8 +143,24 @@ function getSignalNameFromContext(
 		currentPath = currentPath.parentPath;
 	}
 
-	const callee = path.get("callee");
-	return callee.isIdentifier() ? callee.node.name : null;
+	return null;
+}
+
+function getSignalName(
+	path: NodePath<BabelTypes.CallExpression>,
+	filename: string | undefined
+): string | null {
+	const contextName = getSignalNameFromContext(path);
+	const baseName = basename(filename);
+	const lineNumber = path.node.loc?.start.line;
+
+	if (baseName && lineNumber) {
+		return contextName
+			? `${contextName} (${baseName}:${lineNumber})`
+			: `${baseName}:${lineNumber}`;
+	}
+
+	return contextName;
 }
 
 function shouldSkipNameInjection(
@@ -174,21 +192,9 @@ function shouldSkipNameInjection(
 function injectSignalName(
 	t: typeof BabelTypes,
 	path: NodePath<BabelTypes.CallExpression>,
-	variableName: string,
-	filename: string | undefined
+	nameValue: string
 ): void {
 	const args = path.get("arguments");
-
-	// Create enhanced name with filename and line number
-	let nameValue = variableName;
-	if (filename) {
-		const baseName = basename(filename);
-		const lineNumber = path.node.loc?.start.line;
-		if (baseName && lineNumber) {
-			nameValue = `${variableName} (${baseName}:${lineNumber})`;
-		}
-	}
-
 	const name = t.stringLiteral(nameValue);
 
 	if (args.length === 0) {
@@ -229,10 +235,8 @@ export default function signalsTransform(
 
 					// Only inject name if it doesn't already have one
 					if (!shouldSkipNameInjection(t, args)) {
-						const signalName = getSignalNameFromContext(path);
-						if (signalName) {
-							injectSignalName(t, path, signalName, this.filename);
-						}
+						const signalName = getSignalName(path, this.filename);
+						if (signalName) injectSignalName(t, path, signalName);
 					}
 				}
 			},

--- a/packages/preact-transform/test/node/index.test.tsx
+++ b/packages/preact-transform/test/node/index.test.tsx
@@ -175,6 +175,9 @@ describe("Preact Signals Babel Transform", () => {
 				"const preserved = signal(0, options);",
 				"const spread = signal(0, {...options});",
 				"[first] = [signal(0)];",
+				"effect(() => {});",
+				"useSignalEffect(() => {});",
+				'effect(() => {}, {name: "manual"});',
 			].join("\n");
 
 			const output = transformCode(inputCode, DEBUG_OPTIONS, "Models.js");
@@ -189,17 +192,20 @@ describe("Preact Signals Babel Transform", () => {
 				"label (Models.js:14)",
 				"0 (Models.js:15)",
 				"createVisible (Models.js:18)",
-				"signal (Models.js:20)",
+				"Models.js:20",
 				"createSelected (Models.js:21)",
-				"signal (Models.js:22)",
-				"computed (Models.js:24)",
-				"signal (Models.js:28)",
+				"Models.js:22",
+				"Models.js:24",
+				"Models.js:28",
+				"Models.js:29",
+				"Models.js:30",
 			]) {
 				expect(output).toContain(`name: "${expectedName}"`);
 			}
 			expect(output).toContain("const preserved = signal(0, options);");
 			expect(output).not.toContain("preserved (Models.js:26)");
 			expect(output).not.toContain("spread (Models.js:27)");
+			expect(output).toContain('name: "manual"');
 		});
 	});
 });

--- a/packages/react-transform/src/index.ts
+++ b/packages/react-transform/src/index.ts
@@ -404,14 +404,16 @@ function isJSXAlternativeCall(
 function isSignalCall(path: NodePath<BabelTypes.CallExpression>): boolean {
 	const callee = path.get("callee");
 
-	// Check direct function calls like signal(), computed(), useSignal(), useComputed()
+	// Check direct calls to APIs that accept debug names.
 	if (callee.isIdentifier()) {
 		const name = callee.node.name;
 		return (
 			name === "signal" ||
 			name === "computed" ||
+			name === "effect" ||
 			name === "useSignal" ||
-			name === "useComputed"
+			name === "useComputed" ||
+			name === "useSignalEffect"
 		);
 	}
 
@@ -526,8 +528,24 @@ function getSignalNameFromContext(
 		currentPath = currentPath.parentPath;
 	}
 
-	const callee = path.get("callee");
-	return callee.isIdentifier() ? callee.node.name : null;
+	return null;
+}
+
+function getSignalName(
+	path: NodePath<BabelTypes.CallExpression>,
+	filename: string | undefined
+): string | null {
+	const contextName = getSignalNameFromContext(path);
+	const baseName = basename(filename);
+	const lineNumber = path.node.loc?.start.line;
+
+	if (baseName && lineNumber) {
+		return contextName
+			? `${contextName} (${baseName}:${lineNumber})`
+			: `${baseName}:${lineNumber}`;
+	}
+
+	return contextName;
 }
 
 function shouldSkipNameInjection(
@@ -559,21 +577,9 @@ function shouldSkipNameInjection(
 function injectSignalName(
 	t: typeof BabelTypes,
 	path: NodePath<BabelTypes.CallExpression>,
-	variableName: string,
-	filename: string | undefined
+	nameValue: string
 ): void {
 	const args = path.get("arguments");
-
-	// Create enhanced name with filename and line number
-	let nameValue = variableName;
-	if (filename) {
-		const baseName = basename(filename);
-		const lineNumber = path.node.loc?.start.line;
-		if (baseName && lineNumber) {
-			nameValue = `${variableName} (${baseName}:${lineNumber})`;
-		}
-	}
-
 	const name = t.stringLiteral(nameValue);
 
 	if (args.length === 0) {
@@ -994,10 +1000,8 @@ export default function signalsTransform(
 
 					// Only inject name if it doesn't already have one
 					if (!shouldSkipNameInjection(t, args)) {
-						const signalName = getSignalNameFromContext(path);
-						if (signalName) {
-							injectSignalName(t, path, signalName, this.filename);
-						}
+						const signalName = getSignalName(path, this.filename);
+						if (signalName) injectSignalName(t, path, signalName);
 					}
 				}
 			},

--- a/packages/react-transform/test/node/index.test.tsx
+++ b/packages/react-transform/test/node/index.test.tsx
@@ -1095,6 +1095,9 @@ describe("React Signals Babel Transform", () => {
 				"const preserved = signal(0, options);",
 				"const spread = signal(0, {...options});",
 				"[first] = [signal(0)];",
+				"effect(() => {});",
+				"useSignalEffect(() => {});",
+				'effect(() => {}, {name: "manual"});',
 			].join("\n");
 
 			const output = transformCode(inputCode, DEBUG_OPTIONS, "Models.js");
@@ -1109,17 +1112,20 @@ describe("React Signals Babel Transform", () => {
 				"label (Models.js:14)",
 				"0 (Models.js:15)",
 				"createVisible (Models.js:18)",
-				"signal (Models.js:20)",
+				"Models.js:20",
 				"createSelected (Models.js:21)",
-				"signal (Models.js:22)",
-				"computed (Models.js:24)",
-				"signal (Models.js:28)",
+				"Models.js:22",
+				"Models.js:24",
+				"Models.js:28",
+				"Models.js:29",
+				"Models.js:30",
 			]) {
 				expect(output).toContain(`name: "${expectedName}"`);
 			}
 			expect(output).toContain("const preserved = signal(0, options);");
 			expect(output).not.toContain("preserved (Models.js:26)");
 			expect(output).not.toContain("spread (Models.js:27)");
+			expect(output).toContain('name: "manual"');
 		});
 	});
 


### PR DESCRIPTION
Unnamed effects and reactive primitives are difficult to identify in debugging tools when the transform cannot derive a contextual name.

Transform effects and signal effects too, and fall back to `file:line` while preserving explicit names.