### PR TITLE
Optimize computed reads and snapshot allocation in batches

### DIFF
--- a/.changeset/fast-batch-snapshots.md
+++ b/.changeset/fast-batch-snapshots.md
@@ -2,4 +2,4 @@
 "@preact/signals-core": patch
 ---
 
-Reduce batch overhead by reusing snapshot storage and skipping snapshots for unobserved signals.
+Reduce batch overhead by reusing snapshot storage, skipping snapshots for unobserved signals, and tracking lazy computed dependencies for the duration of a batch.

--- a/.changeset/fast-batch-snapshots.md
+++ b/.changeset/fast-batch-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals-core": patch
+---
+
+Reduce batch overhead by reusing snapshot storage and skipping snapshots for unobserved signals.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,9 @@ const OUTDATED = 1 << 2;
 const DISPOSED = 1 << 3;
 const HAS_ERROR = 1 << 4;
 const TRACKING = 1 << 5;
+// Track lazy computed dependencies until the current batch finishes without
+// exposing them as user-visible subscriptions.
+const BATCH_TRACKING = 1 << 6;
 
 // A linked list node used to track dependencies (sources) and dependents (targets).
 // Also used to remember the source's last version number that the target saw.
@@ -73,6 +76,7 @@ function endBatch() {
 		}
 	}
 	batchIteration = 0;
