### PR TITLE
Avoid closing over vnodes in component updater

### DIFF
--- a/.changeset/crisp-sides-talk.md
+++ b/.changeset/crisp-sides-talk.md
@@ -1,0 +1,5 @@
+---
+"@preact/signals": patch
+---
+
+Avoid closing over VNodes in component updater callbacks.

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -238,7 +238,7 @@ hook(OptionsTypes.RENDER, (old, vnode) => {
 					createComponentUpdateCallback(component),
 					typeof vnode.type === "function"
 						? vnode.type.displayName || vnode.type.name
-						: "",
+						: ""
 				);
 			}
 		}
@@ -248,9 +248,9 @@ hook(OptionsTypes.RENDER, (old, vnode) => {
 	}
 });
 
-function createComponentUpdateCallback(component: Component) {
-	return function(this: Effect) {
-		if (DEVTOOLS_ENABLED) this!._debugCallback?.call(this);
+function createComponentUpdateCallback(component: AugmentedComponent) {
+	return function (this: Effect) {
+		if (DEVTOOLS_ENABLED) this._debugCallback?.call(this);
 		component._updateFlags |= HAS_PENDING_UPDATE;
 		component.setState({});
 	};

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -235,14 +235,10 @@ hook(OptionsTypes.RENDER, (old, vnode) => {
 			updater = component._updater;
 			if (updater === undefined) {
 				component._updater = updater = createUpdater(
-					() => {
-						if (DEVTOOLS_ENABLED) updater!._debugCallback?.call(updater);
-						component._updateFlags |= HAS_PENDING_UPDATE;
-						component.setState({});
-					},
+					createComponentUpdateCallback(component),
 					typeof vnode.type === "function"
 						? vnode.type.displayName || vnode.type.name
-						: ""
+						: "",
 				);
 			}
 		}
@@ -251,6 +247,14 @@ hook(OptionsTypes.RENDER, (old, vnode) => {
 		setCurrentUpdater(updater);
 	}
 });
+
+function createComponentUpdateCallback(component: Component) {
+	return function(this: Effect) {
+		if (DEVTOOLS_ENABLED) this!._debugCallback?.call(this);
+		component._updateFlags |= HAS_PENDING_UPDATE;
+		component.setState({});
+	};
+}
 
 /** Finish current updater if a component errors */
 hook(OptionsTypes.CATCH_ERROR, (old, error, vnode, oldVNode) => {


### PR DESCRIPTION
This pull request refactors the updater initialization logic in the `hook(OptionsTypes.RENDER, ...)` function of `packages/preact/src/index.ts`. The main change is extracting the inline updater callback into a helper function to avoid closing over `vnode`.
