### PR TITLE
Close over the ref'd element in the useSignalEffect cleanup test

### DIFF
--- a/packages/preact/test/browser/index.test.tsx
+++ b/packages/preact/test/browser/index.test.tsx
@@ -1210,8 +1210,9 @@ describe("@preact/signals", () => {
 			function App() {
 				useSignalEffect(() => {
 					const value = sig.value;
-					spy(value, ref.current);
-					return () => cleanup(value, ref.current);
+					const el = ref.current;
+					spy(value, el);
+					return () => cleanup(value, el);
 				});
 				return <p ref={ref}>{sig.value}</p>;
 			}


### PR DESCRIPTION
preactjs/preact#5196 defers passive (`useEffect`) cleanups of unmounted components to the after-paint flush, which runs after Preact detaches refs while committing the unmount.

`should invoke any returned cleanup function for unmounts` reads `ref.current` from inside the cleanup, so on Preact 11 it now receives `null` instead of the `<p>`. That ordering matches React, where refs detach in the mutation phase and passive destroys run after paint, so the expectation is what's stale here rather than the behaviour.

The test only cares about the element the effect was set up with, so it now closes over `ref.current` in the effect body. That keeps it passing on both Preact 10 and 11 instead of encoding either version's ref-detach timing.