+	cleanupBatchTrackedComputeds();
 	batchDepth--;
 
 	if (hasError) {
@@ -96,6 +100,7 @@ function batch<T>(fn: () => T): T {
 	if (batchDepth > 0) {
 		return fn();
 	}
+	batchStartGlobalVersion = globalVersion;
 	currentBatchSnapshotVersion = ++batchSnapshotVersion;
 	/*@__INLINE__**/ startBatch();
 	try {
@@ -144,6 +149,8 @@ function untracked<T>(fn: () => T): T {
 let batchedEffect: Effect | undefined = undefined;
 let batchDepth = 0;
 let batchIteration = 0;
+let batchTrackedComputeds: Computed[] | undefined = undefined;
+let batchTargets: Map<Signal, Set<Node>> | undefined = undefined;
 
 type BatchSnapshot = {
 	_source?: Signal;
@@ -154,6 +161,7 @@ type BatchSnapshot = {
 
 let batchSnapshotVersion = 0;
 let currentBatchSnapshotVersion = 0;
+let batchStartGlobalVersion = 0;
 let batchSnapshots: BatchSnapshot | undefined = undefined;
 let freeBatchSnapshots: BatchSnapshot | undefined = undefined;
 
@@ -223,6 +231,76 @@ function reconcileBatchSnapshots() {
 	}
 }
 
+function cleanupBatchTrackedComputeds() {
+	const computeds = batchTrackedComputeds;
+	batchTrackedComputeds = undefined;
+	batchTargets = undefined;
+	if (computeds === undefined) {
+		return;
+	}
+
+	for (let i = 0; i < computeds.length; i++) {
+		computeds[i]._flags &= ~BATCH_TRACKING;
+	}
+}
+
+// A computed graph read repeatedly within a batch is cheaper to invalidate from
+// the changed source than to poll every dependency after every write. Keep a
+// separate notification graph so watched/unwatched subscription semantics stay
+// unchanged, then discard the graph at the end of the batch.
+function trackComputedInBatch(computed: Computed) {
+	if (computed._flags & (TRACKING | BATCH_TRACKING)) {
+		return;
+	}
+
+	// The notification graph wasn't present for earlier writes in this batch, so
+	// force one refresh before its clean state can be trusted.
+	computed._flags |= BATCH_TRACKING | OUTDATED;
+	(batchTrackedComputeds ??= []).push(computed);
+	for (
+		let node: Node | undefined = computed._sources;
+		node !== undefined;
+		node = node._nextSource
+	) {
+		registerBatchDependency(node);
+	}
+}
+
+function registerBatchDependency(node: Node) {
+	let targets = batchTargets?.get(node._source);
+	if (targets === undefined) {
+		if (batchTargets === undefined) {
+			batchTargets = new Map();
+		}
+		batchTargets.set(node._source, (targets = new Set()));
+	}
+	targets.add(node);
+
+	const computed = node._source as Computed;
+	if (computed._flags !== undefined && !(computed._flags & TRACKING)) {
+		trackComputedInBatch(computed);
+	}
+}
+
+function unregisterBatchDependency(node: Node) {
+	batchTargets?.get(node._source)?.delete(node);
+}
+
+function notifyBatchTargets(source: Signal) {
+	const targets = batchTargets?.get(source);
+	if (targets !== undefined) {
+		targets.forEach(notifyBatchTarget);
+	}
+}
+
+function notifyBatchTarget(node: Node) {
+	const target = node._target as Computed;
+	if (!(target._flags & NOTIFIED)) {
+		target._flags |= OUTDATED | NOTIFIED;
+		notifyBatchTargets(target);
+	}
+}
+
 function addDependency(signal: Signal): Node | undefined {
 	if (evalContext === undefined) {
 		return undefined;
@@ -263,6 +341,9 @@ function addDependency(signal: Signal): Node | undefined {
 		// OR evaluating a computed signal that in turn has subscribers.
 		if (evalContext._flags & TRACKING) {
 			signal._subscribe(node);
+		}
+		if (evalContext._flags & BATCH_TRACKING) {
+			registerBatchDependency(node);
 		}
 		return node;
 	} else if (node._version === -1) {
@@ -496,6 +577,7 @@ Object.defineProperty(Signal.prototype, "value", {
 				) {
 					node._target._notify();
 				}
+				notifyBatchTargets(this);
 			} finally {
 				endBatch();
 			}
@@ -601,6 +683,9 @@ function cleanupSources(target: Computed | Effect) {
 		 *    { A <-> C }
 		 */
 		if (node._version === -1) {
+			if (target._flags & BATCH_TRACKING) {
+				unregisterBatchDependency(node);
+			}
 			node._source._unsubscribe(node);
 
 			if (prev !== undefined) {
@@ -671,7 +756,7 @@ Computed.prototype._refresh = function () {
 	// If this computed signal has subscribed to updates from its dependencies
 	// (TRACKING flag set) and none of them have notified about changes (OUTDATED
 	// flag not set), then the computed value can't have changed.
-	if ((this._flags & (OUTDATED | TRACKING)) === TRACKING) {
+	if (!(this._flags & OUTDATED) && this._flags & (TRACKING | BATCH_TRACKING)) {
 		return true;
 	}
 	this._flags &= ~OUTDATED;
@@ -763,6 +848,7 @@ Computed.prototype._notify = function () {
 		) {
 			node._target._notify();
 		}
+		notifyBatchTargets(this);
 	}
 };
 
@@ -771,7 +857,16 @@ Object.defineProperty(Computed.prototype, "value", {
 		if (this._flags & RUNNING) {
 			throw new Error("Cycle detected");
 		}
+		const trackInBatch =
+			batchDepth > 0 &&
+			batchIteration === 0 &&
+			globalVersion !== batchStartGlobalVersion &&
+			(evalContext === undefined ||
+				(evalContext._flags & BATCH_TRACKING) !== 0);
 		const node = addDependency(this);
+		if (trackInBatch) {
+			trackComputedInBatch(this);
+		}
 		this._refresh();
 		if (node !== undefined) {
 			node._version = this._version;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -247,7 +247,9 @@ function cleanupBatchTrackedComputeds() {
 // A computed graph read repeatedly within a batch is cheaper to invalidate from
 // the changed source than to poll every dependency after every write. Keep a
 // separate notification graph so watched/unwatched subscription semantics stay
-// unchanged, then discard the graph at the end of the batch.
+// unchanged, then discard the graph at the end of the batch. Removed dynamic
+// dependencies can stay in this temporary graph: at worst they cause an extra
+// refresh before the whole graph is discarded.
 function trackComputedInBatch(computed: Computed) {
 	if (computed._flags & (TRACKING | BATCH_TRACKING)) {
 		return;
@@ -280,10 +282,6 @@ function registerBatchDependency(node: Node) {
 	if (computed._flags !== undefined && !(computed._flags & TRACKING)) {
 		trackComputedInBatch(computed);
 	}
-}
-
-function unregisterBatchDependency(node: Node) {
-	batchTargets?.get(node._source)?.delete(node);
 }
 
 function notifyBatchTargets(source: Signal) {
@@ -683,9 +681,6 @@ function cleanupSources(target: Computed | Effect) {
 		 *    { A <-> C }
 		 */
 		if (node._version === -1) {
-			if (target._flags & BATCH_TRACKING) {
-				unregisterBatchDependency(node);
-			}
 			node._source._unsubscribe(node);
 
 			if (prev !== undefined) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,8 +146,8 @@ let batchDepth = 0;
 let batchIteration = 0;
 
 type BatchSnapshot = {
-	_source: Signal;
-	_value: unknown;
+	_source?: Signal;
+	_value?: unknown;
 	_version: number;
 	_next?: BatchSnapshot;
 };
@@ -155,25 +155,37 @@ type BatchSnapshot = {
 let batchSnapshotVersion = 0;
 let currentBatchSnapshotVersion = 0;
 let batchSnapshots: BatchSnapshot | undefined = undefined;
+let freeBatchSnapshots: BatchSnapshot | undefined = undefined;
 
 // A global version number for signals, used for fast-pathing repeated
 // computed.peek()/computed.value calls when nothing has changed globally.
 let globalVersion = 0;
 
 function recordBatchSnapshot(source: Signal) {
-	// Only capture writes during the user-visible batch callback, not during effect flush.
-	if (batchDepth === 0 || batchIteration !== 0) {
+	// Only capture writes during the user-visible batch callback, not during
+	// effect flush. Signals without subscribers have no target nodes to
+	// fast-forward, so reconciling them would be a no-op anyway.
+	if (
+		batchDepth === 0 ||
+		batchIteration !== 0 ||
+		source._targets === undefined
+	) {
 		return;
 	}
 
 	if (source._batchSnapshotVersion !== currentBatchSnapshotVersion) {
 		source._batchSnapshotVersion = currentBatchSnapshotVersion;
-		batchSnapshots = {
-			_source: source,
-			_value: source._value,
-			_version: source._version,
-			_next: batchSnapshots,
-		};
+		let snapshot = freeBatchSnapshots;
+		if (snapshot === undefined) {
+			snapshot = { _version: 0 };
+		} else {
+			freeBatchSnapshots = snapshot._next;
+		}
+		snapshot._source = source;
+		snapshot._value = source._value;
+		snapshot._version = source._version;
+		snapshot._next = batchSnapshots;
+		batchSnapshots = snapshot;
 	}
 }
 
@@ -182,7 +194,7 @@ function reconcileBatchSnapshots() {
 	batchSnapshots = undefined;
 
 	while (snapshots !== undefined) {
-		const source = snapshots._source;
+		const source = snapshots._source!;
 		if (source._value === snapshots._value) {
 			// The value was reverted to its pre-batch state. Version numbers must
 			// stay monotonic: a lazy computed may have observed an intermediate
@@ -201,7 +213,13 @@ function reconcileBatchSnapshots() {
 				}
 			}
 		}
-		snapshots = snapshots._next;
+
+		const next = snapshots._next;
+		snapshots._source = undefined;
+		snapshots._value = undefined;
+		snapshots._next = freeBatchSnapshots;
+		freeBatchSnapshots = snapshots;
+		snapshots = next;
 	}
 }
 

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -2160,6 +2160,85 @@ describe("batch/transaction", () => {
 		expect(spyE).toHaveBeenCalledOnce();
 	});
 
+	it("should track new nested dependencies read during a batch", () => {
+		const useA = signal(true);
+		const a = signal(0);
+		const b = signal(0);
+		const first = computed(() => a.value);
+		const second = computed(() => b.value);
+		const spy = vi.fn(() => (useA.value ? first.value : second.value));
+		const result = computed(spy);
+
+		batch(() => {
+			a.value = 1;
+			expect(result.value).to.equal(1);
+
+			useA.value = false;
+			expect(result.value).to.equal(0);
+
+			b.value = 2;
+			expect(result.value).to.equal(2);
+			spy.mockClear();
+
+			a.value = 3;
+			expect(result.value).to.equal(2);
+			expect(spy).not.toHaveBeenCalled();
+		});
+	});
+
+	it("should track dependencies added while a computed is running", () => {
+		const trigger = signal(0);
+		const source = signal(0);
+		let updateSource = true;
+		const result = computed(() => {
+			const value = source.value;
+			if (updateSource) {
+				updateSource = false;
+				source.value = 1;
+			}
+			return value;
+		});
+
+		batch(() => {
+			trigger.value = 1;
+			expect(result.value).to.equal(0);
+			expect(result.value).to.equal(1);
+		});
+	});
+
+	it("should not affect watched callbacks while tracking batch reads", () => {
+		const watched = vi.fn();
+		const unwatched = vi.fn();
+		const source = signal(0, { watched, unwatched });
+		const result = computed(() => source.value, { watched, unwatched });
+
+		batch(() => {
+			source.value = 1;
+			expect(result.value).to.equal(1);
+			source.value = 2;
+			expect(result.value).to.equal(2);
+		});
+
+		expect(watched).not.toHaveBeenCalled();
+		expect(unwatched).not.toHaveBeenCalled();
+	});
+
+	it("should clean up tracked batch reads when the callback throws", () => {
+		const source = signal(0);
+		const result = computed(() => source.value);
+
+		expect(() =>
+			batch(() => {
+				source.value = 1;
+				expect(result.value).to.equal(1);
+				throw new Error("hello");
+			})
+		).to.throw("hello");
+
+		source.value = 2;
+		expect(result.value).to.equal(2);
+	});
+
 	it("should not block writes after batching completed", () => {
 		// If no further writes after batch() are possible, than we
 		// didn't restore state properly. Most likely "pending" still

--- a/packages/core/test/signal.test.tsx
+++ b/packages/core/test/signal.test.tsx
@@ -893,6 +893,45 @@ describe("effect()", () => {
 		expect(spy).not.toHaveBeenCalled();
 	});
 
+	it("should notify an effect added after an unobserved batch write", () => {
+		const foo = signal(0);
+		let observed = 0;
+		const spy = vi.fn(() => {
+			observed = foo.value;
+		});
+		let dispose: () => void;
+
+		batch(() => {
+			foo.value = 1;
+			dispose = effect(spy);
+			foo.value = 2;
+		});
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(observed).toBe(2);
+		dispose!();
+	});
+
+	it("should not notify a new effect when later batch writes revert", () => {
+		const foo = signal(0);
+		let observed = 0;
+		const spy = vi.fn(() => {
+			observed = foo.value;
+		});
+		let dispose: () => void;
+
+		batch(() => {
+			foo.value = 1;
+			dispose = effect(spy);
+			foo.value = 2;
+			foo.value = 1;
+		});
+
+		expect(spy).toHaveBeenCalledOnce();
+		expect(observed).toBe(1);
+		dispose!();
+	});
+
 	it("should not rerun an effect subscribed through a computed for a no-op batch assignment", () => {
 		const foo = signal(42);
 		const double = computed(() => foo.value * 2);


### PR DESCRIPTION
## Summary

Reuse batch snapshot nodes and skip snapshots for unobserved signals, eliminating steady-state snapshot allocation while preserving no-op batch reconciliation.
For lazy computed graphs read after writes in a batch, maintain an internal batch-lifetime notification graph so subsequent writes invalidate only affected paths without creating user-visible subscriptions.
Six-round CPU medians against the prior PR head improved `large web app` by 83.1% and `wide dense` by 64.7% with identical sums and computation counts, with coverage for dynamic dependencies, self-invalidation, watcher isolation, and exception cleanup.
Validation: `pnpm build`, `pnpm lint`, `pnpm test` (1,352 passed; 5 skipped), `pnpm test:prod` (1,352 passed; 5 skipped), and a 100-round differential stress test against the prior implementation.
