### PR TITLE
Fix settings popover actions

### DIFF
--- a/.changeset/tidy-tools-close.md
+++ b/.changeset/tidy-tools-close.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-devtools-ui": patch
+---
+
+Close the settings popover when changes are applied or cancelled.

--- a/packages/devtools-ui/src/components/SettingsPanel.tsx
+++ b/packages/devtools-ui/src/components/SettingsPanel.tsx
@@ -16,13 +16,13 @@ export function SettingsPanel() {
 		localSettings.value = settingsStore.settings.value;
 	});
 
-	const handleApply = () => {
-		onApply(localSettings.value);
+	const closePopover = () => {
+		popover.current?.hidePopover();
 	};
 
-	const onCancel = () => {
-		// @ts-expect-error
-		popover.current?.hide();
+	const handleApply = () => {
+		onApply(localSettings.value);
+		closePopover();
 	};
 
 	return (
@@ -146,7 +146,7 @@ export function SettingsPanel() {
 					<Button onClick={handleApply} variant="primary">
 						Apply
 					</Button>
-					<Button onClick={onCancel}>Cancel</Button>
+					<Button onClick={closePopover}>Cancel</Button>
 				</div>
 			</div>
 		</div>

--- a/packages/devtools-ui/test/browser/index.test.tsx
+++ b/packages/devtools-ui/test/browser/index.test.tsx
@@ -580,6 +580,46 @@ describe("@preact/signals-devtools-ui", () => {
 		});
 	});
 
+	describe("SettingsPanel", () => {
+		beforeEach(() => {
+			initDevTools(mockAdapter);
+		});
+
+		it("should close when Cancel is clicked", () => {
+			render(<SettingsPanel />, scratch);
+
+			const popover = scratch.querySelector<HTMLDivElement>(
+				"#settings-panel-popover"
+			)!;
+			popover.showPopover();
+			expect(popover.matches(":popover-open")).to.be.true;
+
+			const cancelButton = Array.from(scratch.querySelectorAll("button")).find(
+				button => button.textContent === "Cancel"
+			)!;
+			cancelButton.click();
+
+			expect(popover.matches(":popover-open")).to.be.false;
+		});
+
+		it("should apply settings and close when Apply is clicked", () => {
+			render(<SettingsPanel />, scratch);
+
+			const popover = scratch.querySelector<HTMLDivElement>(
+				"#settings-panel-popover"
+			)!;
+			popover.showPopover();
+
+			const applyButton = Array.from(scratch.querySelectorAll("button")).find(
+				button => button.textContent === "Apply"
+			)!;
+			applyButton.click();
+
+			expect(mockAdapter.sendConfig).toHaveBeenCalledOnce();
+			expect(popover.matches(":popover-open")).to.be.false;
+		});
+	});
+
 	describe("UpdatesContainer", () => {
 		beforeEach(() => {
 			initDevTools(mockAdapter);


### PR DESCRIPTION
## Problem

The settings popover remained open after Cancel, and Apply offered no visible completion feedback.

## Solution

Use the native popover API to close the settings panel after either action while preserving setting application.