### PR TITLE
feat: support lazy `<For>` fallback

### DIFF
--- a/.changeset/lazy-for-fallback.md
+++ b/.changeset/lazy-for-fallback.md
@@ -1,0 +1,14 @@
+---
+"@preact/signals": minor
+"@preact/signals-react": minor
+---
+
+Add support for passing functions as fallback to `<For>` for lazy instantiation.
+
+```tsx
+<For each={list} fallback={() => <p>No items</p>}>
+	{item => <p>{item}</p>}
+</For>
+```
+
+This avoids eager evaluation of the fallback when the collection has items, which matters when you're dealing with signals.

--- a/packages/preact/utils/src/index.tsx
+++ b/packages/preact/utils/src/index.tsx
@@ -38,7 +38,7 @@ type ForEach<T> =
 
 interface ForProps<T> {
 	each: ForEach<T> | (() => ForEach<T>);
-	fallback?: ComponentChildren;
+	fallback?: ComponentChildren | (() => ComponentChildren);
 	getKey?: (item: T, index: number) => string | number;
 	children: (value: T, index: number) => ComponentChildren;
 }
@@ -51,7 +51,10 @@ export function For<T>(props: ForProps<T>): ComponentChildren | null {
 
 	const listValue = list instanceof Signal ? list.value : list;
 
-	if (!listValue.length) return props.fallback || null;
+	if (!listValue.length) {
+		const fallback = props.fallback;
+		return typeof fallback === "function" ? fallback() : fallback || null;
+	}
 
 	const removed = new Set(cache.keys());
 

--- a/packages/preact/utils/test/browser/index.test.tsx
+++ b/packages/preact/utils/test/browser/index.test.tsx
@@ -185,6 +185,64 @@ describe("@preact/signals-utils", () => {
 			expect(scratch.innerHTML).to.eq("<p>foo</p><p>bar</p>");
 		});
 
+		it("Should call function fallback lazily", () => {
+			const list = signal<Array<string>>(["foo", "bar"])!;
+			let fallbackCalled = false;
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			act(() => {
+				render(
+					<For
+						each={list}
+						fallback={() => {
+							fallbackCalled = true;
+							return <Paragraph>No items</Paragraph>;
+						}}
+					>
+						{item => <Paragraph key={item}>{item}</Paragraph>}
+					</For>,
+					scratch
+				);
+			});
+
+			// When list has items, fallback should NOT have been called
+			expect(fallbackCalled).to.eq(false);
+			expect(scratch.innerHTML).to.eq("<p>foo</p><p>bar</p>");
+
+			act(() => {
+				list.value = [];
+			});
+
+			// Now fallback should have been called
+			expect(fallbackCalled).to.eq(true);
+			expect(scratch.innerHTML).to.eq("<p>No items</p>");
+		});
+
+		it("Should reactively show items with lazy function fallback", () => {
+			const list = signal<Array<string>>([])!;
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			act(() => {
+				render(
+					<For each={list} fallback={() => <Paragraph>No items</Paragraph>}>
+						{item => <Paragraph key={item}>{item}</Paragraph>}
+					</For>,
+					scratch
+				);
+			});
+			expect(scratch.innerHTML).to.eq("<p>No items</p>");
+
+			act(() => {
+				list.value = ["foo", "bar"];
+			});
+			expect(scratch.innerHTML).to.eq("<p>foo</p><p>bar</p>");
+
+			act(() => {
+				list.value = [];
+			});
+			expect(scratch.innerHTML).to.eq("<p>No items</p>");
+		});
+
 		it("Should iterate over a list of signals w/ nested reactivity", () => {
 			const list = signal<Array<string>>([])!;
 			const test = signal("foo");

--- a/packages/react/utils/src/index.tsx
+++ b/packages/react/utils/src/index.tsx
@@ -47,7 +47,7 @@ type ForEach<T> =
 
 interface ForProps<T> {
 	each: ForEach<T> | (() => ForEach<T>);
-	fallback?: ReactNode;
+	fallback?: ReactNode | (() => ReactNode);
 	getKey?: (item: T, index: number) => string | number;
 	children: (value: T, index: number) => ReactNode;
 }
@@ -61,7 +61,12 @@ export function For<T>(props: ForProps<T>): JSX.Element | null {
 
 	const listValue = list instanceof Signal ? list.value : list;
 
-	if (!listValue.length) return (props.fallback as JSX.Element) || null;
+	if (!listValue.length) {
+		const fallback = props.fallback;
+		return (
+			typeof fallback === "function" ? fallback() : fallback
+		) as JSX.Element | null;
+	}
 
 	const removed = new Set(cache.keys());
 

--- a/packages/react/utils/test/browser/index.test.tsx
+++ b/packages/react/utils/test/browser/index.test.tsx
@@ -217,6 +217,62 @@ describe("@preact/signals-react-utils", () => {
 			expect(scratch.innerHTML).to.eq("<p>foo</p><p>bar</p>");
 		});
 
+		it("Should call function fallback lazily", async () => {
+			const list = signal<Array<string>>(["foo", "bar"])!;
+			let fallbackCalled = false;
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			await act(() => {
+				render(
+					<For
+						each={list}
+						fallback={() => {
+							fallbackCalled = true;
+							return <Paragraph>No items</Paragraph>;
+						}}
+					>
+						{item => <Paragraph key={item}>{item}</Paragraph>}
+					</For>
+				);
+			});
+
+			// When list has items, fallback should NOT have been called
+			expect(fallbackCalled).to.eq(false);
+			expect(scratch.innerHTML).to.eq("<p>foo</p><p>bar</p>");
+
+			await act(() => {
+				list.value = [];
+			});
+
+			// Now fallback should have been called
+			expect(fallbackCalled).to.eq(true);
+			expect(scratch.innerHTML).to.eq("<p>No items</p>");
+		});
+
+		it("Should reactively show items with lazy function fallback", async () => {
+			const list = signal<Array<string>>([])!;
+			const Paragraph = (p: any) => <p>{p.children}</p>;
+
+			await act(() => {
+				render(
+					<For each={list} fallback={() => <Paragraph>No items</Paragraph>}>
+						{item => <Paragraph key={item}>{item}</Paragraph>}
+					</For>
+				);
+			});
+			expect(scratch.innerHTML).to.eq("<p>No items</p>");
+
+			await act(() => {
+				list.value = ["foo", "bar"];
+			});
+			expect(scratch.innerHTML).to.eq("<p>foo</p><p>bar</p>");
+
+			await act(() => {
+				list.value = [];
+			});
+			expect(scratch.innerHTML).to.eq("<p>No items</p>");
+		});
+
 		it("Should iterate over a list of signals w/ nested reactivity", async () => {
 			const list = signal<Array<string>>([])!;
 			const test = signal("foo");


### PR DESCRIPTION
This adds support for passing a callback to the `fallback` prop of `<For>` for lazy evaluation:

```tsx
<For each={list} fallback={() => <p>No items</p>}>
	{item => <p>{item}</p>}
</For>
```

This mirrors what the `<Show>` component already supports.