### PR TITLE
Focus large dependency graphs

### DIFF
--- a/.changeset/quiet-graphs-focus.md
+++ b/.changeset/quiet-graphs-focus.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-devtools-ui": minor
+---
+
+Focus large dependency graphs on a searched or selected node and its direct dependencies and dependents, while keeping the full graph available on demand.

--- a/packages/devtools-ui/src/components/Graph.tsx
+++ b/packages/devtools-ui/src/components/Graph.tsx
@@ -18,6 +18,8 @@ const NODE_COLUMN_SPACING = 160;
 const NODE_ROW_SPACING = 120;
 const LAYER_SPACING = 250;
 const GRAPH_PADDING = 100;
+export const LARGE_GRAPH_THRESHOLD = 200;
+const MAX_SEARCH_RESULTS = 20;
 
 interface Point {
 	x: number;
@@ -104,6 +106,39 @@ export const calculateFitTransform = (
 	};
 };
 
+export const filterGraphToNeighborhood = (
+	graph: GraphData,
+	focalNodeId: string,
+	hops = 1
+): GraphData => {
+	const visibleNodeIds = new Set([focalNodeId]);
+	let frontier = new Set([focalNodeId]);
+
+	for (let hop = 0; hop < hops && frontier.size > 0; hop++) {
+		const nextFrontier = new Set<string>();
+
+		for (const link of graph.links) {
+			if (frontier.has(link.source) && !visibleNodeIds.has(link.target)) {
+				visibleNodeIds.add(link.target);
+				nextFrontier.add(link.target);
+			}
+			if (frontier.has(link.target) && !visibleNodeIds.has(link.source)) {
+				visibleNodeIds.add(link.source);
+				nextFrontier.add(link.source);
+			}
+		}
+
+		frontier = nextFrontier;
+	}
+
+	return {
+		nodes: graph.nodes.filter(node => visibleNodeIds.has(node.id)),
+		links: graph.links.filter(
+			link => visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target)
+		),
+	};
+};
+
 const copyToClipboard = (text: string) => {
 	const copyEl = document.createElement("textarea");
 	try {
@@ -129,6 +164,9 @@ export function GraphVisualization() {
 	const isPanning = useSignal(false);
 	const startPan = useSignal({ x: 0, y: 0 });
 	const showExportMenu = useSignal(false);
+	const selectedNodeId = useSignal<string>();
+	const showLargeFullGraph = useSignal(false);
+	const searchTerm = useSignal("");
 	const toastText = useSignal<string>();
 	const hoveredNode = useSignal<GraphNode | null>(null);
 	const tooltipPos = useSignal({ x: 0, y: 0 });
@@ -343,7 +381,7 @@ export function GraphVisualization() {
 		}
 	};
 
-	const graphData = useComputed<GraphRenderData>(() => {
+	const topologyData = useComputed<GraphData>(() => {
 		const rawUpdates = updates.value;
 		const disposed = disposedSignalIds.value;
 		const showDisposed = settingsStore.showDisposedSignals.value;
@@ -420,7 +458,53 @@ export function GraphVisualization() {
 			}
 		}
 
-		const allLinks = Array.from(links.values());
+		return {
+			nodes: Array.from(nodes.values()),
+			links: Array.from(links.values()),
+		};
+	});
+
+	const selectedNode = useComputed(() =>
+		topologyData.value.nodes.find(node => node.id === selectedNodeId.value)
+	);
+	const isLargeGraphHidden = useComputed(
+		() =>
+			topologyData.value.nodes.length > LARGE_GRAPH_THRESHOLD &&
+			!selectedNode.value &&
+			!showLargeFullGraph.value
+	);
+	const searchResults = useComputed(() => {
+		const query = searchTerm.value.trim().toLowerCase();
+		if (!query) return [];
+
+		return topologyData.value.nodes
+			.filter(node => node.name.toLowerCase().includes(query))
+			.sort((a, b) => {
+				const aStartsWithQuery = a.name.toLowerCase().startsWith(query);
+				const bStartsWithQuery = b.name.toLowerCase().startsWith(query);
+				if (aStartsWithQuery !== bStartsWithQuery) {
+					return aStartsWithQuery ? -1 : 1;
+				}
+				return a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+			})
+			.slice(0, MAX_SEARCH_RESULTS);
+	});
+	const visibleTopologyData = useComputed<GraphData>(() => {
+		if (selectedNode.value) {
+			return filterGraphToNeighborhood(
+				topologyData.value,
+				selectedNode.value.id
+			);
+		}
+		if (isLargeGraphHidden.value) return { nodes: [], links: [] };
+		return topologyData.value;
+	});
+
+	const graphData = useComputed<GraphRenderData>(() => {
+		const nodes = new Map(
+			visibleTopologyData.value.nodes.map(node => [node.id, { ...node }])
+		);
+		const allLinks = visibleTopologyData.value.links;
 
 		// Compute proper layers using topological sort
 		const nodeLayers = computeNodeLayers(nodes, allLinks);
@@ -635,6 +719,28 @@ export function GraphVisualization() {
 		fitView();
 	};
 
+	const focusNode = (nodeId: string) => {
+		selectedNodeId.value = nodeId;
+		showLargeFullGraph.value = false;
+		searchTerm.value = "";
+		hoveredNode.value = null;
+		hasUserAdjustedView.value = false;
+	};
+
+	const clearFocus = () => {
+		selectedNodeId.value = undefined;
+		showLargeFullGraph.value = false;
+		hoveredNode.value = null;
+		hasUserAdjustedView.value = false;
+	};
+
+	const showFullGraph = () => {
+		selectedNodeId.value = undefined;
+		showLargeFullGraph.value = true;
+		hoveredNode.value = null;
+		hasUserAdjustedView.value = false;
+	};
+
 	const toggleExportMenu = () => {
 		showExportMenu.value = !showExportMenu.value;
 	};
@@ -722,7 +828,7 @@ export function GraphVisualization() {
 		showToast("Copied to clipboard!");
 	};
 
-	if (graphData.value.nodes.length === 0) {
+	if (topologyData.value.nodes.length === 0) {
 		return (
 			<div className="graph-empty">
 				<div>
@@ -751,6 +857,19 @@ export function GraphVisualization() {
 				onWheel={handleWheel}
 				style={{ cursor: isPanning.value ? "grabbing" : "grab" }}
 			>
+				{isLargeGraphHidden.value && (
+					<div className="graph-large-state">
+						<div>
+							<h3>{topologyData.value.nodes.length} reactive nodes</h3>
+							<p>
+								Search for a node to inspect its direct dependencies and
+								dependents.
+							</p>
+							<button onClick={showFullGraph}>Show full graph</button>
+						</div>
+					</div>
+				)}
+
 				<svg
 					ref={svgRef}
 					className="graph-svg"
@@ -813,11 +932,13 @@ export function GraphVisualization() {
 										? node.name.slice(0, maxChars - 1) + "…"
 										: node.name;
 								const isHovered = hoveredNode.value?.id === node.id;
+								const isSelected = selectedNode.value?.id === node.id;
 
 								return (
 									<g
 										key={node.id}
-										className={`graph-node-group ${isHovered ? "hovered" : ""}`}
+										className={`graph-node-group ${isHovered ? "hovered" : ""} ${isSelected ? "selected" : ""}`}
+										onClick={() => focusNode(node.id)}
 										onMouseEnter={(e: MouseEvent) =>
 											handleNodeMouseEnter(node, e)
 										}
@@ -846,45 +967,102 @@ export function GraphVisualization() {
 					</g>
 				</svg>
 
-				<div className="graph-controls">
-					<button
-						className="graph-reset-button"
-						onClick={resetView}
-						title="Fit graph to viewport"
-					>
-						⟲ Fit View
-					</button>
-
-					<div ref={exportMenuRef} className="graph-export-container">
-						<button
-							className="graph-export-button"
-							onClick={toggleExportMenu}
-							title="Export graph"
-						>
-							↓ Export
-						</button>
-						{showExportMenu.value && (
-							<div className="graph-export-menu">
-								<button
-									className="graph-export-menu-item"
-									onClick={handleExportMermaid}
-								>
-									Mermaid
-								</button>
-								<button
-									className="graph-export-menu-item"
-									onClick={handleExportJSON}
-								>
-									JSON
-								</button>
+				<div
+					className="graph-controls"
+					onMouseDown={(event: MouseEvent) => event.stopPropagation()}
+				>
+					<div className="graph-search-container">
+						<input
+							type="search"
+							className="graph-search-input"
+							placeholder="Find a reactive node…"
+							aria-label="Find a reactive node"
+							value={searchTerm.value}
+							onInput={(event: Event) => {
+								searchTerm.value = (
+									event.currentTarget as HTMLInputElement
+								).value;
+							}}
+						/>
+						{searchTerm.value.trim() && (
+							<div className="graph-search-results">
+								{searchResults.value.length > 0 ? (
+									searchResults.value.map(node => (
+										<button
+											key={node.id}
+											className="graph-search-result"
+											onClick={() => focusNode(node.id)}
+										>
+											<span>{node.name}</span>
+											<small>
+												{node.type} · {node.id.slice(-7)}
+											</small>
+										</button>
+									))
+								) : (
+									<div className="graph-search-empty">No matching nodes</div>
+								)}
 							</div>
 						)}
 					</div>
 
-					<div className="graph-zoom-indicator" title="Zoom level">
-						{Math.round(zoom.value * 100)}%
-					</div>
+					{selectedNode.value && (
+						<button className="graph-focus-button" onClick={clearFocus}>
+							Clear focus
+						</button>
+					)}
+
+					{!isLargeGraphHidden.value && (
+						<>
+							<button
+								className="graph-reset-button"
+								onClick={resetView}
+								title="Fit graph to viewport"
+							>
+								⟲ Fit View
+							</button>
+
+							<div ref={exportMenuRef} className="graph-export-container">
+								<button
+									className="graph-export-button"
+									onClick={toggleExportMenu}
+									title="Export graph"
+								>
+									↓ Export
+								</button>
+								{showExportMenu.value && (
+									<div className="graph-export-menu">
+										<button
+											className="graph-export-menu-item"
+											onClick={handleExportMermaid}
+										>
+											Mermaid
+										</button>
+										<button
+											className="graph-export-menu-item"
+											onClick={handleExportJSON}
+										>
+											JSON
+										</button>
+									</div>
+								)}
+							</div>
+
+							<div className="graph-zoom-indicator" title="Zoom level">
+								{Math.round(zoom.value * 100)}%
+							</div>
+						</>
+					)}
 				</div>
+
+				{selectedNode.value && (
+					<div className="graph-focus-summary">
+						Showing {graphData.value.nodes.length} of{" "}
+						{topologyData.value.nodes.length} nodes around{" "}
+						<strong>{selectedNode.value.name}</strong>
+						<button onClick={showFullGraph}>Show all</button>
+					</div>
+				)}
 
 				{toastText.value && (
 					<div className="graph-toast">{toastText.value}</div>

--- a/packages/devtools-ui/src/styles.css
+++ b/packages/devtools-ui/src/styles.css
@@ -766,12 +766,79 @@ body {
   top: 16px;
   left: 16px;
   display: flex;
+  align-items: flex-start;
   gap: 8px;
   z-index: 10;
 }
 
+.graph-search-container {
+  position: relative;
+  width: min(280px, 40vw);
+}
+
+.graph-search-input {
+  box-sizing: border-box;
+  width: 100%;
+  background: var(--graph-controls-bg);
+  backdrop-filter: blur(4px);
+  border: 1px solid var(--graph-controls-border);
+  border-radius: 6px;
+  color: var(--graph-controls-text);
+  padding: 8px 10px;
+  font-size: 12px;
+  box-shadow: 0 2px 6px var(--shadow-light);
+}
+
+.graph-search-results {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  width: 100%;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--graph-export-bg);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  box-shadow: 0 8px 20px var(--shadow-color);
+}
+
+.graph-search-result {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border-primary);
+  color: var(--text-primary);
+  padding: 8px 10px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.graph-search-result:last-child {
+  border-bottom: 0;
+}
+
+.graph-search-result:hover {
+  background: var(--bg-primary);
+}
+
+.graph-search-result small,
+.graph-search-empty {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.graph-search-empty {
+  padding: 12px;
+}
+
 .graph-reset-button,
-.graph-export-button {
+.graph-export-button,
+.graph-focus-button,
+.graph-focus-summary button,
+.graph-large-state button {
   background: var(--graph-controls-bg);
   backdrop-filter: blur(4px);
   border: 1px solid var(--graph-controls-border);
@@ -786,7 +853,10 @@ body {
 }
 
 .graph-reset-button:hover,
-.graph-export-button:hover {
+.graph-export-button:hover,
+.graph-focus-button:hover,
+.graph-focus-summary button:hover,
+.graph-large-state button:hover {
   background: var(--bg-secondary);
   border-color: var(--border-secondary);
   box-shadow: 0 4px 8px var(--shadow-medium);
@@ -794,7 +864,10 @@ body {
 }
 
 .graph-reset-button:active,
-.graph-export-button:active {
+.graph-export-button:active,
+.graph-focus-button:active,
+.graph-focus-summary button:active,
+.graph-large-state button:active {
   background: var(--graph-controls-active);
   transform: translateY(1px);
 }
@@ -870,6 +943,11 @@ body {
 .graph-node-group.hovered .graph-node {
   filter: brightness(1.15) drop-shadow(0 4px 12px rgba(0, 0, 0, 0.25));
   stroke-width: 3;
+}
+
+.graph-node-group.selected .graph-node {
+  stroke: white;
+  stroke-width: 5;
 }
 
 /* Identity colors — same in both themes */
@@ -1047,14 +1125,62 @@ body {
   pointer-events: none;
 }
 
-.graph-empty {
-  padding: 32px 0;
+.graph-empty,
+.graph-large-state {
+  padding: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
   height: 100%;
+  box-sizing: border-box;
   text-align: center;
   color: var(--text-muted);
+}
+
+.graph-large-state {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+}
+
+.graph-large-state h3 {
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.graph-large-state p {
+  max-width: 440px;
+  margin: 0 auto 16px;
+}
+
+.graph-focus-summary {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: calc(100% - 32px);
+  transform: translateX(-50%);
+  background: var(--graph-controls-bg);
+  backdrop-filter: blur(4px);
+  border: 1px solid var(--graph-controls-border);
+  border-radius: 6px;
+  color: var(--graph-controls-text);
+  padding: 6px 8px 6px 12px;
+  font-size: 11px;
+  box-shadow: 0 2px 6px var(--shadow-light);
+}
+
+.graph-focus-summary strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-focus-summary button {
+  padding: 4px 8px;
 }
 
 .graph-toast {

--- a/packages/devtools-ui/test/browser/index.test.tsx
+++ b/packages/devtools-ui/test/browser/index.test.tsx
@@ -20,6 +20,7 @@ import {
 	GraphVisualization,
 	calculateFitTransform,
 	calculateGraphBounds,
+	filterGraphToNeighborhood,
 } from "../../src/components/Graph";
 import type {
 	DevToolsAdapter,
@@ -1002,6 +1003,37 @@ describe("@preact/signals-devtools-ui", () => {
 			expect(3000 * transform.zoom).to.be.at.most(400);
 			expect(transform.offset.x).to.be.greaterThan(0);
 		});
+
+		it("should extract the direct neighborhood around a node", () => {
+			const createNode = (id: string) => ({
+				id,
+				name: id,
+				type: "signal" as const,
+				x: 0,
+				y: 0,
+				depth: 0,
+			});
+			const neighborhood = filterGraphToNeighborhood(
+				{
+					nodes: ["upstream", "selected", "downstream", "second-hop"].map(
+						createNode
+					),
+					links: [
+						{ source: "upstream", target: "selected" },
+						{ source: "selected", target: "downstream" },
+						{ source: "downstream", target: "second-hop" },
+					],
+				},
+				"selected"
+			);
+
+			expect(neighborhood.nodes.map(node => node.id)).to.deep.equal([
+				"upstream",
+				"selected",
+				"downstream",
+			]);
+			expect(neighborhood.links).to.have.length(2);
+		});
 	});
 
 	describe("GraphVisualization - Dependency Node Creation", () => {
@@ -1125,7 +1157,7 @@ describe("@preact/signals-devtools-ui", () => {
 			expect(links.length).to.equal(2);
 		});
 
-		it("should wrap dense layers instead of shrinking them into a line", () => {
+		it("should wrap a dense full graph instead of shrinking it into a line", async () => {
 			initDevTools(mockAdapter);
 
 			const denseLayerUpdates = Array.from({ length: 1000 }, (_, index) => ({
@@ -1140,6 +1172,13 @@ describe("@preact/signals-devtools-ui", () => {
 
 			mockAdapter._emit("signalUpdate", denseLayerUpdates);
 			render(<GraphVisualization />, scratch);
+			await act(async () => {
+				(
+					scratch.querySelector(
+						".graph-large-state button"
+					) as HTMLButtonElement
+				).click();
+			});
 
 			const nodes = Array.from(
 				scratch.querySelectorAll<SVGCircleElement>(".graph-node")
@@ -1154,7 +1193,100 @@ describe("@preact/signals-devtools-ui", () => {
 			expect(nodes).to.have.length(1000);
 			expect(xPositions.size).to.be.greaterThan(10);
 			expect(yPositions.size).to.be.lessThan(50);
-			expect(zoomPercent).to.be.greaterThan(5);
+			expect(zoomPercent).to.be.at.least(5);
+		});
+
+		it("should ask users to choose a node before rendering a large graph", async () => {
+			const updates = Array.from({ length: 201 }, (_, index) => ({
+				type: "update" as const,
+				signalType: "signal" as const,
+				signalName: `signal-${index}`,
+				signalId: `signal-${index}`,
+				prevValue: index,
+				newValue: index + 1,
+				receivedAt: Date.now(),
+			}));
+
+			mockAdapter._emit("signalUpdate", updates);
+			render(<GraphVisualization />, scratch);
+
+			expect(scratch.querySelector(".graph-large-state")).to.not.be.null;
+			expect(scratch.querySelectorAll(".graph-node")).to.have.length(0);
+
+			await act(async () => {
+				(
+					scratch.querySelector(
+						".graph-large-state button"
+					) as HTMLButtonElement
+				).click();
+			});
+
+			expect(scratch.querySelectorAll(".graph-node")).to.have.length(201);
+		});
+
+		it("should search a large graph and render the selected neighborhood", async () => {
+			const isolatedUpdates = Array.from({ length: 198 }, (_, index) => ({
+				type: "update" as const,
+				signalType: "signal" as const,
+				signalName: `isolated-${index}`,
+				signalId: `isolated-${index}`,
+				prevValue: index,
+				newValue: index + 1,
+				receivedAt: Date.now(),
+			}));
+			mockAdapter._emit("signalUpdate", [
+				...isolatedUpdates,
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "selected-total",
+					signalId: "selected-total",
+					prevValue: 0,
+					newValue: 1,
+					receivedAt: Date.now(),
+					allDependencies: [
+						{ id: "upstream", name: "upstream", type: "signal" },
+					],
+				},
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "downstream",
+					signalId: "downstream",
+					prevValue: 0,
+					newValue: 1,
+					receivedAt: Date.now(),
+					allDependencies: [
+						{ id: "selected-total", name: "selected-total", type: "computed" },
+					],
+				},
+			]);
+			render(<GraphVisualization />, scratch);
+
+			const searchInput = scratch.querySelector(
+				".graph-search-input"
+			) as HTMLInputElement;
+			await act(async () => {
+				searchInput.value = "selected-total";
+				searchInput.dispatchEvent(new InputEvent("input", { bubbles: true }));
+			});
+			await act(async () => {
+				(
+					scratch.querySelector(".graph-search-result") as HTMLButtonElement
+				).click();
+			});
+
+			const names = Array.from(scratch.querySelectorAll(".graph-text")).map(
+				node => node.textContent
+			);
+			expect(names).to.have.members([
+				"upstream",
+				"selected-total",
+				"downstream",
+			]);
+			expect(
+				scratch.querySelector(".graph-focus-summary")!.textContent
+			).to.contain("Showing 3 of 201 nodes");
 		});
 
 		it("should keep a wrapped dependency layer before its dependent layer", () => {


### PR DESCRIPTION
Large dependency graphs become too dense to navigate when every runtime node is rendered at once.

For graphs over 200 nodes, prompt users to search for a reactive node and render its direct dependencies and dependents. Nodes can be selected to recenter the neighborhood, while the complete instance graph remains available on demand.