### PR TITLE
Add Signals performance insights

### DIFF
--- a/.changeset/silly-insights-track.md
+++ b/.changeset/silly-insights-track.md
@@ -1,0 +1,7 @@
+---
+"@preact/signals-debug": minor
+"@preact/signals-devtools-adapter": minor
+"@preact/signals-devtools-ui": minor
+---
+
+Add Performance Insights for instance-level update hotspots and explicitly instrumented no-output-change computed recomputations.

--- a/packages/debug/src/devtools.ts
+++ b/packages/debug/src/devtools.ts
@@ -19,6 +19,10 @@ export interface FormattedSignalUpdate {
 	subscribedTo?: string;
 	/** All dependencies this computed/effect currently depends on (with rich info) */
 	allDependencies?: DependencyInfo[];
+	/** Present when this entry was produced by a computed evaluation. */
+	recomputed?: true;
+	/** Whether that computed evaluation changed its output using the runtime's `!==` check. */
+	outputChanged?: boolean;
 }
 
 /** Formatted signal disposal event for external consumers */

--- a/packages/debug/src/index.ts
+++ b/packages/debug/src/index.ts
@@ -16,6 +16,8 @@ const signalValues = new WeakMap<Signal | Effect, any>();
 const subscriptions = new WeakMap<Signal | Effect, () => void>();
 const internalEffects = new WeakSet<Effect>();
 const signalDependencies = new WeakMap<Signal | Effect, Set<string>>(); // Track what each signal depends on
+const instrumentedComputeds = new WeakSet<Computed>();
+const computedWasEvaluated = new WeakMap<Computed, boolean>();
 
 export function setDebugOptions(options: {
 	grouped?: boolean;
@@ -103,13 +105,30 @@ Signal.prototype._subscribe = function (node: Node) {
 	return originalSubscribe.call(this, node);
 };
 
+type DebugComputed = Computed & { _fn: () => unknown };
+
+function instrumentComputed(computed: DebugComputed) {
+	if (instrumentedComputeds.has(computed)) return;
+
+	const originalFn = computed._fn;
+	computed._fn = function () {
+		computedWasEvaluated.set(computed, true);
+		return originalFn.call(this);
+	};
+	instrumentedComputeds.add(computed);
+}
+
 const originalRefresh = Computed.prototype._refresh;
 Computed.prototype._refresh = function () {
+	const computed = this as DebugComputed;
+	instrumentComputed(computed);
+	computedWasEvaluated.set(computed, false);
+
 	const prevValue = this._value;
 	const result = originalRefresh.call(this);
 	const newValue = this._value;
 	const baseSignal = bubbleUpToBaseSignal(this as any);
-	if (baseSignal && prevValue !== newValue) {
+	if (baseSignal && computedWasEvaluated.get(computed)) {
 		// Track dependency
 		trackDependency(this, baseSignal.signal);
 
@@ -123,6 +142,8 @@ Computed.prototype._refresh = function () {
 			type: "value",
 			subscribedTo: getSignalId(baseSignal.signal),
 			allDependencies: getAllCurrentDependencies(this as any),
+			recomputed: true,
+			outputChanged: prevValue !== newValue,
 		});
 		updateInfoMap.set(baseSignal.signal, updateInfoList);
 	}
@@ -397,6 +418,12 @@ function logUpdate(
 	prevOpenedGroup: boolean
 ): boolean {
 	if (!debugEnabled || !consoleLoggingEnabled) return false;
+
+	// Performance Insights needs to observe no-output-change evaluations, but
+	// preserve the existing console surface by only logging visible output changes.
+	if (info.type === "value" && info.recomputed && !info.outputChanged) {
+		return false;
+	}
 
 	const { signal, type, depth } = info;
 	const name = getSignalName(signal, type);

--- a/packages/debug/src/internal.ts
+++ b/packages/debug/src/internal.ts
@@ -33,6 +33,10 @@ export interface ValueUpdate {
 	depth: number;
 	subscribedTo?: string; // signalId of the signal this effect is subscribed to
 	allDependencies?: DependencyInfo[]; // All dependencies this computed depends on
+	/** Present when this entry was produced by a computed evaluation. */
+	recomputed?: true;
+	/** Whether this evaluation changed its output using the runtime's `!==` check. */
+	outputChanged?: boolean;
 }
 
 interface EffectUpdate {

--- a/packages/debug/test/browser/signal.test.tsx
+++ b/packages/debug/test/browser/signal.test.tsx
@@ -87,6 +87,71 @@ describe("Signal Debug", () => {
 			expect(consoleSpy).toHaveBeenCalledWith("  Type: Computed");
 		});
 
+		it("reports computed recomputations even when their output does not change", async () => {
+			const count = signal(0, { name: "count" });
+			const parity = computed(() => count.value % 2, { name: "parity" });
+			const unsubscribeComputed = parity.subscribe(() => {});
+			const updates: any[] = [];
+			const unsubscribeDevTools = window.__PREACT_SIGNALS_DEVTOOLS__.onUpdate(
+				newUpdates => updates.push(...newUpdates)
+			);
+
+			count.value = 2;
+			await new Promise(resolve => setTimeout(resolve, 0));
+			count.value = 3;
+			await new Promise(resolve => setTimeout(resolve, 0));
+
+			unsubscribeDevTools();
+			unsubscribeComputed();
+
+			const parityUpdates = updates.filter(
+				update => update.signalName === "parity"
+			);
+			expect(parityUpdates).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						recomputed: true,
+						outputChanged: false,
+						prevValue: 0,
+						newValue: 0,
+					}),
+					expect.objectContaining({
+						recomputed: true,
+						outputChanged: true,
+						prevValue: 0,
+						newValue: 1,
+					}),
+				])
+			);
+		});
+
+		it("does not count a computed refresh fast path as a recomputation", async () => {
+			const count = signal(0, { name: "count" });
+			const evaluateParity = vi.fn(() => count.value % 2);
+			const parity = computed(evaluateParity, { name: "shared-parity" });
+			const left = computed(() => parity.value, { name: "left" });
+			const right = computed(() => parity.value, { name: "right" });
+			const unsubscribeLeft = left.subscribe(() => {});
+			const unsubscribeRight = right.subscribe(() => {});
+			const updates: any[] = [];
+			const unsubscribeDevTools = window.__PREACT_SIGNALS_DEVTOOLS__.onUpdate(
+				newUpdates => updates.push(...newUpdates)
+			);
+
+			evaluateParity.mockClear();
+			count.value = 2;
+			await new Promise(resolve => setTimeout(resolve, 0));
+
+			unsubscribeDevTools();
+			unsubscribeLeft();
+			unsubscribeRight();
+
+			expect(evaluateParity).toHaveBeenCalledOnce();
+			expect(
+				updates.filter(update => update.signalName === "shared-parity")
+			).toHaveLength(1);
+		});
+
 		it("should handle nested computed signals", async () => {
 			const count = signal(0, { name: "count" });
 			const doubled = computed(() => count.value * 2, { name: "doubled" });

--- a/packages/devtools-adapter/src/types.ts
+++ b/packages/devtools-adapter/src/types.ts
@@ -23,6 +23,10 @@ export interface SignalUpdate {
 	subscribedTo?: string;
 	/** All dependencies this computed/effect currently depends on (with rich info) */
 	allDependencies?: DependencyInfo[];
+	/** Present when this entry was produced by a computed evaluation. */
+	recomputed?: true;
+	/** Whether that computed evaluation changed its output using the runtime's `!==` check. */
+	outputChanged?: boolean;
 }
 
 /**

--- a/packages/devtools-adapter/test/index.test.tsx
+++ b/packages/devtools-adapter/test/index.test.tsx
@@ -125,6 +125,35 @@ describe("@preact/signals-devtools-adapter", () => {
 				message: "Connected",
 			});
 		});
+
+		it("relays computed recomputation metadata without deriving it from values", async () => {
+			const fakeWindow = new FakeWindow();
+			const adapter = createPostMessageAdapter({
+				sourceWindow: fakeWindow as unknown as Window,
+				sourceOrigin: fakeWindow.location.origin,
+			});
+			const onUpdate = vi.fn();
+			adapter.on("signalUpdate", onUpdate);
+			await adapter.connect();
+
+			const update: SignalUpdate = {
+				type: "update",
+				signalType: "computed",
+				signalName: "parity",
+				signalId: "computed-parity",
+				prevValue: { parity: 0 },
+				newValue: { parity: 0 },
+				receivedAt: Date.now(),
+				recomputed: true,
+				outputChanged: false,
+			};
+			fakeWindow.emitMessage({
+				type: "SIGNALS_UPDATE",
+				payload: { updates: [update] },
+			});
+
+			expect(onUpdate).toHaveBeenCalledWith([update]);
+		});
 	});
 
 	describe("BrowserExtensionAdapter", () => {

--- a/packages/devtools-ui/README.md
+++ b/packages/devtools-ui/README.md
@@ -77,6 +77,7 @@ import {
 	initDevTools,
 	Header,
 	UpdatesContainer,
+	PerformanceInsights,
 	GraphVisualization,
 } from "@preact/signals-devtools-ui";
 import { createDirectAdapter } from "@preact/signals-devtools-adapter";
@@ -91,6 +92,7 @@ function MyCustomDevTools() {
 			<Header />
 			<div className="my-layout">
 				<UpdatesContainer />
+				<PerformanceInsights />
 				<GraphVisualization />
 			</div>
 		</div>
@@ -102,19 +104,19 @@ function MyCustomDevTools() {
 
 ### `mount(options)`
 
-| Option       | Type                   | Required | Description                      |
-| ------------ | ---------------------- | -------- | -------------------------------- |
-| `adapter`    | `DevToolsAdapter`      | Yes      | The communication adapter to use |
-| `container`  | `HTMLElement`          | Yes      | The DOM element to render into   |
-| `hideHeader` | `boolean`              | No       | Hide the header bar              |
-| `initialTab` | `"updates" \| "graph"` | No       | Which tab to show initially      |
+| Option       | Type                                    | Required | Description                      |
+| ------------ | --------------------------------------- | -------- | -------------------------------- |
+| `adapter`    | `DevToolsAdapter`                       | Yes      | The communication adapter to use |
+| `container`  | `HTMLElement`                           | Yes      | The DOM element to render into   |
+| `hideHeader` | `boolean`                               | No       | Hide the header bar              |
+| `initialTab` | `"updates" \| "performance" \| "graph"` | No       | Which tab to show initially      |
 
 ### `DevToolsPanel`
 
-| Prop         | Type                   | Default     | Description            |
-| ------------ | ---------------------- | ----------- | ---------------------- |
-| `hideHeader` | `boolean`              | `false`     | Hide the header bar    |
-| `initialTab` | `"updates" \| "graph"` | `"updates"` | Initial tab to display |
+| Prop         | Type                                    | Default     | Description            |
+| ------------ | --------------------------------------- | ----------- | ---------------------- |
+| `hideHeader` | `boolean`                               | `false`     | Hide the header bar    |
+| `initialTab` | `"updates" \| "performance" \| "graph"` | `"updates"` | Initial tab to display |
 
 ## Styling
 
@@ -132,6 +134,7 @@ Or include the CSS file from the dist folder manually.
 - `Header` - Header with status and controls
 - `SettingsPanel` - Debug settings configuration
 - `UpdatesContainer` - Signal updates list
+- `PerformanceInsights` - Instance-level update hotspots and no-output-change computed recomputations
 - `GraphVisualization` - Dependency graph
 - `EmptyState` - Empty state placeholder
 - `StatusIndicator` - Connection status indicator

--- a/packages/devtools-ui/src/DevToolsPanel.tsx
+++ b/packages/devtools-ui/src/DevToolsPanel.tsx
@@ -3,6 +3,7 @@ import { useSignal } from "@preact/signals";
 import type { DevToolsAdapter } from "@preact/signals-devtools-adapter";
 import { EmptyState } from "./components/EmptyState";
 import { Header } from "./components/Header";
+import { PerformanceInsights } from "./components/PerformanceInsights";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { GraphVisualization } from "./components/Graph";
 import { UpdatesContainer } from "./components/UpdatesContainer";
@@ -13,11 +14,19 @@ import {
 	setCurrentDevToolsContext,
 } from "./context";
 
+type PanelTab = "updates" | "performance" | "graph";
+
+const PANEL_TABS: Array<{ id: PanelTab; label: string }> = [
+	{ id: "updates", label: "Updates" },
+	{ id: "performance", label: "Performance" },
+	{ id: "graph", label: "Dependency Graph" },
+];
+
 export interface DevToolsPanelProps {
 	/** Hide the header (useful for embedded contexts) */
 	hideHeader?: boolean;
 	/** Initial tab to show */
-	initialTab?: "updates" | "graph";
+	initialTab?: PanelTab;
 }
 
 export function DevToolsPanel({
@@ -25,7 +34,7 @@ export function DevToolsPanel({
 	initialTab = "updates",
 }: DevToolsPanelProps = {}) {
 	const { connectionStore } = getContext();
-	const activeTab = useSignal<"updates" | "graph">(initialTab);
+	const activeTab = useSignal<PanelTab>(initialTab);
 
 	return (
 		<div className="signals-devtools">
@@ -34,26 +43,34 @@ export function DevToolsPanel({
 			<SettingsPanel />
 
 			<main className="main-content">
-				<div className="tabs">
-					<button
-						className={`tab ${activeTab.value === "updates" ? "active" : ""}`}
-						onClick={() => (activeTab.value = "updates")}
-					>
-						Updates
-					</button>
-					<button
-						className={`tab ${activeTab.value === "graph" ? "active" : ""}`}
-						onClick={() => (activeTab.value = "graph")}
-					>
-						Dependency Graph
-					</button>
+				<div className="tabs" role="tablist" aria-label="DevTools views">
+					{PANEL_TABS.map(tab => (
+						<button
+							key={tab.id}
+							id={`tab-${tab.id}`}
+							className={`tab ${activeTab.value === tab.id ? "active" : ""}`}
+							onClick={() => (activeTab.value = tab.id)}
+							role="tab"
+							aria-selected={activeTab.value === tab.id}
+							aria-controls={`tabpanel-${tab.id}`}
+							tabindex={activeTab.value === tab.id ? 0 : -1}
+						>
+							{tab.label}
+						</button>
+					))}
 				</div>
-				<div className="tab-content">
+				<div
+					className="tab-content"
+					role="tabpanel"
+					aria-labelledby={`tab-${activeTab.value}`}
+					id={`tabpanel-${activeTab.value}`}
+				>
 					{!connectionStore.isConnected.value ? (
 						<EmptyState onRefresh={connectionStore.refreshConnection} />
 					) : (
 						<>
 							{activeTab.value === "updates" && <UpdatesContainer />}
+							{activeTab.value === "performance" && <PerformanceInsights />}
 							{activeTab.value === "graph" && <GraphVisualization />}
 						</>
 					)}

--- a/packages/devtools-ui/src/clipboard.ts
+++ b/packages/devtools-ui/src/clipboard.ts
@@ -1,0 +1,11 @@
+export function copyToClipboard(text: string): void {
+	const copyElement = document.createElement("textarea");
+	try {
+		copyElement.value = text;
+		document.body.append(copyElement);
+		copyElement.select();
+		document.execCommand("copy");
+	} finally {
+		copyElement.remove();
+	}
+}

--- a/packages/devtools-ui/src/components/Graph.tsx
+++ b/packages/devtools-ui/src/components/Graph.tsx
@@ -1,8 +1,9 @@
 import { useRef, useEffect } from "preact/hooks";
 import { useComputed, useSignal } from "@preact/signals";
-import type { GraphData, GraphLink, GraphNode } from "../types";
+import { copyToClipboard } from "../clipboard";
 import type { SignalUpdate } from "../context";
 import { getContext } from "../context";
+import type { GraphData, GraphLink, GraphNode } from "../types";
 
 interface GraphRenderData extends GraphData {
 	nodeLookup: Map<string, GraphNode>;
@@ -137,18 +138,6 @@ export const filterGraphToNeighborhood = (
 			link => visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target)
 		),
 	};
-};
-
-const copyToClipboard = (text: string) => {
-	const copyEl = document.createElement("textarea");
-	try {
-		copyEl.value = text;
-		document.body.append(copyEl);
-		copyEl.select();
-		document.execCommand("copy");
-	} finally {
-		copyEl.remove();
-	}
 };
 
 export function GraphVisualization() {

--- a/packages/devtools-ui/src/components/PerformanceInsights.tsx
+++ b/packages/devtools-ui/src/components/PerformanceInsights.tsx
@@ -87,6 +87,35 @@ function DependencyList({
 	);
 }
 
+function TriggerSource({
+	occurrence,
+}: {
+	occurrence: NoOutputChangeOccurrence;
+}) {
+	if (!occurrence.subscribedTo) {
+		return <span className="performance-muted">Unknown source</span>;
+	}
+
+	const dependency = occurrence.allDependencies?.find(
+		candidate => candidate.id === occurrence.subscribedTo
+	);
+	if (!dependency) {
+		return (
+			<code className="performance-trigger-id">{occurrence.subscribedTo}</code>
+		);
+	}
+
+	return (
+		<span className="performance-trigger-source">
+			<span className={`performance-dependency-type ${dependency.type}`}>
+				{dependency.type}
+			</span>
+			<strong>{dependency.name || "(anonymous)"}</strong>
+			<code className="performance-trigger-id">{dependency.id}</code>
+		</span>
+	);
+}
+
 function OccurrenceRow({
 	occurrence,
 }: {
@@ -96,11 +125,8 @@ function OccurrenceRow({
 		<li className="performance-occurrence">
 			<div className="performance-occurrence-row">
 				<span className="performance-occurrence-label">Triggered by</span>
-				<span
-					className="performance-occurrence-value"
-					title={occurrence.subscribedTo}
-				>
-					{occurrence.subscribedTo || "Unknown source"}
+				<span className="performance-occurrence-value">
+					<TriggerSource occurrence={occurrence} />
 				</span>
 			</div>
 			<div className="performance-occurrence-row">
@@ -293,9 +319,8 @@ export function PerformanceInsights() {
 																	aria-label={`${isOpen ? "Hide" : "Inspect"} recent causes for ${summary.signalName || "anonymous computed"}`}
 																>
 																	<span aria-hidden="true">
-																		{isOpen ? "▾" : "▸"}
+																		{isOpen ? "▼" : "▶"}
 																	</span>
-																	{isOpen ? "Hide causes" : "Inspect causes"}
 																</button>
 															</div>
 														</td>

--- a/packages/devtools-ui/src/components/PerformanceInsights.tsx
+++ b/packages/devtools-ui/src/components/PerformanceInsights.tsx
@@ -1,5 +1,6 @@
 import { Fragment, type ComponentChildren } from "preact";
 import { useSignal } from "@preact/signals";
+import { copyToClipboard } from "../clipboard";
 import { getContext } from "../context";
 import type {
 	NoOutputChangeOccurrence,
@@ -155,6 +156,7 @@ export function PerformanceInsights() {
 	const { performanceStore } = getContext();
 	const insights = performanceStore.insights.value;
 	const expanded = useSignal<Set<string>>(new Set());
+	const exportStatus = useSignal<string>();
 
 	const toggleRow = (signalId: string) => {
 		const next = new Set(expanded.value);
@@ -166,6 +168,14 @@ export function PerformanceInsights() {
 		expanded.value = next;
 	};
 
+	const exportInsights = () => {
+		copyToClipboard(JSON.stringify(insights, null, 2));
+		exportStatus.value = "Copied to clipboard!";
+		setTimeout(() => {
+			exportStatus.value = undefined;
+		}, 2000);
+	};
+
 	const baselineIsDefensible =
 		insights.hotspotPopulation >= MIN_BASELINE_POPULATION;
 	const noHotspotsMessage = baselineIsDefensible
@@ -175,12 +185,30 @@ export function PerformanceInsights() {
 	return (
 		<div className="performance-insights">
 			<header className="performance-insights-header">
-				<h2>Performance Insights</h2>
-				<p>
-					Metrics use a rolling window of the last{" "}
-					{PERFORMANCE_OBSERVATION_LIMIT} observed update events. Clear resets
-					the window.
-				</p>
+				<div>
+					<h2>Performance Insights</h2>
+					<p>
+						Metrics use a rolling window of the last{" "}
+						{PERFORMANCE_OBSERVATION_LIMIT} observed update events. Clear resets
+						the window.
+					</p>
+				</div>
+				<div className="performance-export">
+					<button
+						className="performance-export-button"
+						onClick={exportInsights}
+						title="Copy performance insights as JSON"
+					>
+						↓ Export JSON
+					</button>
+					<span
+						className="performance-export-status"
+						role="status"
+						aria-live="polite"
+					>
+						{exportStatus.value}
+					</span>
+				</div>
 			</header>
 
 			<div className="performance-insights-content">

--- a/packages/devtools-ui/src/components/PerformanceInsights.tsx
+++ b/packages/devtools-ui/src/components/PerformanceInsights.tsx
@@ -1,6 +1,11 @@
-import type { ComponentChildren } from "preact";
+import { Fragment, type ComponentChildren } from "preact";
+import { useSignal } from "@preact/signals";
 import { getContext } from "../context";
-import type { PerformanceInstanceSummary } from "../models/PerformanceInsightsModel";
+import type {
+	NoOutputChangeOccurrence,
+	PerformanceInstanceSummary,
+} from "../models/PerformanceInsightsModel";
+import { MIN_BASELINE_POPULATION } from "../models/PerformanceInsightsModel";
 import { PERFORMANCE_OBSERVATION_LIMIT } from "../models/UpdatesModel";
 
 const MAX_INSIGHT_ROWS = 100;
@@ -39,9 +44,107 @@ function VisibleRows({
 	);
 }
 
+function HotspotTierBadge({
+	tier,
+}: {
+	tier: PerformanceInstanceSummary["hotspotTier"];
+}) {
+	if (tier === "severe") {
+		return <span className="performance-tier severe">≥4× baseline</span>;
+	}
+	return <span className="performance-tier elevated">≥2× baseline</span>;
+}
+
+function formatTimestamp(value: number | undefined): string {
+	if (value === undefined) return "—";
+	return new Date(value).toLocaleTimeString();
+}
+
+function DependencyList({
+	dependencies,
+}: {
+	dependencies: NoOutputChangeOccurrence["allDependencies"];
+}) {
+	if (!dependencies || dependencies.length === 0) {
+		return <span className="performance-muted">No dependency metadata</span>;
+	}
+	return (
+		<ul className="performance-dependency-list">
+			{dependencies.map(dep => (
+				<li key={dep.id} className="performance-dependency-item">
+					<span className={`performance-dependency-type ${dep.type}`}>
+						{dep.type}
+					</span>
+					<span className="performance-dependency-name">
+						{dep.name || "(anonymous)"}
+					</span>
+					<span className="performance-dependency-id" title={dep.id}>
+						{dep.id}
+					</span>
+				</li>
+			))}
+		</ul>
+	);
+}
+
+function OccurrenceRow({
+	occurrence,
+}: {
+	occurrence: NoOutputChangeOccurrence;
+}) {
+	return (
+		<li className="performance-occurrence">
+			<div className="performance-occurrence-row">
+				<span className="performance-occurrence-label">Triggered by</span>
+				<span
+					className="performance-occurrence-value"
+					title={occurrence.subscribedTo}
+				>
+					{occurrence.subscribedTo || "Unknown source"}
+				</span>
+			</div>
+			<div className="performance-occurrence-row">
+				<span className="performance-occurrence-label">Runtime timestamp</span>
+				<span className="performance-occurrence-value">
+					{formatTimestamp(occurrence.timestamp)}
+				</span>
+			</div>
+			<div className="performance-occurrence-row">
+				<span className="performance-occurrence-label">Received at</span>
+				<span className="performance-occurrence-value">
+					{formatTimestamp(occurrence.receivedAt)}
+				</span>
+			</div>
+			<div className="performance-occurrence-deps">
+				<span className="performance-occurrence-label">
+					Current dependencies
+				</span>
+				<DependencyList dependencies={occurrence.allDependencies} />
+			</div>
+		</li>
+	);
+}
+
 export function PerformanceInsights() {
 	const { performanceStore } = getContext();
 	const insights = performanceStore.insights.value;
+	const expanded = useSignal<Set<string>>(new Set());
+
+	const toggleRow = (signalId: string) => {
+		const next = new Set(expanded.value);
+		if (next.has(signalId)) {
+			next.delete(signalId);
+		} else {
+			next.add(signalId);
+		}
+		expanded.value = next;
+	};
+
+	const baselineIsDefensible =
+		insights.hotspotPopulation >= MIN_BASELINE_POPULATION;
+	const noHotspotsMessage = baselineIsDefensible
+		? `No runtime instance is disproportionately active relative to the median baseline (≥2×). The median per-instance update count is ${insights.hotspotBaseline} across ${insights.hotspotPopulation} identified instance${insights.hotspotPopulation === 1 ? "" : "s"}.`
+		: "Not enough identified instances to compute a defensible median baseline. Update more tracked Signals to populate hotspots.";
 
 	return (
 		<div className="performance-insights">
@@ -63,8 +166,12 @@ export function PerformanceInsights() {
 						<div>
 							<h3 id="hotspots-heading">Hotspots</h3>
 							<p>
-								Ranked by observed update events for each runtime instance ID,
-								not by display name. This measures activity, not elapsed time.
+								A hotspot is a runtime instance whose observed update count is
+								disproportionate to the median per-instance activity. Only
+								instances at ≥2× the median baseline are shown; ≥4× is flagged
+								as severe. Instances are ranked by observed update events for
+								each runtime instance ID, not by display name. This measures
+								activity, not elapsed time.
 							</p>
 						</div>
 						<span className="performance-section-count">
@@ -76,6 +183,8 @@ export function PerformanceInsights() {
 						<p className="performance-empty">
 							Update a tracked Signal to collect performance observations.
 						</p>
+					) : insights.hotspots.length === 0 ? (
+						<p className="performance-empty">{noHotspotsMessage}</p>
 					) : (
 						<div className="performance-table-scroll">
 							<table className="performance-table">
@@ -83,26 +192,42 @@ export function PerformanceInsights() {
 									<tr>
 										<th>Instance</th>
 										<th>Type</th>
+										<th>Tier</th>
 										<th>Observed events</th>
-										<th>No-output-change recomputations</th>
+										<th>vs. baseline</th>
 									</tr>
 								</thead>
 								<tbody>
-									<VisibleRows items={insights.hotspots} colSpan={4}>
+									<VisibleRows items={insights.hotspots} colSpan={5}>
 										{summary => (
 											<tr key={summary.signalId}>
 												<td>
 													<InstanceCell summary={summary} />
 												</td>
 												<td>{summary.signalType}</td>
+												<td>
+													<HotspotTierBadge tier={summary.hotspotTier} />
+												</td>
 												<td>{summary.updateCount}</td>
-												<td>{summary.noOutputChangeCount}</td>
+												<td>
+													{insights.hotspotBaseline > 0
+														? `${(summary.updateCount / insights.hotspotBaseline).toFixed(1)}× median`
+														: "—"}
+												</td>
 											</tr>
 										)}
 									</VisibleRows>
 								</tbody>
 							</table>
 						</div>
+					)}
+					{insights.hotspotPopulation >= MIN_BASELINE_POPULATION && (
+						<p className="performance-note">
+							Baseline: median of {insights.hotspotBaseline} observed update
+							event{insights.hotspotBaseline === 1 ? "" : "s"} per instance
+							across {insights.hotspotPopulation} identified instance
+							{insights.hotspotPopulation === 1 ? "" : "s"}.
+						</p>
 					)}
 					{insights.unidentifiedObservationCount > 0 && (
 						<p className="performance-note">
@@ -126,7 +251,9 @@ export function PerformanceInsights() {
 								A counted entry is an instrumented computed recomputation with{" "}
 								<code>outputChanged: false</code>. It does not compare
 								serialized values and does not claim the recomputation was
-								avoidable.
+								avoidable. Expand a row to inspect recent occurrences, their
+								trigger source, and current dependencies — all taken verbatim
+								from the runtime observation.
 							</p>
 						</div>
 					</div>
@@ -149,23 +276,73 @@ export function PerformanceInsights() {
 								</thead>
 								<tbody>
 									<VisibleRows items={insights.redundantWork} colSpan={4}>
-										{summary => (
-											<tr key={summary.signalId}>
-												<td>
-													<InstanceCell summary={summary} />
-												</td>
-												<td>{summary.noOutputChangeCount}</td>
-												<td>{summary.recomputationCount}</td>
-												<td>
-													{Math.round(
-														(summary.noOutputChangeCount /
-															summary.recomputationCount) *
-															100
+										{summary => {
+											const isOpen = expanded.value.has(summary.signalId);
+											return (
+												<Fragment key={summary.signalId}>
+													<tr
+														className={`performance-expandable-row${isOpen ? " expanded" : ""}`}
+													>
+														<td>
+															<div className="performance-instance-with-toggle">
+																<InstanceCell summary={summary} />
+																<button
+																	className="performance-expand-toggle"
+																	onClick={() => toggleRow(summary.signalId)}
+																	aria-expanded={isOpen}
+																	aria-label={`${isOpen ? "Hide" : "Inspect"} recent causes for ${summary.signalName || "anonymous computed"}`}
+																>
+																	<span aria-hidden="true">
+																		{isOpen ? "▾" : "▸"}
+																	</span>
+																	{isOpen ? "Hide causes" : "Inspect causes"}
+																</button>
+															</div>
+														</td>
+														<td>{summary.noOutputChangeCount}</td>
+														<td>{summary.recomputationCount}</td>
+														<td>
+															{summary.recomputationCount > 0
+																? `${Math.round(
+																		(summary.noOutputChangeCount /
+																			summary.recomputationCount) *
+																			100
+																	)}%`
+																: "—"}
+														</td>
+													</tr>
+													{isOpen && (
+														<tr className="performance-occurrence-detail">
+															<td colSpan={4}>
+																<div className="performance-occurrence-detail-inner">
+																	<h4>
+																		Recent no-output-change recomputations
+																	</h4>
+																	{summary.recentOccurrences &&
+																	summary.recentOccurrences.length > 0 ? (
+																		<ol className="performance-occurrence-list">
+																			{summary.recentOccurrences.map(
+																				(occurrence, index) => (
+																					<OccurrenceRow
+																						key={`${occurrence.signalId}-${occurrence.receivedAt}-${index}`}
+																						occurrence={occurrence}
+																					/>
+																				)
+																			)}
+																		</ol>
+																	) : (
+																		<p className="performance-muted">
+																			No occurrence metadata retained for this
+																			instance.
+																		</p>
+																	)}
+																</div>
+															</td>
+														</tr>
 													)}
-													%
-												</td>
-											</tr>
-										)}
+												</Fragment>
+											);
+										}}
 									</VisibleRows>
 								</tbody>
 							</table>

--- a/packages/devtools-ui/src/components/PerformanceInsights.tsx
+++ b/packages/devtools-ui/src/components/PerformanceInsights.tsx
@@ -1,0 +1,178 @@
+import type { ComponentChildren } from "preact";
+import { getContext } from "../context";
+import type { PerformanceInstanceSummary } from "../models/PerformanceInsightsModel";
+import { PERFORMANCE_OBSERVATION_LIMIT } from "../models/UpdatesModel";
+
+const MAX_INSIGHT_ROWS = 100;
+
+function InstanceCell({ summary }: { summary: PerformanceInstanceSummary }) {
+	return (
+		<div className="performance-instance">
+			<strong>{summary.signalName || "(anonymous)"}</strong>
+			<span className="performance-instance-id" title={summary.signalId}>
+				{summary.signalId}
+			</span>
+		</div>
+	);
+}
+
+function VisibleRows({
+	items,
+	colSpan,
+	children,
+}: {
+	items: PerformanceInstanceSummary[];
+	colSpan: number;
+	children: (summary: PerformanceInstanceSummary) => ComponentChildren;
+}) {
+	return (
+		<>
+			{items.slice(0, MAX_INSIGHT_ROWS).map(children)}
+			{items.length > MAX_INSIGHT_ROWS && (
+				<tr className="performance-truncation">
+					<td colSpan={colSpan}>
+						Showing the top {MAX_INSIGHT_ROWS} of {items.length} instances.
+					</td>
+				</tr>
+			)}
+		</>
+	);
+}
+
+export function PerformanceInsights() {
+	const { performanceStore } = getContext();
+	const insights = performanceStore.insights.value;
+
+	return (
+		<div className="performance-insights">
+			<header className="performance-insights-header">
+				<h2>Performance Insights</h2>
+				<p>
+					Metrics use a rolling window of the last{" "}
+					{PERFORMANCE_OBSERVATION_LIMIT} observed update events. Clear resets
+					the window.
+				</p>
+			</header>
+
+			<div className="performance-insights-content">
+				<section
+					className="performance-section"
+					aria-labelledby="hotspots-heading"
+				>
+					<div className="performance-section-heading">
+						<div>
+							<h3 id="hotspots-heading">Hotspots</h3>
+							<p>
+								Ranked by observed update events for each runtime instance ID,
+								not by display name. This measures activity, not elapsed time.
+							</p>
+						</div>
+						<span className="performance-section-count">
+							{insights.observationCount} observed
+						</span>
+					</div>
+
+					{insights.observationCount === 0 ? (
+						<p className="performance-empty">
+							Update a tracked Signal to collect performance observations.
+						</p>
+					) : (
+						<div className="performance-table-scroll">
+							<table className="performance-table">
+								<thead>
+									<tr>
+										<th>Instance</th>
+										<th>Type</th>
+										<th>Observed events</th>
+										<th>No-output-change recomputations</th>
+									</tr>
+								</thead>
+								<tbody>
+									<VisibleRows items={insights.hotspots} colSpan={4}>
+										{summary => (
+											<tr key={summary.signalId}>
+												<td>
+													<InstanceCell summary={summary} />
+												</td>
+												<td>{summary.signalType}</td>
+												<td>{summary.updateCount}</td>
+												<td>{summary.noOutputChangeCount}</td>
+											</tr>
+										)}
+									</VisibleRows>
+								</tbody>
+							</table>
+						</div>
+					)}
+					{insights.unidentifiedObservationCount > 0 && (
+						<p className="performance-note">
+							{insights.unidentifiedObservationCount} observed event
+							{insights.unidentifiedObservationCount === 1 ? "" : "s"} lacked a
+							runtime instance ID and{" "}
+							{insights.unidentifiedObservationCount === 1 ? "was" : "were"}{" "}
+							excluded rather than merged by name.
+						</p>
+					)}
+				</section>
+
+				<section
+					className="performance-section"
+					aria-labelledby="redundant-work-heading"
+				>
+					<div className="performance-section-heading">
+						<div>
+							<h3 id="redundant-work-heading">Redundant Work</h3>
+							<p>
+								A counted entry is an instrumented computed recomputation with{" "}
+								<code>outputChanged: false</code>. It does not compare
+								serialized values and does not claim the recomputation was
+								avoidable.
+							</p>
+						</div>
+					</div>
+
+					{insights.redundantWork.length === 0 ? (
+						<p className="performance-empty">
+							No computed recomputations without an output change in this
+							observation window.
+						</p>
+					) : (
+						<div className="performance-table-scroll">
+							<table className="performance-table">
+								<thead>
+									<tr>
+										<th>Computed instance</th>
+										<th>No-output-change</th>
+										<th>All recomputations</th>
+										<th>Rate</th>
+									</tr>
+								</thead>
+								<tbody>
+									<VisibleRows items={insights.redundantWork} colSpan={4}>
+										{summary => (
+											<tr key={summary.signalId}>
+												<td>
+													<InstanceCell summary={summary} />
+												</td>
+												<td>{summary.noOutputChangeCount}</td>
+												<td>{summary.recomputationCount}</td>
+												<td>
+													{Math.round(
+														(summary.noOutputChangeCount /
+															summary.recomputationCount) *
+															100
+													)}
+													%
+												</td>
+											</tr>
+										)}
+									</VisibleRows>
+								</tbody>
+							</table>
+						</div>
+					)}
+				</section>
+			</div>
+		</div>
+	);
+}

--- a/packages/devtools-ui/src/components/index.ts
+++ b/packages/devtools-ui/src/components/index.ts
@@ -2,6 +2,7 @@ export { Button } from "./Button";
 export { EmptyState } from "./EmptyState";
 export { GraphVisualization } from "./Graph";
 export { Header } from "./Header";
+export { PerformanceInsights } from "./PerformanceInsights";
 export { SettingsPanel } from "./SettingsPanel";
 export { StatusIndicator } from "./StatusIndicator";
 export { UpdateItem } from "./UpdateItem";

--- a/packages/devtools-ui/src/context.ts
+++ b/packages/devtools-ui/src/context.ts
@@ -23,6 +23,8 @@ export type {
 export type {
 	PerformanceInsightsData,
 	PerformanceInstanceSummary,
+	NoOutputChangeOccurrence,
+	HotspotTier,
 } from "./models/PerformanceInsightsModel";
 export type { ThemeMode } from "./models/ThemeModel";
 

--- a/packages/devtools-ui/src/context.ts
+++ b/packages/devtools-ui/src/context.ts
@@ -3,21 +3,34 @@ import { ConnectionModel } from "./models/ConnectionModel";
 import { SettingsModel } from "./models/SettingsModel";
 import { ThemeModel } from "./models/ThemeModel";
 import { UpdatesModel } from "./models/UpdatesModel";
+import { PerformanceInsightsModel } from "./models/PerformanceInsightsModel";
 
-export { ConnectionModel, SettingsModel, ThemeModel, UpdatesModel };
+export {
+	ConnectionModel,
+	SettingsModel,
+	ThemeModel,
+	UpdatesModel,
+	PerformanceInsightsModel,
+};
 export type {
 	SignalUpdate,
 	Divider,
 	UpdateTreeNode,
 	UpdateTreeNodeSingle,
 	UpdateTreeNodeGroup,
+	PerformanceObservation,
 } from "./models/UpdatesModel";
+export type {
+	PerformanceInsightsData,
+	PerformanceInstanceSummary,
+} from "./models/PerformanceInsightsModel";
 export type { ThemeMode } from "./models/ThemeModel";
 
 export interface DevToolsContext {
 	adapter: DevToolsAdapter;
 	connectionStore: InstanceType<typeof ConnectionModel>;
 	updatesStore: InstanceType<typeof UpdatesModel>;
+	performanceStore: InstanceType<typeof PerformanceInsightsModel>;
 	settingsStore: InstanceType<typeof SettingsModel>;
 	themeStore: InstanceType<typeof ThemeModel>;
 }
@@ -26,10 +39,12 @@ let currentContext: DevToolsContext | null = null;
 
 function createContextStores(adapter: DevToolsAdapter): DevToolsContext {
 	const settingsStore = new SettingsModel(adapter);
+	const updatesStore = new UpdatesModel(adapter, settingsStore);
 	return {
 		adapter,
 		connectionStore: new ConnectionModel(adapter),
-		updatesStore: new UpdatesModel(adapter, settingsStore),
+		updatesStore,
+		performanceStore: new PerformanceInsightsModel(updatesStore),
 		settingsStore,
 		themeStore: new ThemeModel(),
 	};
@@ -65,6 +80,7 @@ export function setCurrentDevToolsContext(
 
 export function destroyDevToolsContext(context: DevToolsContext): void {
 	context.connectionStore[Symbol.dispose]();
+	context.performanceStore[Symbol.dispose]();
 	context.updatesStore[Symbol.dispose]();
 	context.settingsStore[Symbol.dispose]();
 	context.themeStore[Symbol.dispose]();

--- a/packages/devtools-ui/src/index.ts
+++ b/packages/devtools-ui/src/index.ts
@@ -24,6 +24,8 @@ export {
 	type PerformanceObservation,
 	type PerformanceInsightsData,
 	type PerformanceInstanceSummary,
+	type NoOutputChangeOccurrence,
+	type HotspotTier,
 } from "./context";
 
 // Types

--- a/packages/devtools-ui/src/index.ts
+++ b/packages/devtools-ui/src/index.ts
@@ -13,6 +13,7 @@ export {
 	getContext,
 	ConnectionModel,
 	UpdatesModel,
+	PerformanceInsightsModel,
 	SettingsModel,
 	type DevToolsContext,
 	type SignalUpdate,
@@ -20,6 +21,9 @@ export {
 	type UpdateTreeNodeSingle,
 	type UpdateTreeNodeGroup,
 	type Divider,
+	type PerformanceObservation,
+	type PerformanceInsightsData,
+	type PerformanceInstanceSummary,
 } from "./context";
 
 // Types
@@ -31,6 +35,7 @@ export {
 	EmptyState,
 	GraphVisualization,
 	Header,
+	PerformanceInsights,
 	SettingsPanel,
 	StatusIndicator,
 	UpdateItem,

--- a/packages/devtools-ui/src/models/PerformanceInsightsModel.ts
+++ b/packages/devtools-ui/src/models/PerformanceInsightsModel.ts
@@ -1,0 +1,109 @@
+import { computed, createModel } from "@preact/signals";
+import type {
+	PerformanceObservation,
+	SignalUpdate,
+	UpdatesModel,
+} from "./UpdatesModel";
+
+export interface PerformanceInstanceSummary {
+	/** Stable runtime identity emitted by the debug runtime. */
+	signalId: string;
+	signalName: string;
+	signalType: SignalUpdate["signalType"];
+	/** Number of observed update events for this instance in the rolling window. */
+	updateCount: number;
+	/** Number of explicitly instrumented computed evaluations. */
+	recomputationCount: number;
+	/** Computed evaluations whose output did not change according to the runtime. */
+	noOutputChangeCount: number;
+	lastObservedAt: number;
+}
+
+export interface PerformanceInsightsData {
+	/** Instances ranked by observed update activity, never by display name. */
+	hotspots: PerformanceInstanceSummary[];
+	/** Computed instances with one or more no-output-change recomputations. */
+	redundantWork: PerformanceInstanceSummary[];
+	observationCount: number;
+	unidentifiedObservationCount: number;
+}
+
+const byMostRecentActivity = (
+	a: PerformanceInstanceSummary,
+	b: PerformanceInstanceSummary
+) =>
+	b.updateCount - a.updateCount ||
+	b.lastObservedAt - a.lastObservedAt ||
+	a.signalId.localeCompare(b.signalId);
+
+const byMostRedundantWork = (
+	a: PerformanceInstanceSummary,
+	b: PerformanceInstanceSummary
+) =>
+	b.noOutputChangeCount - a.noOutputChangeCount ||
+	b.recomputationCount - a.recomputationCount ||
+	b.lastObservedAt - a.lastObservedAt ||
+	a.signalId.localeCompare(b.signalId);
+
+/**
+ * Aggregates only stable runtime IDs. Events without an ID are deliberately not
+ * merged by label, because two unrelated Signals may share a display name.
+ */
+export function derivePerformanceInsights(
+	observations: PerformanceObservation[]
+): PerformanceInsightsData {
+	const instances = new Map<string, PerformanceInstanceSummary>();
+	let unidentifiedObservationCount = 0;
+
+	for (const observation of observations) {
+		if (!observation.signalId) {
+			unidentifiedObservationCount++;
+			continue;
+		}
+
+		let summary = instances.get(observation.signalId);
+		if (!summary) {
+			summary = {
+				signalId: observation.signalId,
+				signalName: observation.signalName,
+				signalType: observation.signalType,
+				updateCount: 0,
+				recomputationCount: 0,
+				noOutputChangeCount: 0,
+				lastObservedAt: observation.timestamp ?? observation.receivedAt,
+			};
+			instances.set(observation.signalId, summary);
+		}
+
+		summary.updateCount++;
+		summary.lastObservedAt = Math.max(
+			summary.lastObservedAt,
+			observation.timestamp ?? observation.receivedAt
+		);
+
+		if (observation.recomputed) {
+			summary.recomputationCount++;
+			if (observation.outputChanged === false) {
+				summary.noOutputChangeCount++;
+			}
+		}
+	}
+
+	const hotspots = Array.from(instances.values()).sort(byMostRecentActivity);
+	return {
+		hotspots,
+		redundantWork: hotspots
+			.filter(summary => summary.noOutputChangeCount > 0)
+			.sort(byMostRedundantWork),
+		observationCount: observations.length,
+		unidentifiedObservationCount,
+	};
+}
+
+export const PerformanceInsightsModel = createModel(
+	(updatesStore: InstanceType<typeof UpdatesModel>) => ({
+		insights: computed(() =>
+			derivePerformanceInsights(updatesStore.performanceObservations.value)
+		),
+	})
+);

--- a/packages/devtools-ui/src/models/PerformanceInsightsModel.ts
+++ b/packages/devtools-ui/src/models/PerformanceInsightsModel.ts
@@ -1,9 +1,32 @@
 import { computed, createModel } from "@preact/signals";
+import type { DependencyInfo } from "@preact/signals-devtools-adapter";
 import type {
 	PerformanceObservation,
 	SignalUpdate,
 	UpdatesModel,
 } from "./UpdatesModel";
+
+/**
+ * A single retained no-output-change recomputation, kept so developers can
+ * inspect what triggered it. Identity and dependency fields are copied
+ * verbatim from the runtime observation — values are never compared to infer
+ * whether the output changed.
+ */
+export interface NoOutputChangeOccurrence {
+	/** Stable runtime identity of the computed that recomputed. */
+	signalId: string;
+	signalName: string;
+	/** Source/trigger signal identity from `subscribedTo`, when available. */
+	subscribedTo?: string;
+	/** Current dependency names/IDs/types from `allDependencies`, when available. */
+	allDependencies?: DependencyInfo[];
+	/** Runtime timestamp of the recomputation, when available. */
+	timestamp?: number;
+	/** Wall-clock time the devtools received the observation. */
+	receivedAt: number;
+}
+
+export type HotspotTier = "elevated" | "severe";
 
 export interface PerformanceInstanceSummary {
 	/** Stable runtime identity emitted by the debug runtime. */
@@ -17,16 +40,40 @@ export interface PerformanceInstanceSummary {
 	/** Computed evaluations whose output did not change according to the runtime. */
 	noOutputChangeCount: number;
 	lastObservedAt: number;
+	/** Hotspot tier relative to the median baseline; only set for hotspot rows. */
+	hotspotTier?: HotspotTier;
+	/**
+	 * Recent no-output-change recomputations (most recent first), bounded by
+	 * `MAX_RECENT_OCCURRENCES`. Only populated for redundant-work entries.
+	 */
+	recentOccurrences?: NoOutputChangeOccurrence[];
 }
 
 export interface PerformanceInsightsData {
-	/** Instances ranked by observed update activity, never by display name. */
+	/**
+	 * Instances whose observed update count is disproportionate to the median
+	 * per-instance baseline (>=2x). `severe` tier entries are >=4x. Never ranked
+	 * by display name.
+	 */
 	hotspots: PerformanceInstanceSummary[];
 	/** Computed instances with one or more no-output-change recomputations. */
 	redundantWork: PerformanceInstanceSummary[];
 	observationCount: number;
 	unidentifiedObservationCount: number;
+	/** Median per-instance observed update count used as the hotspot baseline. */
+	hotspotBaseline: number;
+	/** Number of identified instances the baseline was computed over. */
+	hotspotPopulation: number;
 }
+
+/** Maximum recent occurrences retained per redundant-work instance. */
+export const MAX_RECENT_OCCURRENCES = 10;
+
+/** A population smaller than this cannot support a defensible baseline. */
+export const MIN_BASELINE_POPULATION = 2;
+
+const HOTSPOT_ELEVATED_MULTIPLIER = 2;
+const HOTSPOT_SEVERE_MULTIPLIER = 4;
 
 const byMostRecentActivity = (
 	a: PerformanceInstanceSummary,
@@ -46,8 +93,27 @@ const byMostRedundantWork = (
 	a.signalId.localeCompare(b.signalId);
 
 /**
+ * Median of a list of numbers. Returns 0 for an empty list. Uses the average
+ * of the two middle values for even-length lists.
+ */
+function median(values: number[]): number {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 !== 0
+		? sorted[mid]
+		: (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
  * Aggregates only stable runtime IDs. Events without an ID are deliberately not
  * merged by label, because two unrelated Signals may share a display name.
+ *
+ * Hotspots are filtered against the median per-instance update count so that
+ * only instances whose activity is disproportionate (>=2x baseline) appear.
+ * No-output-change entries retain verbatim runtime identity and dependency
+ * metadata from the observation — output-change status is never inferred from
+ * serialized value equality.
  */
 export function derivePerformanceInsights(
 	observations: PerformanceObservation[]
@@ -85,18 +151,63 @@ export function derivePerformanceInsights(
 			summary.recomputationCount++;
 			if (observation.outputChanged === false) {
 				summary.noOutputChangeCount++;
+				// Retain verbatim runtime metadata for later inspection. Values are
+				// intentionally not stored — output-change status comes from the
+				// runtime's `!==` check, not from serialized equality here.
+				const occurrence: NoOutputChangeOccurrence = {
+					signalId: observation.signalId,
+					signalName: observation.signalName,
+					subscribedTo: observation.subscribedTo,
+					allDependencies: observation.allDependencies,
+					timestamp: observation.timestamp,
+					receivedAt: observation.receivedAt,
+				};
+				if (!summary.recentOccurrences) {
+					summary.recentOccurrences = [];
+				}
+				summary.recentOccurrences.push(occurrence);
 			}
 		}
 	}
 
-	const hotspots = Array.from(instances.values()).sort(byMostRecentActivity);
+	const population = instances.size;
+	const baseline =
+		population >= MIN_BASELINE_POPULATION
+			? median(Array.from(instances.values(), summary => summary.updateCount))
+			: 0;
+
+	const hotspots: PerformanceInstanceSummary[] = [];
+	if (population >= MIN_BASELINE_POPULATION && baseline > 0) {
+		const elevatedThreshold = baseline * HOTSPOT_ELEVATED_MULTIPLIER;
+		const severeThreshold = baseline * HOTSPOT_SEVERE_MULTIPLIER;
+		for (const summary of instances.values()) {
+			if (summary.updateCount >= severeThreshold) {
+				hotspots.push({ ...summary, hotspotTier: "severe" });
+			} else if (summary.updateCount >= elevatedThreshold) {
+				hotspots.push({ ...summary, hotspotTier: "elevated" });
+			}
+		}
+		hotspots.sort(byMostRecentActivity);
+	}
+
+	const redundantWork = Array.from(instances.values())
+		.filter(summary => summary.noOutputChangeCount > 0)
+		.map(summary => ({
+			...summary,
+			// Keep only the most recent occurrences, most-recent-first.
+			recentOccurrences: summary.recentOccurrences
+				? summary.recentOccurrences.slice(-MAX_RECENT_OCCURRENCES).reverse()
+				: undefined,
+		}))
+		.sort(byMostRedundantWork);
+
 	return {
 		hotspots,
-		redundantWork: hotspots
-			.filter(summary => summary.noOutputChangeCount > 0)
-			.sort(byMostRedundantWork),
+		redundantWork,
 		observationCount: observations.length,
 		unidentifiedObservationCount,
+		hotspotBaseline: baseline,
+		hotspotPopulation: population,
 	};
 }
 

--- a/packages/devtools-ui/src/models/PerformanceInsightsModel.ts
+++ b/packages/devtools-ui/src/models/PerformanceInsightsModel.ts
@@ -182,9 +182,17 @@ export function derivePerformanceInsights(
 		const severeThreshold = baseline * HOTSPOT_SEVERE_MULTIPLIER;
 		for (const summary of instances.values()) {
 			if (summary.updateCount >= severeThreshold) {
-				hotspots.push({ ...summary, hotspotTier: "severe" });
+				hotspots.push({
+					...summary,
+					recentOccurrences: undefined,
+					hotspotTier: "severe",
+				});
 			} else if (summary.updateCount >= elevatedThreshold) {
-				hotspots.push({ ...summary, hotspotTier: "elevated" });
+				hotspots.push({
+					...summary,
+					recentOccurrences: undefined,
+					hotspotTier: "elevated",
+				});
 			}
 		}
 		hotspots.sort(byMostRecentActivity);

--- a/packages/devtools-ui/src/models/UpdatesModel.ts
+++ b/packages/devtools-ui/src/models/UpdatesModel.ts
@@ -19,9 +19,18 @@ export interface SignalUpdate {
 	subscribedTo?: string;
 	/** All dependencies this computed/effect currently depends on (with rich info) */
 	allDependencies?: DependencyInfo[];
+	/** Present when this entry was produced by a computed evaluation. */
+	recomputed?: true;
+	/** Whether that computed evaluation changed its output using the runtime's `!==` check. */
+	outputChanged?: boolean;
 }
 
 export type Divider = { type: "divider" };
+
+/** A single event retained for the bounded Performance Insights observation window. */
+export type PerformanceObservation = SignalUpdate;
+
+export const PERFORMANCE_OBSERVATION_LIMIT = 1000;
 
 export interface UpdateTreeNodeBase {
 	id: string;
@@ -88,23 +97,34 @@ export const UpdatesModel = createModel(
 		settingsStore: InstanceType<typeof SettingsModel>
 	) => {
 		const updates = signal<(SignalUpdate | Divider)[]>([]);
+		const performanceObservations = signal<PerformanceObservation[]>([]);
 		const isPaused = signal<boolean>(false);
 		const disposedSignalIds = signal<Set<string>>(new Set());
 
 		const addUpdate = (
 			update: SignalUpdate | Divider | Array<SignalUpdate | Divider>
 		) => {
-			if (Array.isArray(update)) {
-				update.forEach(item => {
-					if (item.type !== "divider") item.receivedAt = Date.now();
-				});
-			} else if (update.type === "update") {
-				update.receivedAt = Date.now();
-			}
+			const receivedAt = Date.now();
+			const items = Array.isArray(update) ? update : [update];
 			updates.value = [
 				...updates.value,
-				...(Array.isArray(update) ? update : [update]),
+				...items.map(item =>
+					item.type === "divider" ? item : { ...item, receivedAt }
+				),
 			];
+		};
+
+		const addPerformanceBatch = (signalUpdates: SignalUpdate[]) => {
+			const receivedAt = Date.now();
+			const observations = signalUpdates.map(update => ({
+				...update,
+				receivedAt,
+			}));
+
+			performanceObservations.value = [
+				...performanceObservations.value,
+				...observations,
+			].slice(-PERFORMANCE_OBSERVATION_LIMIT);
 		};
 
 		const addDisposal = (disposal: SignalDisposed | SignalDisposed[]) => {
@@ -183,6 +203,7 @@ export const UpdatesModel = createModel(
 
 		const clearUpdates = () => {
 			updates.value = [];
+			performanceObservations.value = [];
 			disposedSignalIds.value = new Set();
 		};
 
@@ -192,12 +213,22 @@ export const UpdatesModel = createModel(
 				(signalUpdates: SignalUpdate[]) => {
 					if (isPaused.value) return;
 
-					const updatesArray: Array<SignalUpdate | Divider> = [
-						...signalUpdates,
-					].reverse();
-					updatesArray.push({ type: "divider" });
+					addPerformanceBatch(signalUpdates);
 
-					addUpdate(updatesArray);
+					// No-output-change recomputations are performance observations, not
+					// visible value updates. Keep the existing Updates and Graph views
+					// focused on externally observable output changes.
+					const visibleUpdates = signalUpdates.filter(
+						update => !update.recomputed || update.outputChanged !== false
+					);
+					if (visibleUpdates.length > 0) {
+						const updatesArray: Array<SignalUpdate | Divider> = [
+							...visibleUpdates,
+						].reverse();
+						updatesArray.push({ type: "divider" });
+
+						addUpdate(updatesArray);
+					}
 				}
 			);
 
@@ -225,6 +256,7 @@ export const UpdatesModel = createModel(
 
 		return {
 			updates,
+			performanceObservations,
 			updateTree,
 			collapsedUpdateTree,
 			totalUpdates: computed(() => Object.keys(updateTree.value).length),

--- a/packages/devtools-ui/src/models/index.ts
+++ b/packages/devtools-ui/src/models/index.ts
@@ -3,9 +3,17 @@ export { SettingsModel } from "./SettingsModel";
 export { ThemeModel, type ThemeMode } from "./ThemeModel";
 export {
 	UpdatesModel,
+	PERFORMANCE_OBSERVATION_LIMIT,
 	type SignalUpdate,
 	type Divider,
+	type PerformanceObservation,
 	type UpdateTreeNode,
 	type UpdateTreeNodeSingle,
 	type UpdateTreeNodeGroup,
 } from "./UpdatesModel";
+export {
+	PerformanceInsightsModel,
+	derivePerformanceInsights,
+	type PerformanceInsightsData,
+	type PerformanceInstanceSummary,
+} from "./PerformanceInsightsModel";

--- a/packages/devtools-ui/src/models/index.ts
+++ b/packages/devtools-ui/src/models/index.ts
@@ -14,6 +14,10 @@ export {
 export {
 	PerformanceInsightsModel,
 	derivePerformanceInsights,
+	MAX_RECENT_OCCURRENCES,
+	MIN_BASELINE_POPULATION,
 	type PerformanceInsightsData,
 	type PerformanceInstanceSummary,
+	type NoOutputChangeOccurrence,
+	type HotspotTier,
 } from "./PerformanceInsightsModel";

--- a/packages/devtools-ui/src/styles.css
+++ b/packages/devtools-ui/src/styles.css
@@ -732,6 +732,159 @@ body {
   background: var(--scrollbar-thumb-hover);
 }
 
+/* Performance Insights */
+.performance-insights {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.performance-insights-header,
+.performance-section-heading {
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.performance-insights-header {
+  padding: 12px;
+}
+
+.performance-insights-header h2,
+.performance-section-heading h3 {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.performance-insights-header h2 {
+  font-size: 15px;
+}
+
+.performance-insights-header p,
+.performance-section-heading p,
+.performance-note,
+.performance-empty,
+.performance-truncation {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.performance-insights-header p,
+.performance-section-heading p {
+  margin: 4px 0 0;
+}
+
+.performance-insights-content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.performance-section {
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+.performance-section + .performance-section {
+  margin-top: 12px;
+}
+
+.performance-section-heading {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: start;
+  padding: 10px 12px;
+}
+
+.performance-section-heading h3 {
+  font-size: 14px;
+}
+
+.performance-section-heading code {
+  font-family: monospace;
+  font-size: 11px;
+}
+
+.performance-section-count {
+  color: var(--text-faint);
+  flex-shrink: 0;
+  font-size: 11px;
+}
+
+.performance-table-scroll {
+  overflow-x: auto;
+}
+
+.performance-table {
+  border-collapse: collapse;
+  min-width: 620px;
+  width: 100%;
+  font-size: 12px;
+}
+
+.performance-table th,
+.performance-table td {
+  border-bottom: 1px solid var(--border-primary);
+  padding: 8px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.performance-table th {
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.performance-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.performance-instance {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 180px;
+}
+
+.performance-instance strong {
+  color: var(--brand-purple);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.performance-instance-id {
+  color: var(--text-faint);
+  font-family: monospace;
+  font-size: 10px;
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.performance-empty,
+.performance-note {
+  margin: 0;
+  padding: 12px;
+}
+
+.performance-note {
+  border-top: 1px solid var(--border-primary);
+}
+
+.performance-truncation td {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* Graph Visualization */
 .graph-container {
   height: 100%;

--- a/packages/devtools-ui/src/styles.css
+++ b/packages/devtools-ui/src/styles.css
@@ -747,7 +747,51 @@ body {
 }
 
 .performance-insights-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
   padding: 12px;
+}
+
+.performance-insights-header > :first-child {
+  flex: 1;
+  min-width: 0;
+}
+
+.performance-export {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.performance-export-button {
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 6px 10px;
+}
+
+.performance-export-button:hover {
+  background: var(--bg-hover);
+}
+
+.performance-export-button:focus-visible {
+  outline: 2px solid var(--brand-purple);
+  outline-offset: 1px;
+}
+
+.performance-export-status {
+  min-height: 14px;
+  color: var(--text-muted);
+  font-size: 10px;
 }
 
 .performance-insights-header h2,

--- a/packages/devtools-ui/src/styles.css
+++ b/packages/devtools-ui/src/styles.css
@@ -885,6 +885,200 @@ body {
   font-style: italic;
 }
 
+/* Hotspot tier badges */
+.performance-tier {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  letter-spacing: 0.3px;
+}
+
+.performance-tier.elevated {
+  background: #fff3e0;
+  color: #e65100;
+}
+
+.performance-tier.severe {
+  background: #ffebee;
+  color: #c62828;
+}
+
+.signals-devtools[data-theme="dark"] .performance-tier.elevated {
+  background: #2e1a00;
+  color: #ffb74d;
+}
+
+.signals-devtools[data-theme="dark"] .performance-tier.severe {
+  background: #3a1212;
+  color: #ef5350;
+}
+
+@media (prefers-color-scheme: dark) {
+  .signals-devtools:not([data-theme="light"]) .performance-tier.elevated {
+    background: #2e1a00;
+    color: #ffb74d;
+  }
+
+  .signals-devtools:not([data-theme="light"]) .performance-tier.severe {
+    background: #3a1212;
+    color: #ef5350;
+  }
+}
+
+/* Expandable redundant-work rows */
+.performance-expandable-row.expanded {
+  background: var(--bg-tertiary);
+}
+
+.performance-instance-with-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.performance-expand-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  padding: 2px 6px;
+  border: 1px solid var(--border-primary);
+  border-radius: 3px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+}
+
+.performance-expand-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.performance-expand-toggle:focus-visible {
+  outline: 2px solid var(--brand-purple);
+  outline-offset: 1px;
+}
+
+.performance-occurrence-detail td {
+  background: var(--bg-tertiary);
+  padding: 12px;
+}
+
+.performance-occurrence-detail-inner {
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  padding: 10px 12px;
+}
+
+.performance-occurrence-detail-inner h4 {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--text-primary);
+}
+
+.performance-occurrence-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.performance-occurrence {
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin-bottom: 6px;
+  background: var(--bg-primary);
+}
+
+.performance-occurrence:last-child {
+  margin-bottom: 0;
+}
+
+.performance-occurrence-row {
+  display: flex;
+  gap: 8px;
+  font-size: 11px;
+  margin-bottom: 3px;
+}
+
+.performance-occurrence-label {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  min-width: 130px;
+}
+
+.performance-occurrence-value {
+  color: var(--text-primary);
+  font-family: monospace;
+  word-break: break-all;
+}
+
+.performance-occurrence-deps {
+  margin-top: 6px;
+}
+
+.performance-occurrence-deps .performance-occurrence-label {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.performance-dependency-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.performance-dependency-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  padding: 2px 0;
+}
+
+.performance-dependency-type {
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: white;
+}
+
+.performance-dependency-type.signal {
+  background: #2196f3;
+}
+
+.performance-dependency-type.computed {
+  background: #ff9800;
+}
+
+.performance-dependency-name {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.performance-dependency-id {
+  color: var(--text-faint);
+  font-family: monospace;
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.performance-muted {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 /* Graph Visualization */
 .graph-container {
   height: 100%;

--- a/packages/devtools-ui/src/styles.css
+++ b/packages/devtools-ui/src/styles.css
@@ -939,18 +939,21 @@ body {
 }
 
 .performance-expand-toggle {
+  order: -1;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  justify-content: center;
   flex: none;
-  padding: 2px 6px;
-  border: 1px solid var(--border-primary);
+  inline-size: 20px;
+  block-size: 20px;
+  padding: 0;
+  border: 0;
   border-radius: 3px;
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
+  background: none;
+  color: var(--text-muted);
   cursor: pointer;
   font: inherit;
-  font-size: 10px;
+  font-size: 9px;
 }
 
 .performance-expand-toggle:hover {
@@ -1017,6 +1020,24 @@ body {
   color: var(--text-primary);
   font-family: monospace;
   word-break: break-all;
+}
+
+.performance-trigger-source {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: inherit;
+}
+
+.performance-trigger-source strong {
+  font-family: inherit;
+  font-weight: 600;
+  word-break: normal;
+}
+
+.performance-trigger-id {
+  color: var(--text-faint);
+  font-size: 10px;
 }
 
 .performance-occurrence-deps {

--- a/packages/devtools-ui/test/browser/index.test.tsx
+++ b/packages/devtools-ui/test/browser/index.test.tsx
@@ -23,7 +23,10 @@ import {
 	calculateGraphBounds,
 	filterGraphToNeighborhood,
 } from "../../src/components/Graph";
-import { derivePerformanceInsights } from "../../src/models/PerformanceInsightsModel";
+import {
+	derivePerformanceInsights,
+	MAX_RECENT_OCCURRENCES,
+} from "../../src/models/PerformanceInsightsModel";
 import type { PerformanceObservation } from "../../src/models/UpdatesModel";
 import type {
 	DevToolsAdapter,
@@ -983,7 +986,10 @@ describe("@preact/signals-devtools-ui", () => {
 			];
 
 			const insights = derivePerformanceInsights(observations);
-			expect(insights.hotspots).to.have.length(2);
+			// Two instances with one observation each cannot be disproportionate to
+			// the median baseline (median 1, threshold 2), so neither is a hotspot.
+			expect(insights.hotspots).to.have.length(0);
+			expect(insights.hotspotPopulation).to.equal(2);
 			expect(insights.redundantWork).to.have.length(1);
 			expect(insights.redundantWork[0].signalId).to.equal("computed-total-a");
 			expect(insights.redundantWork[0].noOutputChangeCount).to.equal(1);
@@ -1094,6 +1100,266 @@ describe("@preact/signals-devtools-ui", () => {
 				"does not compare serialized values"
 			);
 			expect(scratch.textContent).to.contain("parity");
+		});
+
+		it("filters hotspots against the median baseline with >=2x and >=4x tiers", () => {
+			// Three quiet instances (1 update each) establish a median of 1.
+			// One instance with 2 updates is exactly 2x (elevated), one with 4
+			// updates is 4x (severe), and one with 1 update is below threshold.
+			const observations: PerformanceObservation[] = [
+				...["a", "b", "c"].map((id, i) => ({
+					type: "update" as const,
+					signalType: "signal" as const,
+					signalName: id,
+					signalId: `signal-${id}`,
+					receivedAt: i,
+				})),
+				...Array.from({ length: 2 }, (_, i) => ({
+					type: "update" as const,
+					signalType: "signal" as const,
+					signalName: "elevated",
+					signalId: "signal-elevated",
+					receivedAt: 10 + i,
+				})),
+				...Array.from({ length: 4 }, (_, i) => ({
+					type: "update" as const,
+					signalType: "signal" as const,
+					signalName: "severe",
+					signalId: "signal-severe",
+					receivedAt: 20 + i,
+				})),
+			];
+
+			const insights = derivePerformanceInsights(observations);
+			expect(insights.hotspotBaseline).to.equal(1);
+			expect(insights.hotspotPopulation).to.equal(5);
+			expect(insights.hotspots).to.have.length(2);
+			const elevated = insights.hotspots.find(
+				h => h.signalId === "signal-elevated"
+			)!;
+			const severe = insights.hotspots.find(
+				h => h.signalId === "signal-severe"
+			)!;
+			expect(elevated.hotspotTier).to.equal("elevated");
+			expect(severe.hotspotTier).to.equal("severe");
+			// Severe (4 updates) ranks above elevated (2 updates).
+			expect(insights.hotspots[0].signalId).to.equal("signal-severe");
+		});
+
+		it("reports no hotspots when no instance reaches 2x the median", () => {
+			const observations: PerformanceObservation[] = [
+				...Array.from({ length: 3 }, (_, i) => ({
+					type: "update" as const,
+					signalType: "signal" as const,
+					signalName: "even",
+					signalId: `signal-${i}`,
+					receivedAt: i,
+				})),
+			];
+
+			const insights = derivePerformanceInsights(observations);
+			expect(insights.hotspotPopulation).to.equal(3);
+			expect(insights.hotspotBaseline).to.equal(1);
+			expect(insights.hotspots).to.have.length(0);
+		});
+
+		it("does not compute a baseline for a single identified instance", () => {
+			const observations: PerformanceObservation[] = [
+				{
+					type: "update",
+					signalType: "signal",
+					signalName: "lonely",
+					signalId: "signal-lonely",
+					receivedAt: 1,
+				},
+			];
+
+			const insights = derivePerformanceInsights(observations);
+			expect(insights.hotspotPopulation).to.equal(1);
+			expect(insights.hotspotBaseline).to.equal(0);
+			expect(insights.hotspots).to.have.length(0);
+		});
+
+		it("renders the baseline explanation and honest empty-hotspots message", () => {
+			initDevTools(mockAdapter);
+			mockAdapter._emit("signalUpdate", [
+				{
+					type: "update",
+					signalType: "signal",
+					signalName: "solo",
+					signalId: "signal-solo",
+					receivedAt: Date.now(),
+				},
+			]);
+
+			render(<PerformanceInsights />, scratch);
+
+			expect(scratch.textContent).to.contain(
+				"disproportionate to the median per-instance activity"
+			);
+			expect(scratch.textContent).to.contain("≥2×");
+			expect(scratch.textContent).to.contain("≥4×");
+			expect(scratch.textContent).to.contain(
+				"Not enough identified instances to compute a defensible median baseline"
+			);
+		});
+
+		it("retains verbatim trigger and dependency metadata in recent occurrences", () => {
+			const observations: PerformanceObservation[] = [
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "parity",
+					signalId: "computed-parity",
+					prevValue: 0,
+					newValue: 0,
+					receivedAt: 100,
+					timestamp: 9001,
+					recomputed: true,
+					outputChanged: false,
+					subscribedTo: "signal-count",
+					allDependencies: [
+						{
+							id: "signal-count",
+							name: "count",
+							type: "signal" as const,
+						},
+					],
+				},
+			];
+
+			const insights = derivePerformanceInsights(observations);
+			expect(insights.redundantWork).to.have.length(1);
+			const entry = insights.redundantWork[0];
+			expect(entry.recentOccurrences).to.have.length(1);
+			const occurrence = entry.recentOccurrences![0];
+			expect(occurrence.signalId).to.equal("computed-parity");
+			expect(occurrence.subscribedTo).to.equal("signal-count");
+			expect(occurrence.timestamp).to.equal(9001);
+			expect(occurrence.receivedAt).to.equal(100);
+			expect(occurrence.allDependencies).to.have.length(1);
+			expect(occurrence.allDependencies![0]).to.deep.equal({
+				id: "signal-count",
+				name: "count",
+				type: "signal",
+			});
+		});
+
+		it("does not infer no-output-change from serialized value equality", () => {
+			// Both observations have identical prev/new values, but only the
+			// runtime's `outputChanged` flag determines the count — serialized
+			// equality is never consulted.
+			const observations: PerformanceObservation[] = [
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "same",
+					signalId: "computed-same-false",
+					prevValue: { v: 1 },
+					newValue: { v: 1 },
+					receivedAt: 1,
+					recomputed: true,
+					outputChanged: false,
+				},
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "same",
+					signalId: "computed-same-true",
+					prevValue: { v: 1 },
+					newValue: { v: 1 },
+					receivedAt: 2,
+					recomputed: true,
+					outputChanged: true,
+				},
+			];
+
+			const insights = derivePerformanceInsights(observations);
+			const flagged = insights.redundantWork.find(
+				e => e.signalId === "computed-same-false"
+			)!;
+			const notFlagged = insights.redundantWork.find(
+				e => e.signalId === "computed-same-true"
+			);
+			expect(flagged.noOutputChangeCount).to.equal(1);
+			expect(notFlagged).to.be.undefined;
+		});
+
+		it("bounds recent occurrences to the most recent window", () => {
+			const observations: PerformanceObservation[] = Array.from(
+				{ length: MAX_RECENT_OCCURRENCES + 5 },
+				(_, i) => ({
+					type: "update" as const,
+					signalType: "computed" as const,
+					signalName: "parity",
+					signalId: "computed-parity",
+					prevValue: 0,
+					newValue: 0,
+					receivedAt: i,
+					timestamp: i,
+					recomputed: true as const,
+					outputChanged: false,
+				})
+			);
+
+			const insights = derivePerformanceInsights(observations);
+			const entry = insights.redundantWork[0];
+			expect(entry.noOutputChangeCount).to.equal(MAX_RECENT_OCCURRENCES + 5);
+			expect(entry.recentOccurrences).to.have.length(MAX_RECENT_OCCURRENCES);
+			// Most recent first.
+			expect(entry.recentOccurrences![0].receivedAt).to.equal(
+				MAX_RECENT_OCCURRENCES + 4
+			);
+		});
+
+		it("expands a redundant-work row to show trigger source and dependencies", () => {
+			initDevTools(mockAdapter);
+			mockAdapter._emit("signalUpdate", [
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "parity",
+					signalId: "computed-parity",
+					prevValue: 0,
+					newValue: 0,
+					receivedAt: Date.now(),
+					timestamp: 12345,
+					recomputed: true,
+					outputChanged: false,
+					subscribedTo: "signal-count",
+					allDependencies: [
+						{
+							id: "signal-count",
+							name: "count",
+							type: "signal" as const,
+						},
+					],
+				},
+			]);
+
+			render(<PerformanceInsights />, scratch);
+
+			const inspectButton = scratch.querySelector<HTMLButtonElement>(
+				".performance-expand-toggle"
+			);
+			expect(inspectButton).to.not.be.null;
+			expect(inspectButton!.getAttribute("aria-expanded")).to.equal("false");
+
+			// Before expanding, occurrence details are not rendered.
+			expect(scratch.querySelector(".performance-occurrence-detail")).to.be
+				.null;
+
+			act(() => {
+				inspectButton!.click();
+			});
+			expect(inspectButton!.getAttribute("aria-expanded")).to.equal("true");
+
+			const detail = scratch.querySelector(".performance-occurrence-detail");
+			expect(detail).to.not.be.null;
+			expect(detail!.textContent).to.contain("signal-count");
+			expect(detail!.textContent).to.contain("count");
+			expect(detail!.textContent).to.contain("Triggered by");
+			expect(detail!.textContent).to.contain("Current dependencies");
 		});
 	});
 

--- a/packages/devtools-ui/test/browser/index.test.tsx
+++ b/packages/devtools-ui/test/browser/index.test.tsx
@@ -1102,6 +1102,103 @@ describe("@preact/signals-devtools-ui", () => {
 			expect(scratch.textContent).to.contain("parity");
 		});
 
+		it("exports the derived performance insights as JSON", async () => {
+			initDevTools(mockAdapter);
+			mockAdapter._emit("signalUpdate", [
+				...Array.from({ length: 4 }, (_, index) => ({
+					type: "update" as const,
+					signalType: "computed" as const,
+					signalName: "hot",
+					signalId: "signal-hot",
+					prevValue: index,
+					newValue: index,
+					receivedAt: index,
+					recomputed: true as const,
+					outputChanged: false,
+				})),
+				...[
+					["signal-a", "a"],
+					["signal-b", "b"],
+					["signal-c", "c"],
+				].map(([signalId, signalName], index) => ({
+					type: "update" as const,
+					signalType: "signal" as const,
+					signalId,
+					signalName,
+					receivedAt: 10 + index,
+				})),
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "parity",
+					signalId: "computed-parity",
+					prevValue: 0,
+					newValue: 0,
+					receivedAt: 20,
+					recomputed: true,
+					outputChanged: false,
+					subscribedTo: "signal-hot",
+				},
+				{
+					type: "update",
+					signalType: "signal",
+					signalName: "anonymous",
+					receivedAt: 21,
+				},
+			]);
+
+			let copiedText = "";
+			const originalExecCommand = document.execCommand;
+			document.execCommand = vi.fn(command => {
+				copiedText =
+					(
+						document.body.querySelector(
+							"textarea"
+						) as HTMLTextAreaElement | null
+					)?.value ?? "";
+				return command === "copy";
+			});
+
+			try {
+				render(<PerformanceInsights />, scratch);
+				await act(async () => {
+					(
+						scratch.querySelector(
+							".performance-export-button"
+						) as HTMLButtonElement
+					).click();
+				});
+			} finally {
+				document.execCommand = originalExecCommand;
+			}
+
+			const exported = JSON.parse(copiedText);
+			expect(Object.keys(exported).sort()).to.deep.equal([
+				"hotspotBaseline",
+				"hotspotPopulation",
+				"hotspots",
+				"observationCount",
+				"redundantWork",
+				"unidentifiedObservationCount",
+			]);
+			expect(exported.observationCount).to.equal(9);
+			expect(exported.unidentifiedObservationCount).to.equal(1);
+			expect(exported.hotspotBaseline).to.equal(1);
+			expect(exported.hotspotPopulation).to.equal(5);
+			expect(exported.hotspots).to.have.length(1);
+			expect(exported.hotspots[0].signalId).to.equal("signal-hot");
+			expect(exported.hotspots[0]).to.not.have.property("recentOccurrences");
+			expect(exported.redundantWork).to.have.length(2);
+			const parity = exported.redundantWork.find(
+				(summary: { signalId: string }) =>
+					summary.signalId === "computed-parity"
+			)!;
+			expect(parity.recentOccurrences[0].subscribedTo).to.equal("signal-hot");
+			expect(copiedText).to.not.contain("prevValue");
+			expect(copiedText).to.not.contain("newValue");
+			expect(scratch.textContent).to.contain("Copied to clipboard!");
+		});
+
 		it("filters hotspots against the median baseline with >=2x and >=4x tiers", () => {
 			// Three quiet instances (1 update each) establish a median of 1.
 			// One instance with 2 updates is exactly 2x (elevated), one with 4

--- a/packages/devtools-ui/test/browser/index.test.tsx
+++ b/packages/devtools-ui/test/browser/index.test.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "../../src/components/Button";
 import { EmptyState } from "../../src/components/EmptyState";
 import { Header } from "../../src/components/Header";
+import { PerformanceInsights } from "../../src/components/PerformanceInsights";
 import { SettingsPanel } from "../../src/components/SettingsPanel";
 import { StatusIndicator } from "../../src/components/StatusIndicator";
 import { UpdateItem } from "../../src/components/UpdateItem";
@@ -22,6 +23,8 @@ import {
 	calculateGraphBounds,
 	filterGraphToNeighborhood,
 } from "../../src/components/Graph";
+import { derivePerformanceInsights } from "../../src/models/PerformanceInsightsModel";
+import type { PerformanceObservation } from "../../src/models/UpdatesModel";
 import type {
 	DevToolsAdapter,
 	Settings,
@@ -451,9 +454,10 @@ describe("@preact/signals-devtools-ui", () => {
 			render(<DevToolsPanel />, scratch);
 
 			const tabs = scratch.querySelectorAll(".tab");
-			expect(tabs.length).to.equal(2);
+			expect(tabs.length).to.equal(3);
 			expect(tabs[0].textContent).to.equal("Updates");
-			expect(tabs[1].textContent).to.equal("Dependency Graph");
+			expect(tabs[1].textContent).to.equal("Performance");
+			expect(tabs[2].textContent).to.equal("Dependency Graph");
 		});
 
 		it("should show updates tab as active by default", () => {
@@ -470,10 +474,17 @@ describe("@preact/signals-devtools-ui", () => {
 			expect(activeTab!.textContent).to.equal("Dependency Graph");
 		});
 
+		it("should show performance tab as active when initialTab is performance", () => {
+			render(<DevToolsPanel initialTab="performance" />, scratch);
+
+			const activeTab = scratch.querySelector(".tab.active");
+			expect(activeTab!.textContent).to.equal("Performance");
+		});
+
 		it("should switch tabs when clicked", () => {
 			render(<DevToolsPanel />, scratch);
 
-			const graphTab = scratch.querySelectorAll(".tab")[1] as HTMLButtonElement;
+			const graphTab = scratch.querySelectorAll(".tab")[2] as HTMLButtonElement;
 			act(() => {
 				graphTab.click();
 			});
@@ -941,6 +952,148 @@ describe("@preact/signals-devtools-ui", () => {
 
 			expect(context.updatesStore.disposedSignalIds.value.has("signal-123")).to
 				.be.true;
+		});
+	});
+
+	describe("PerformanceInsights", () => {
+		it("keeps same-named runtime instances separate and uses explicit recomputation metadata", () => {
+			const observations: PerformanceObservation[] = [
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "total",
+					signalId: "computed-total-a",
+					prevValue: { total: 1 },
+					newValue: { total: 1 },
+					receivedAt: 1,
+					recomputed: true,
+					outputChanged: false,
+				},
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "total",
+					signalId: "computed-total-b",
+					prevValue: { total: 1 },
+					newValue: { total: 1 },
+					receivedAt: 2,
+					recomputed: true,
+					outputChanged: true,
+				},
+			];
+
+			const insights = derivePerformanceInsights(observations);
+			expect(insights.hotspots).to.have.length(2);
+			expect(insights.redundantWork).to.have.length(1);
+			expect(insights.redundantWork[0].signalId).to.equal("computed-total-a");
+			expect(insights.redundantWork[0].noOutputChangeCount).to.equal(1);
+		});
+
+		it("bounds observations and clears performance insights with updates", () => {
+			initDevTools(mockAdapter);
+			const context = getContext();
+			const updates = Array.from({ length: 1001 }, (_, index) => ({
+				type: "update" as const,
+				signalType: "signal" as const,
+				signalName: `signal-${index}`,
+				signalId: `signal-${index}`,
+				receivedAt: index,
+			}));
+
+			mockAdapter._emit("signalUpdate", updates);
+
+			expect(context.updatesStore.performanceObservations.value).to.have.length(
+				1000
+			);
+			expect(context.performanceStore.insights.value.observationCount).to.equal(
+				1000
+			);
+
+			context.updatesStore.clearUpdates();
+			expect(context.performanceStore.insights.value.observationCount).to.equal(
+				0
+			);
+		});
+
+		it("does not collect performance observations when paused", () => {
+			initDevTools(mockAdapter);
+			const context = getContext();
+
+			context.updatesStore.isPaused.value = true;
+
+			mockAdapter._emit("signalUpdate", [
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "parity",
+					signalId: "computed-parity",
+					prevValue: 0,
+					newValue: 0,
+					receivedAt: Date.now(),
+					recomputed: true,
+					outputChanged: false,
+				},
+			]);
+
+			expect(context.updatesStore.performanceObservations.value).to.have.length(
+				0
+			);
+			expect(context.performanceStore.insights.value.observationCount).to.equal(
+				0
+			);
+		});
+
+		it("excludes no-output-change recomputations from the visible Updates view", () => {
+			initDevTools(mockAdapter);
+			const context = getContext();
+
+			mockAdapter._emit("signalUpdate", [
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "parity",
+					signalId: "computed-parity",
+					prevValue: 0,
+					newValue: 0,
+					receivedAt: Date.now(),
+					recomputed: true,
+					outputChanged: false,
+				},
+			]);
+
+			// The performance observation is still collected...
+			expect(context.updatesStore.performanceObservations.value).to.have.length(
+				1
+			);
+			// ...but the visible Updates list stays empty.
+			expect(context.updatesStore.hasUpdates.value).to.be.false;
+		});
+
+		it("renders metric definitions and no-output-change recomputations", () => {
+			initDevTools(mockAdapter);
+			mockAdapter._emit("signalUpdate", [
+				{
+					type: "update",
+					signalType: "computed",
+					signalName: "parity",
+					signalId: "computed-parity",
+					prevValue: 0,
+					newValue: 0,
+					receivedAt: Date.now(),
+					recomputed: true,
+					outputChanged: false,
+				},
+			]);
+
+			render(<PerformanceInsights />, scratch);
+
+			expect(scratch.textContent).to.contain(
+				"not by display name. This measures activity, not elapsed time."
+			);
+			expect(scratch.textContent).to.contain(
+				"does not compare serialized values"
+			);
+			expect(scratch.textContent).to.contain("parity");
 		});
 	});
 

--- a/packages/devtools-ui/test/browser/index.test.tsx
+++ b/packages/devtools-ui/test/browser/index.test.tsx
@@ -1344,6 +1344,7 @@ describe("@preact/signals-devtools-ui", () => {
 			);
 			expect(inspectButton).to.not.be.null;
 			expect(inspectButton!.getAttribute("aria-expanded")).to.equal("false");
+			expect(inspectButton!.textContent).to.equal("▶");
 
 			// Before expanding, occurrence details are not rendered.
 			expect(scratch.querySelector(".performance-occurrence-detail")).to.be
@@ -1353,11 +1354,15 @@ describe("@preact/signals-devtools-ui", () => {
 				inspectButton!.click();
 			});
 			expect(inspectButton!.getAttribute("aria-expanded")).to.equal("true");
+			expect(inspectButton!.textContent).to.equal("▼");
 
 			const detail = scratch.querySelector(".performance-occurrence-detail");
 			expect(detail).to.not.be.null;
-			expect(detail!.textContent).to.contain("signal-count");
-			expect(detail!.textContent).to.contain("count");
+			const trigger = detail!.querySelector(".performance-trigger-source");
+			expect(trigger).to.not.be.null;
+			expect(trigger!.textContent).to.contain("signal");
+			expect(trigger!.textContent).to.contain("count");
+			expect(trigger!.textContent).to.contain("signal-count");
 			expect(detail!.textContent).to.contain("Triggered by");
 			expect(detail!.textContent).to.contain("Current dependencies");
 		});


### PR DESCRIPTION
Signals DevTools does not currently identify high-activity instances or computed evaluations that rerun without changing their output, and the resulting diagnostics cannot be shared outside the panel.

This adds a Performance tab with instance-level hotspots and accurately instrumented no-output-change recomputations, using a bounded observation window without merging same-named runtime instances. The complete derived performance snapshot can be copied as JSON for sharing and offline analysis.

> [!NOTE]
> Authored with GLM 5.2.
